### PR TITLE
WIP: Move proposal creation to a background process

### DIFF
--- a/src/components/Section/ProposalDetailSection.tsx
+++ b/src/components/Section/ProposalDetailSection.tsx
@@ -61,6 +61,7 @@ export default React.memo(function ProposalDetailSection({ proposal, loading, di
           {proposal && Time.from(proposal.finish_at).format('MMM DD HH:mm')}
         </div>
       </div>
+      { proposal?.snapshot_id &&
       <div className="DetailsSection__Flex">
         <div>{l('page.proposal_detail.details_snapshot_label')}</div>
         <div className="DetailsSection__Value">
@@ -69,7 +70,7 @@ export default React.memo(function ProposalDetailSection({ proposal, loading, di
             <img src={openIcon}  width="12" height="12" style={{ marginLeft: '.5rem' }} />
           </Anchor>}
         </div>
-      </div>
+      </div>}
     </div>
   </div>
 })

--- a/src/components/Section/ProposalResultSection.tsx
+++ b/src/components/Section/ProposalResultSection.tsx
@@ -68,7 +68,7 @@ export default React.memo(function ProposalResultSection({ proposal, loading, di
         </div>
       }
     </div>
-    {!finished && <div className="DetailsSection__Content">
+    { proposal?.snapshot_id && !proposal.deleted && !finished && <div className="DetailsSection__Content">
       <Loader active={!loading && accountState.loading} />
 
       {!account && <Button basic loading={accountState.loading} disabled={accountState.loading} onClick={() => accountState.select()}>

--- a/src/entities/Proposal/jobs.ts
+++ b/src/entities/Proposal/jobs.ts
@@ -4,9 +4,157 @@ import { Vote } from "../Votes/types";
 import ProposalModel from "./model";
 import { INVALID_PROPOSAL_POLL_OPTIONS, ProposalAttributes, ProposalStatus } from "./types";
 
+import * as templates from './templates';
+import { dropSnapshotProposal } from './routes'
+import { IPFS, HashContent } from '../../api/IPFS';
+import Time from 'decentraland-gatsby/dist/utils/date/Time';
+import { Discourse, DiscoursePost } from '../../api/Discourse';
+import { AlchemyProvider, Block } from '@ethersproject/providers'
+import { proposalUrl, snapshotProposalUrl, forumUrl } from './utils';
+import { DISCOURSE_AUTH, DISCOURSE_CATEGORY } from '../Discourse/utils';
+import Catalyst, { Avatar } from 'decentraland-gatsby/dist/utils/api/Catalyst';
+import { Snapshot, SnapshotResult, SnapshotSpace, SnapshotStatus } from '../../api/Snapshot';
+import { SNAPSHOT_SPACE, SNAPSHOT_ACCOUNT, SNAPSHOT_ADDRESS, SNAPSHOT_DURATION, signMessage } from '../Snapshot/utils';
+
 export async function activateProposals(context: JobContext) {
   const activatedProposals = await ProposalModel.activateProposals()
   context.log(activatedProposals === 0 ? `No activated proposals` : `Activated ${activatedProposals} proposals...`)
+}
+
+export async function createProposals(context: JobContext) {
+const pendingProposals = await ProposalModel.getCreatingProposal()
+
+  context.log('Creating proposals: ' + pendingProposals.length)
+  pendingProposals.forEach(proposal => createProposal(proposal))
+}
+
+async function createProposal(proposal: ProposalAttributes) {
+  let profile: Avatar | null
+  const proposal_url = proposalUrl(proposal)
+  const start = Time.utc().set('seconds', 0)
+  const end = Time.utc(start).add(SNAPSHOT_DURATION, 'seconds')
+
+  try {
+    profile = await Catalyst.get().getProfile(proposal.user)
+  } catch (err) {
+    throw new Error(`Error getting profile "${proposal.user}"`)
+  }
+
+  //
+  // Create proposal payload
+  //
+  let msg: string
+  let block: Block
+  let snapshotStatus: SnapshotStatus
+  let snapshotSpace: SnapshotSpace
+  try {
+    snapshotStatus = await Snapshot.get().getStatus()
+    snapshotSpace = await Snapshot.get().getSpace(SNAPSHOT_SPACE)
+  } catch (err) {
+    throw new Error(`Error getting snapshot space "${SNAPSHOT_SPACE}"`)
+  }
+
+  try {
+    const provider = new AlchemyProvider(Number(snapshotSpace.network), process.env.ALCHEMY_API_KEY)
+    block = await provider.getBlock('latest')
+  } catch (err) {
+    throw new Error(`Couldn't get the latest block`)
+  }
+
+  try {
+    const snapshotTemplateProps: templates.SnapshotTemplateProps = {
+      user: proposal.user,
+      type: proposal.type,
+      configuration: proposal.configuration,
+      profile,
+      proposal_url
+    }
+
+    msg = await Snapshot.get().createProposalMessage(SNAPSHOT_SPACE,
+      snapshotStatus.version, snapshotSpace.network, snapshotSpace.strategies, {
+      name: await templates.snapshotTitle(snapshotTemplateProps),
+      body: await templates.snapshotDescription(snapshotTemplateProps),
+      choices: proposal.configuration.choices,
+      snapshot: block.number,
+      end,
+      start,
+    })
+  } catch (err) {
+    throw new Error(`Error creating the snapshot message`)
+  }
+
+  //
+  // Create proposal in Snapshot
+  //
+  let snapshotProposal: SnapshotResult
+  try {
+    const sig = await signMessage(SNAPSHOT_ACCOUNT, msg)
+    console.log(sig, msg)
+    snapshotProposal = await Snapshot.get().send(SNAPSHOT_ADDRESS, msg, sig)
+  } catch (err) {
+    throw new Error(`Couldn't create proposal in snapshot`)
+  }
+
+  const snapshot_url = snapshotProposalUrl({ snapshot_space: SNAPSHOT_SPACE, snapshot_id: snapshotProposal.ipfsHash })
+  console.log(`Snapshot proposal created:`, snapshot_url, JSON.stringify(snapshotProposal))
+
+  //
+  // Get snapshot content
+  //
+  let snapshotContent: HashContent
+  try {
+    snapshotContent = await IPFS.get().getHash(snapshotProposal.ipfsHash)
+  } catch (err) {
+    dropSnapshotProposal(SNAPSHOT_SPACE, snapshotProposal.ipfsHash)
+    throw new Error(`Couldn't retrieve proposal from the IPFS`)
+  }
+
+  //
+  // Create proposal in Discourse
+  //
+  let discourseProposal: DiscoursePost
+  try {
+    const discourseTemplateProps: templates.ForumTemplateProps = {
+      type: proposal.type,
+      configuration: proposal.configuration,
+      user: proposal.user,
+      profile,
+      proposal_url,
+      snapshot_url,
+      snapshot_id: snapshotProposal.ipfsHash
+    }
+
+    discourseProposal = await Discourse.get().createPost({
+      category: DISCOURSE_CATEGORY ? Number(DISCOURSE_CATEGORY) : undefined,
+      title: await templates.forumTitle(discourseTemplateProps),
+      raw: await templates.forumDescription(discourseTemplateProps),
+    }, DISCOURSE_AUTH)
+  } catch (err) {
+    dropSnapshotProposal(SNAPSHOT_SPACE, snapshotProposal.ipfsHash)
+    throw new Error(`Forum error: ${err.body.errors.join(', ')}`)
+  }
+
+  const forum_url = forumUrl({ discourse_topic_slug: discourseProposal.topic_slug, discourse_topic_id: discourseProposal.topic_id })
+  console.log(`Discourse proposal created:`, forum_url, JSON.stringify(discourseProposal))
+
+  //
+  // Update proposal in DB
+  //
+  const update: Partial<ProposalAttributes> = {
+    status: ProposalStatus.Active,
+    snapshot_id: snapshotProposal.ipfsHash,
+    snapshot_proposal: JSON.stringify(JSON.parse(snapshotContent.msg).payload),
+    snapshot_signature: snapshotContent.sig,
+    snapshot_network: snapshotSpace.network,
+    discourse_id: discourseProposal.id,
+    discourse_topic_id: discourseProposal.topic_id,
+    discourse_topic_slug: discourseProposal.topic_slug,
+    start_at: start.toJSON() as any,
+    finish_at: end.toJSON() as any,
+    updated_at: new Date(),
+  }
+  await ProposalModel.update(update, { id: proposal.id })
+  console.log(`Proposal updated!`)
 }
 
 function sameOptions(options: string[], expected: string[]) {

--- a/src/entities/Proposal/model.ts
+++ b/src/entities/Proposal/model.ts
@@ -56,10 +56,23 @@ export default class ProposalModel extends Model<ProposalAttributes> {
       WHERE
         "deleted" = FALSE
         AND "status" = ${ProposalStatus.Pending}
-        AND "start_at" >= now()
+        AND "start_at" <= now()
     `
 
     return this.rowCount(query)
+  }
+
+  static async getCreatingProposal() {
+    const query = SQL`
+      SELECT *
+      FROM ${table(ProposalModel)}
+      WHERE
+        "deleted" = FALSE
+        AND "status" = ${ProposalStatus.Creating}
+    `
+
+    const result = await this.query(query)
+    return result.map(ProposalModel.parse)
   }
 
   static async getFinishedProposal() {

--- a/src/entities/Proposal/model.ts
+++ b/src/entities/Proposal/model.ts
@@ -132,7 +132,7 @@ export default class ProposalModel extends Model<ProposalAttributes> {
       SELECT COUNT(*) as "total"
       FROM ${table(ProposalModel)} p
       ${conditional(!!filter.subscribed, SQL`INNER JOIN ${table(SubscriptionModel)} s ON s."proposal_id" = p."id"`)}
-      WHERE "deleted" = FALSE
+      WHERE "deleted" = FALSE AND "status" != ${ ProposalStatus.Creating}
       ${conditional(!!filter.user, SQL`AND p."user" = ${filter.user}`)}
       ${conditional(!!filter.type, SQL`AND p."type" = ${filter.type}`)}
       ${conditional(!!filter.status, SQL`AND p."status" = ${filter.status}`)}
@@ -163,7 +163,7 @@ export default class ProposalModel extends Model<ProposalAttributes> {
       SELECT p.*
       FROM ${table(ProposalModel)} p
       ${conditional(!!filter.subscribed, SQL`INNER JOIN ${table(SubscriptionModel)} s ON s."proposal_id" = p."id"`)}
-      WHERE "deleted" = FALSE
+      WHERE "deleted" = FALSE AND "status" != ${ ProposalStatus.Creating}
       ${conditional(!!filter.user, SQL`AND "user" = ${filter.user}`)}
       ${conditional(!!filter.type, SQL`AND "type" = ${filter.type}`)}
       ${conditional(!!filter.status, SQL`AND "status" = ${filter.status}`)}

--- a/src/entities/Proposal/routes.ts
+++ b/src/entities/Proposal/routes.ts
@@ -249,7 +249,7 @@ export async function createProposal(data: Pick<ProposalAttributes, 'type' | 'us
     status: ProposalStatus.Creating,
     snapshot_id: "",
     snapshot_space: SNAPSHOT_SPACE,
-    snapshot_proposal: JSON.stringify(data),
+    snapshot_proposal: JSON.stringify({choices: data.configuration.choices}),
     snapshot_signature: "",
     snapshot_network: "",
     discourse_id: 0,
@@ -259,6 +259,7 @@ export async function createProposal(data: Pick<ProposalAttributes, 'type' | 'us
     finish_at: end.toJSON() as any,
     deleted: false,
     deleted_by: null,
+    deleted_description: null,
     enacted: false,
     enacted_by: null,
     enacted_description: null,
@@ -281,7 +282,7 @@ export async function getProposal(req: Request<{ proposal: string }>) {
     throw new RequestError(`Not found proposal: "${id}"`, RequestError.NotFound)
   }
 
-  const proposal = await ProposalModel.findOne<ProposalAttributes>({ id, deleted: false })
+  const proposal = await ProposalModel.findOne<ProposalAttributes>({ id })
   if (!proposal) {
     throw new RequestError(`Not found proposal: "${id}"`, RequestError.NotFound)
   }

--- a/src/entities/Proposal/types.ts
+++ b/src/entities/Proposal/types.ts
@@ -40,8 +40,7 @@ export enum ProposalStatus {
   Rejected = 'rejected',
   Passed = 'passed',
   Enacted = 'enacted',
-  Deleted = 'deleted',
-  Error = 'error'
+  Deleted = 'deleted'
 }
 
 export function isProposalStatus(value:  string | null | undefined): boolean {
@@ -53,7 +52,6 @@ export function isProposalStatus(value:  string | null | undefined): boolean {
     case ProposalStatus.Rejected:
     case ProposalStatus.Passed:
     case ProposalStatus.Enacted:
-    case ProposalStatus.Error:
       return true
     default:
       return false

--- a/src/entities/Proposal/types.ts
+++ b/src/entities/Proposal/types.ts
@@ -19,7 +19,8 @@ export type ProposalAttributes<C extends {} = any> = {
   start_at: Date
   finish_at: Date
   deleted: boolean
-  deleted_by: string | null,
+  deleted_by: string | null
+  deleted_description: string | null
   enacted: boolean
   enacted_by: string | null
   enacted_description: string | null
@@ -40,7 +41,8 @@ export enum ProposalStatus {
   Rejected = 'rejected',
   Passed = 'passed',
   Enacted = 'enacted',
-  Deleted = 'deleted'
+  Deleted = 'deleted',
+  Error = 'error'
 }
 
 export function isProposalStatus(value:  string | null | undefined): boolean {
@@ -52,6 +54,7 @@ export function isProposalStatus(value:  string | null | undefined): boolean {
     case ProposalStatus.Rejected:
     case ProposalStatus.Passed:
     case ProposalStatus.Enacted:
+    case ProposalStatus.Error:
       return true
     default:
       return false

--- a/src/entities/Proposal/types.ts
+++ b/src/entities/Proposal/types.ts
@@ -33,23 +33,27 @@ export type ProposalAttributes<C extends {} = any> = {
 }
 
 export enum ProposalStatus {
+  Creating = 'creating',
   Pending = 'pending',
   Active = 'active',
   Finished = 'finished',
   Rejected = 'rejected',
   Passed = 'passed',
   Enacted = 'enacted',
-  Deleted = 'deleted'
+  Deleted = 'deleted',
+  Error = 'error'
 }
 
 export function isProposalStatus(value:  string | null | undefined): boolean {
   switch (value) {
+    case ProposalStatus.Creating:
     case ProposalStatus.Pending:
     case ProposalStatus.Finished:
     case ProposalStatus.Active:
     case ProposalStatus.Rejected:
     case ProposalStatus.Passed:
     case ProposalStatus.Enacted:
+    case ProposalStatus.Error:
       return true
     default:
       return false

--- a/src/entities/Votes/routes.ts
+++ b/src/entities/Votes/routes.ts
@@ -6,7 +6,7 @@ import { Snapshot, SnapshotVote } from '../../api/Snapshot'
 import VotesModel from './model';
 import { Vote, VoteAttributes } from './types';
 import isEthereumAddress from 'validator/lib/isEthereumAddress';
-import { ProposalAttributes } from '../Proposal/types';
+import { ProposalAttributes, ProposalStatus } from '../Proposal/types';
 import { createVotes, toProposalIds } from './utils';
 import { auth, WithAuth } from 'decentraland-gatsby/dist/entities/Auth/middleware';
 import Time from 'decentraland-gatsby/dist/utils/date/Time';
@@ -14,13 +14,15 @@ import chunk from 'decentraland-gatsby/dist/utils/array/chunk';
 
 export default routes((route) => {
   const withAuth = auth()
-route.get('/proposals/:proposal/votes', handleAPI(getProposalVotes))
+  route.get('/proposals/:proposal/votes', handleAPI(getProposalVotes))
   route.get('/proposals/:proposal/vp', withAuth, handleAPI(getMyProposalVotingPower))
   route.get('/votes', handleAPI(getCachedVotes))
 })
 
 export async function getProposalVotes(req: Request<{ proposal: string }>) {
   const proposal = await getProposal(req)
+  if (proposal.status == ProposalStatus.Creating) return {}
+
   let latestVotes = await VotesModel.getVotes(proposal.id)
   if (!latestVotes) {
     latestVotes = await VotesModel.createEmpty(proposal.id)

--- a/src/entities/Votes/routes.ts
+++ b/src/entities/Votes/routes.ts
@@ -21,7 +21,7 @@ export default routes((route) => {
 
 export async function getProposalVotes(req: Request<{ proposal: string }>) {
   const proposal = await getProposal(req)
-  if (proposal.status == ProposalStatus.Creating) return {}
+  if (proposal.status == ProposalStatus.Creating || proposal.status == ProposalStatus.Error) return {}
 
   let latestVotes = await VotesModel.getVotes(proposal.id)
   if (!latestVotes) {

--- a/src/intl/en.json
+++ b/src/intl/en.json
@@ -187,6 +187,8 @@
     "proposal_detail": {
       "title": "Decentraland DAO",
       "description": "The governance hub for Decentraland. Create and vote on proposals that help shape the future of the metaverse.",
+      "creating_title": "Please wait a minute",
+      "creating_description": "Your proposal is being created, it may take up to a minute. Please refresh this page.",
       "forum_button": "Discuss in the forum",
       "subscribe_button": "Add to my Watchlist",
       "subscribed_button": "Remove from my Watchlist",

--- a/src/intl/en.json
+++ b/src/intl/en.json
@@ -189,6 +189,8 @@
       "description": "The governance hub for Decentraland. Create and vote on proposals that help shape the future of the metaverse.",
       "creating_title": "Please wait a minute",
       "creating_description": "Your proposal is being created, it may take up to a minute. Please refresh this page.",
+      "deleted_title": "This proposal has been deleted by",
+      "error_title": "There was an error while creating this proposal",
       "forum_button": "Discuss in the forum",
       "subscribe_button": "Add to my Watchlist",
       "subscribed_button": "Remove from my Watchlist",

--- a/src/migrations/1634777482194_deleted-description.ts
+++ b/src/migrations/1634777482194_deleted-description.ts
@@ -1,0 +1,18 @@
+/* eslint-disable @typescript-eslint/camelcase */
+import { MigrationBuilder, ColumnDefinitions } from 'node-pg-migrate';
+import Model from '../entities/Proposal/model'
+
+export const shorthands: ColumnDefinitions | undefined = undefined;
+
+export async function up(pgm: MigrationBuilder): Promise<void> {
+    pgm.addColumns(Model.tableName, {
+        deleted_description: {
+          type: 'TEXT',
+          default: null,
+        }
+      })
+}
+
+export async function down(pgm: MigrationBuilder): Promise<void> {
+    pgm.dropColumns(Model.tableName, [ 'deleted_description' ])
+}

--- a/src/pages/proposal.tsx
+++ b/src/pages/proposal.tsx
@@ -10,6 +10,7 @@ import Grid from "semantic-ui-react/dist/commonjs/collections/Grid/Grid"
 import { Header } from "decentraland-ui/dist/components/Header/Header"
 import { Loader } from "decentraland-ui/dist/components/Loader/Loader"
 import { Button } from "decentraland-ui/dist/components/Button/Button"
+import { Message } from "decentraland-ui/dist/components/Message/Message"
 import { navigate } from "gatsby-plugin-intl"
 import { Governance } from "../api/Governance"
 import useProposal from "../hooks/useProposal"
@@ -134,12 +135,16 @@ export default function ProposalPage() {
         <Grid.Row>
 
           <Grid.Column tablet="12" className="ProposalDetailDescription">
+            { proposal?.status == ProposalStatus.Creating &&
+              <Message warning visible content={l('page.proposal_detail.creating_description')} header={l('page.proposal_detail.creating_title')} />
+            }
             <Loader active={proposalState.loading} />
             <ProposalHeaderPoi proposal={proposal} />
             <Markdown source={proposal?.description || ''} />
             <ProposalFooterPoi proposal={proposal} />
           </Grid.Column>
 
+          { proposal?.status != ProposalStatus.Creating &&
           <Grid.Column tablet="4" className="ProposalDetailActions">
             <ForumButton loading={proposalState.loading} disabled={!proposal} href={proposal && forumUrl(proposal) || ''} />
             <SubscribeButton
@@ -198,6 +203,7 @@ export default function ProposalPage() {
               >{l('page.proposal_detail.reject')}</Button>
             }
           </Grid.Column>
+          }
         </Grid.Row>
       </Grid>
     </ContentLayout>

--- a/src/pages/proposal.tsx
+++ b/src/pages/proposal.tsx
@@ -138,21 +138,32 @@ export default function ProposalPage() {
             { proposal?.status == ProposalStatus.Creating &&
               <Message warning visible content={l('page.proposal_detail.creating_description')} header={l('page.proposal_detail.creating_title')} />
             }
+
+            { proposal?.status == ProposalStatus.Error &&
+              <Message error visible content={proposal?.deleted_description} header={l('page.proposal_detail.error_title')} />
+            }
+
+            { proposal?.deleted && proposal?.status != ProposalStatus.Error &&
+              <Message warning visible content={proposal.deleted_by} header={l('page.proposal_detail.deleted_title')} />
+            }
             <Loader active={proposalState.loading} />
             <ProposalHeaderPoi proposal={proposal} />
             <Markdown source={proposal?.description || ''} />
             <ProposalFooterPoi proposal={proposal} />
           </Grid.Column>
 
-          { proposal?.status != ProposalStatus.Creating &&
           <Grid.Column tablet="4" className="ProposalDetailActions">
+            { !proposal?.deleted && proposal?.status != ProposalStatus.Creating &&
             <ForumButton loading={proposalState.loading} disabled={!proposal} href={proposal && forumUrl(proposal) || ''} />
+            }
+
+            { !proposal?.deleted && proposal?.status != ProposalStatus.Creating &&
             <SubscribeButton
               loading={proposalState.loading || subscriptionsState.loading || subscribing}
               disabled={!proposal}
               subscribed={subscribed}
               onClick={() => subscribe(!subscribed)}
-            />
+            />}
             <ProposalResultSection
               disabled={!proposal || !votes}
               loading={voting || proposalState.loading || votesState.loading || votingPowerState.loading}
@@ -203,7 +214,6 @@ export default function ProposalPage() {
               >{l('page.proposal_detail.reject')}</Button>
             }
           </Grid.Column>
-          }
         </Grid.Row>
       </Grid>
     </ContentLayout>

--- a/src/server.ts
+++ b/src/server.ts
@@ -16,9 +16,10 @@ import subscription from './entities/Subscription/routes'
 import committee from './entities/Committee/routes'
 import social from './entities/Social/routes'
 import sitemap from './entities/Sitemap/routes'
-import { activateProposals, finishProposal } from './entities/Proposal/jobs'
+import { createProposals, activateProposals, finishProposal } from './entities/Proposal/jobs'
 
 const jobs = manager()
+jobs.cron('@eachMinute', createProposals)
 jobs.cron('@eachMinute', activateProposals)
 jobs.cron('@eachMinute', finishProposal)
 


### PR DESCRIPTION
This PR implements:
* Delay the creation of Snapshot Proposal and Discourse forum thread.
* Proposal creator is immediately directed to proposal detail's page, actions are disabled until creation is done.
* Filter proposals in "creating" status until they are done.