### PR TITLE
Add List of Voters on Proposal Page

### DIFF
--- a/src/components/Modal/VoteListItem.tsx
+++ b/src/components/Modal/VoteListItem.tsx
@@ -1,0 +1,45 @@
+import React from 'react'
+import { navigate } from 'gatsby-plugin-intl'
+import Grid from 'semantic-ui-react/dist/commonjs/collections/Grid/Grid'
+import Avatar from 'decentraland-gatsby/dist/components/User/Avatar'
+import { Address } from 'decentraland-ui/dist/components/Address/Address'
+import useFormatMessage from 'decentraland-gatsby/dist/hooks/useFormatMessage'
+import useAsyncMemo from 'decentraland-gatsby/dist/hooks/useAsyncMemo'
+import profiles from 'decentraland-gatsby/dist/utils/loader/profile'
+import { Vote } from '../../entities/Votes/types'
+import { abbreviateNumber } from '../../entities/Votes/utils'
+import locations from '../../modules/locations'
+
+export type VoteListItemModalProps = {
+  address: string
+  value: Vote
+}
+
+export function VoteListItem({ address, value }: VoteListItemModalProps) {
+  const l = useFormatMessage()
+  const [ profile ] = useAsyncMemo(
+    async () => address ? profiles.load(address) : null,
+    [ address ],
+    { callWithTruthyDeps: true }
+  )  
+  
+  return (
+    <Grid.Row onClick={() => navigate(locations.balance({ address }))} key={address} className="VoteList_Item VotesList_Divider_Line">
+      <Grid.Column width={8}>
+        <div>
+          <Avatar size="small" address={address} style={{ marginRight: '.5rem' }} />
+          {profile && <span>{profile.name}</span>}
+          {(!profile || !profile.name) && <Address value={address} />}
+        </div>
+      </Grid.Column>
+      <Grid.Column>
+        <p style={{ marginLeft: '0.5rem' }}>
+          {value.choice === 1 ? l('modal.votes_list.voted_yes') : l('modal.votes_list.voted_no')}
+        </p>
+      </Grid.Column>
+      <Grid.Column>
+        <p style={{ marginLeft: '0.5rem' }}>{`${abbreviateNumber(value.vp)} ${l('modal.votes_list.vp')}`}</p>
+      </Grid.Column>
+    </Grid.Row>
+  )
+}

--- a/src/components/Modal/VotesList.css
+++ b/src/components/Modal/VotesList.css
@@ -8,9 +8,9 @@
   margin: 0 auto;
   width: 90%;
   margin-bottom: 40px;
-  max-height: calc(70vh);
-  padding: 20px 5px;
-  overflow-y: scroll;
+  height: 50vh;
+  padding: 20px 0px;
+  overflow-y: auto;
   overflow-x: hidden;
 }
 
@@ -32,8 +32,7 @@
   content: "";
   position: absolute;
   top: 0;
-  width: 94%;
-  left: 3%;
+  width: 95%;
   border-bottom: 1px solid #e7e6e9;
 }
 
@@ -41,8 +40,7 @@
   content: "";
   position: absolute;
   bottom: 0;
-  width: 94%;
-  left: 3%;
+  width: 95%;
   border-bottom: 1px solid #e7e6e9;
 }
 
@@ -53,11 +51,10 @@
 
   .VotesList .VotesList_Container_Items {
     width: 97%;
-    padding: 20px 1px;
-    font-size: 14px;
+    font-size: 13px;
   }
 
   .VotesList .VotesList_Container_Header .VotesList_Header {
-    font-size: 14px;
+    font-size: 13px;
   }
 }

--- a/src/components/Modal/VotesList.css
+++ b/src/components/Modal/VotesList.css
@@ -1,0 +1,59 @@
+.VotesList .VotesList_Container_Header {
+  margin: 0 auto;
+  width: 90%;
+  margin-bottom: 20px;
+}
+
+.VotesList .VotesList_Container_Items {
+  margin: 0 auto;
+  width: 90%;
+  margin-bottom: 40px;
+  max-height: calc(70vh);
+  padding: 20px 5px;
+  overflow-y: scroll;
+  overflow-x: hidden;
+}
+
+.VotesList .VotesList_Container_Header .VotesList_Header {
+  color: #a4a2a8;
+}
+
+.VotesList_Divider {
+  position: relative;
+}
+
+.VotesList_Container_Items
+  .VotesList_Divider
+  .VotesList_Divider_Line:first-child:after {
+  content: "";
+  position: absolute;
+  top: 0;
+  width: 94%;
+  left: 3%;
+  border-bottom: 1px solid #e7e6e9;
+}
+
+.VotesList_Divider .VotesList_Divider_Line:before {
+  content: "";
+  position: absolute;
+  bottom: 0;
+  width: 94%;
+  left: 3%;
+  border-bottom: 1px solid #e7e6e9;
+}
+
+@media (max-width: 768px) {
+  .VotesList .VotesList_Container_Header {
+    width: 97%;
+  }
+
+  .VotesList .VotesList_Container_Items {
+    width: 97%;
+    padding: 20px 1px;
+    font-size: 14px;
+  }
+
+  .VotesList .VotesList_Container_Header .VotesList_Header {
+    font-size: 14px;
+  }
+}

--- a/src/components/Modal/VotesList.css
+++ b/src/components/Modal/VotesList.css
@@ -14,6 +14,10 @@
   overflow-x: hidden;
 }
 
+.VotesList .VotesList_Container_Items .VoteList_Item:hover {
+  cursor: pointer;
+}
+
 .VotesList .VotesList_Container_Header .VotesList_Header {
   color: #a4a2a8;
 }

--- a/src/components/Modal/VotesList.tsx
+++ b/src/components/Modal/VotesList.tsx
@@ -1,16 +1,12 @@
-import React from 'react'
-import { navigate } from 'gatsby-plugin-intl'
+import React, { useMemo } from 'react'
 import { Modal, ModalProps } from 'decentraland-ui/dist/components/Modal/Modal'
 import Grid from "semantic-ui-react/dist/commonjs/collections/Grid/Grid"
-import Avatar from 'decentraland-gatsby/dist/components/User/Avatar'
-import { Address } from 'decentraland-ui/dist/components/Address/Address'
+import { VoteListItem } from './VoteListItem';
 import { Vote } from '../../entities/Votes/types'
 import { Header } from 'decentraland-ui/dist/components/Header/Header'
 import { Close } from 'decentraland-ui/dist/components/Close/Close'
 import TokenList from 'decentraland-gatsby/dist/utils/dom/TokenList'
 import useFormatMessage from 'decentraland-gatsby/dist/hooks/useFormatMessage'
-import { abbreviateNumber } from '../../entities/Votes/utils'
-import locations from '../../modules/locations'
 
 import './ProposalModal.css'
 import './VotesList.css'
@@ -22,7 +18,9 @@ export type VotesListModalProps = Omit<ModalProps, 'children'> & {
 
 export function VotesList({onClickAccept, votes, ...props }: VotesListModalProps) {
   const l = useFormatMessage()
-
+  
+  const votesList = useMemo(() => Object.entries(votes || {}).sort((a, b) => b[1].vp - a[1].vp), [votes])
+  
   return <Modal {...props} size="tiny" className={TokenList.join(['ProposalModal', 'VotesList' ,props.className])} closeIcon={<Close />}>
   <Modal.Content className="ProposalModal__Title">
     <Header>{l('modal.votes_list.title', { votes: Object.keys(votes || {}).length })}</Header>
@@ -44,26 +42,9 @@ export function VotesList({onClickAccept, votes, ...props }: VotesListModalProps
   </div>
   <div className="VotesList_Container_Items">
     <Grid columns='equal' className="VotesList_Divider">
-      {Object.entries(votes || {}).sort((a, b) => b[1].vp - a[1].vp).map(vote => {
+      {votesList.map(vote => {
         const [key, value] = vote
-        return (
-          <Grid.Row onClick={() => navigate(locations.balance({ address: key }))} key={key} className="VoteList_Item VotesList_Divider_Line">
-            <Grid.Column width={8}>
-              <div>
-                <Avatar size="small" address={key} style={{ marginRight: '.5rem' }} />
-                <Address value={key} />
-              </div>
-            </Grid.Column>
-            <Grid.Column>
-              <p style={{ marginLeft: '0.5rem' }}>
-                {value.choice === 1 ? l('modal.votes_list.voted_yes') : l('modal.votes_list.voted_no')}
-              </p>
-            </Grid.Column>
-            <Grid.Column>
-              <p style={{ marginLeft: '0.5rem' }}>{`${abbreviateNumber(value.vp)} ${l('modal.votes_list.vp')}`}</p>
-            </Grid.Column>
-          </Grid.Row>
-        )
+        return <VoteListItem key={key} address={key} value={value} />
       })}
     </Grid>
   </div>

--- a/src/components/Modal/VotesList.tsx
+++ b/src/components/Modal/VotesList.tsx
@@ -1,0 +1,87 @@
+import React from 'react'
+import { Modal, ModalProps } from 'decentraland-ui/dist/components/Modal/Modal'
+import Grid from "semantic-ui-react/dist/commonjs/collections/Grid/Grid"
+import Avatar from 'decentraland-gatsby/dist/components/User/Avatar'
+import { Address } from 'decentraland-ui/dist/components/Address/Address'
+import { Vote } from '../../entities/Votes/types'
+import { Header } from 'decentraland-ui/dist/components/Header/Header'
+import { Close } from 'decentraland-ui/dist/components/Close/Close'
+import TokenList from 'decentraland-gatsby/dist/utils/dom/TokenList'
+import useFormatMessage from 'decentraland-gatsby/dist/hooks/useFormatMessage'
+
+import './ProposalModal.css'
+import './VotesList.css'
+
+const SI_SYMBOL = ["", "k", "M", "G", "T", "P", "E"]
+
+function abbreviateNumber(number: number) {
+
+  const tier = Math.log10(Math.abs(number)) / 3 | 0
+  
+  if (tier == 0) return number
+
+  const suffix = SI_SYMBOL[tier];
+  const scale = Math.pow(10, tier * 3)
+
+  const scaled = number / scale
+
+  return scaled.toFixed(1) + suffix
+}
+
+export type VotesListModalProps = Omit<ModalProps, 'children'> & {
+  onClickAccept?: (e: React.MouseEvent<any>) => void
+  votes?: Record<string, Vote> | null,
+}
+
+export function VotesList({onClickAccept, votes, ...props }: VotesListModalProps) {
+  const l = useFormatMessage()
+
+  return <Modal {...props} size="tiny" className={TokenList.join(['ProposalModal', 'VotesList' ,props.className])} closeIcon={<Close />}>
+  <Modal.Content className="ProposalModal__Title">
+    <Header>{Object.entries(votes || {}).length} {Object.entries(votes || {}).length === 1 ? 'Vote' : 'Votes'}</Header>
+  </Modal.Content>
+  <div className="VotesList_Container_Header">
+    <Grid columns='equal'>
+      <Grid.Row className="VotesList_Divider_Line">
+        <Grid.Column width={8}>
+          <div className="VotesList_Header">{l('modal.votes_list.voter')}</div>
+        </Grid.Column>
+        <Grid.Column >
+          <div className="VotesList_Header">{l('modal.votes_list.voted')}</div>
+        </Grid.Column>
+        <Grid.Column>
+          <div className="VotesList_Header">{l('modal.votes_list.vp')}</div>
+        </Grid.Column>
+      </Grid.Row>
+    </Grid>
+  </div>
+  <div className="VotesList_Container_Items">
+    <Grid columns='equal' className="VotesList_Divider">
+      {Object.entries(votes || {}).sort((a, b) => b[1].vp - a[1].vp).map(vote => {
+        const [key, value] = vote
+        return (
+          <Grid.Row key={key} className="VotesList_Divider_Line">
+            <Grid.Column width={8}>
+              <div>
+                <Avatar size="small" address={key} style={{ marginRight: '.5rem' }} />
+                <Address value={key} />
+              </div>
+            </Grid.Column>
+            <Grid.Column>
+              <p style={{ marginLeft: '0.5rem' }}>
+                {value.choice === 1 ? l('modal.votes_list.voted_yes') : l('modal.votes_list.voted_no')}
+              </p>
+            </Grid.Column>
+            <Grid.Column>
+              {/* I added this abbreviateNumber function because when the modal is in mobile screens if the number is high 
+                 will break the text to another line even if the font is smaller in snapshot they do the same if you look at the screenshot
+               */}
+              <p style={{ marginLeft: '0.5rem' }}>{`${abbreviateNumber(value.vp)} ${l('modal.votes_list.vp')}`}</p>
+            </Grid.Column>
+          </Grid.Row>
+        )
+      })}
+    </Grid>
+  </div>
+</Modal>
+}

--- a/src/components/Modal/VotesList.tsx
+++ b/src/components/Modal/VotesList.tsx
@@ -1,4 +1,5 @@
 import React from 'react'
+import { navigate } from 'gatsby-plugin-intl'
 import { Modal, ModalProps } from 'decentraland-ui/dist/components/Modal/Modal'
 import Grid from "semantic-ui-react/dist/commonjs/collections/Grid/Grid"
 import Avatar from 'decentraland-gatsby/dist/components/User/Avatar'
@@ -8,6 +9,7 @@ import { Header } from 'decentraland-ui/dist/components/Header/Header'
 import { Close } from 'decentraland-ui/dist/components/Close/Close'
 import TokenList from 'decentraland-gatsby/dist/utils/dom/TokenList'
 import useFormatMessage from 'decentraland-gatsby/dist/hooks/useFormatMessage'
+import locations from '../../modules/locations'
 
 import './ProposalModal.css'
 import './VotesList.css'
@@ -60,7 +62,7 @@ export function VotesList({onClickAccept, votes, ...props }: VotesListModalProps
       {Object.entries(votes || {}).sort((a, b) => b[1].vp - a[1].vp).map(vote => {
         const [key, value] = vote
         return (
-          <Grid.Row key={key} className="VotesList_Divider_Line">
+          <Grid.Row onClick={() => navigate(locations.balance({ address: key }))} key={key} className="VoteList_Item VotesList_Divider_Line">
             <Grid.Column width={8}>
               <div>
                 <Avatar size="small" address={key} style={{ marginRight: '.5rem' }} />

--- a/src/components/Modal/VotesList.tsx
+++ b/src/components/Modal/VotesList.tsx
@@ -25,7 +25,7 @@ export function VotesList({onClickAccept, votes, ...props }: VotesListModalProps
 
   return <Modal {...props} size="tiny" className={TokenList.join(['ProposalModal', 'VotesList' ,props.className])} closeIcon={<Close />}>
   <Modal.Content className="ProposalModal__Title">
-    <Header>{Object.entries(votes || {}).length} {Object.entries(votes || {}).length === 1 ? l('modal.votes_list.vote') : l('modal.votes_list.votes')}</Header>
+    <Header>{l('modal.votes_list.title', { votes: Object.keys(votes || {}).length })}</Header>
   </Modal.Content>
   <div className="VotesList_Container_Header">
     <Grid columns='equal'>

--- a/src/components/Modal/VotesList.tsx
+++ b/src/components/Modal/VotesList.tsx
@@ -9,26 +9,11 @@ import { Header } from 'decentraland-ui/dist/components/Header/Header'
 import { Close } from 'decentraland-ui/dist/components/Close/Close'
 import TokenList from 'decentraland-gatsby/dist/utils/dom/TokenList'
 import useFormatMessage from 'decentraland-gatsby/dist/hooks/useFormatMessage'
+import { abbreviateNumber } from '../../entities/Votes/utils'
 import locations from '../../modules/locations'
 
 import './ProposalModal.css'
 import './VotesList.css'
-
-const SI_SYMBOL = ["", "k", "M", "G", "T", "P", "E"]
-
-function abbreviateNumber(number: number) {
-
-  const tier = Math.log10(Math.abs(number)) / 3 | 0
-  
-  if (tier == 0) return number
-
-  const suffix = SI_SYMBOL[tier];
-  const scale = Math.pow(10, tier * 3)
-
-  const scaled = number / scale
-
-  return scaled.toFixed(1) + suffix
-}
 
 export type VotesListModalProps = Omit<ModalProps, 'children'> & {
   onClickAccept?: (e: React.MouseEvent<any>) => void
@@ -75,9 +60,6 @@ export function VotesList({onClickAccept, votes, ...props }: VotesListModalProps
               </p>
             </Grid.Column>
             <Grid.Column>
-              {/* I added this abbreviateNumber function because when the modal is in mobile screens if the number is high 
-                 will break the text to another line even if the font is smaller in snapshot they do the same if you look at the screenshot
-               */}
               <p style={{ marginLeft: '0.5rem' }}>{`${abbreviateNumber(value.vp)} ${l('modal.votes_list.vp')}`}</p>
             </Grid.Column>
           </Grid.Row>

--- a/src/components/Modal/VotesList.tsx
+++ b/src/components/Modal/VotesList.tsx
@@ -25,7 +25,7 @@ export function VotesList({onClickAccept, votes, ...props }: VotesListModalProps
 
   return <Modal {...props} size="tiny" className={TokenList.join(['ProposalModal', 'VotesList' ,props.className])} closeIcon={<Close />}>
   <Modal.Content className="ProposalModal__Title">
-    <Header>{Object.entries(votes || {}).length} {Object.entries(votes || {}).length === 1 ? 'Vote' : 'Votes'}</Header>
+    <Header>{Object.entries(votes || {}).length} {Object.entries(votes || {}).length === 1 ? l('modal.votes_list.vote') : l('modal.votes_list.votes')}</Header>
   </Modal.Content>
   <div className="VotesList_Container_Header">
     <Grid columns='equal'>

--- a/src/components/Section/DetailsSection.css
+++ b/src/components/Section/DetailsSection.css
@@ -37,6 +37,12 @@
   align-items: center;
 }
 
+.DetailsSection__Flex_Header_Labels > a {
+  text-transform: uppercase;
+  margin-bottom: 5px;
+  font-size: 13px !important;
+}
+
 .DetailsSection .DetailsSection__Flex > div {
   flex: 0 0 50%;
   text-overflow: ellipsis;

--- a/src/components/Section/DetailsSection.css
+++ b/src/components/Section/DetailsSection.css
@@ -1,6 +1,6 @@
 .DetailsSection {
   width: 100%;
-  border: 1px solid rgba(115, 110, 125, .24);
+  border: 1px solid rgba(115, 110, 125, 0.24);
   border-radius: 8px;
   display: block;
   /* padding: 15px; */
@@ -10,7 +10,7 @@
 
 .DetailsSection.DetailsSection--loading > *,
 .DetailsSection.DetailsSection--disabled > * {
-  opacity: .5;
+  opacity: 0.5;
   pointer-events: none;
 }
 
@@ -21,12 +21,18 @@
 }
 
 .DetailsSection .DetailsSection__Content + .DetailsSection__Content {
-  border-top: 1px solid rgba(115, 110, 125, .24);
+  border-top: 1px solid rgba(115, 110, 125, 0.24);
 }
 
 .DetailsSection .DetailsSection__Flex {
   display: flex;
   margin-top: 16px;
+  justify-content: space-between;
+  align-items: center;
+}
+
+.DetailsSection .DetailsSection__Flex_Header_Labels {
+  display: flex;
   justify-content: space-between;
   align-items: center;
 }
@@ -44,16 +50,18 @@
 }
 
 .DetailsSection .DetailsSection__Secondary {
-  background:  var(--secondary);
+  background: var(--secondary);
   border-radius: 6px;
   margin-top: 24px;
   padding: 8px 11px;
 }
 
-.DetailsSection .DetailsSection__Secondary .DetailsSection__Secondary__Subtitle {
+.DetailsSection
+  .DetailsSection__Secondary
+  .DetailsSection__Secondary__Subtitle {
   font-size: 13px;
   color: var(--text);
-  opacity: .8;
+  opacity: 0.8;
 }
 
 .DetailsSection .DetailsSection__Secondary .DetailsSection__Secondary__Title {
@@ -70,4 +78,16 @@
 .DetailsSection .ui.button {
   width: 100%;
   margin-top: 8px;
+}
+
+@media (min-width: 768px) {
+  .DetailsSection .DetailsSection__Flex_Header_Labels {
+    display: block;
+  }
+}
+
+@media (min-width: 1024px) {
+  .DetailsSection .DetailsSection__Flex_Header_Labels {
+    display: flex;
+  }
 }

--- a/src/components/Section/ProposalResultSection.tsx
+++ b/src/components/Section/ProposalResultSection.tsx
@@ -39,6 +39,7 @@ export default React.memo(function ProposalResultSection({ proposal, loading, di
   const now = useMemo(() => Time.utc(), [])
   const start_at = useMemo(() => Time.utc(proposal?.start_at) || now, [proposal])
   const finish_at = useMemo(() => Time.utc(proposal?.finish_at) || now, [proposal])
+  const isVotes = useMemo(() => Object.keys(votes || {}).length > 0, [votes])
   const untilStart = useCountdown(start_at)
   const untilFinish = useCountdown(finish_at)
   const started = untilStart.time === 0
@@ -55,7 +56,7 @@ export default React.memo(function ProposalResultSection({ proposal, loading, di
       <Loader active={loading} />
       <div className="DetailsSection__Flex_Header_Labels">
         <Header sub>{l('page.proposal_detail.result_label')}</Header>
-        {Object.keys(votes || {}).length > 0 && <Anchor style={{ marginBottom: '5px', textTransform: 'uppercase' }} onClick={onOpenVotesList} >
+        {isVotes && <Anchor onClick={onOpenVotesList}>
           {l('page.proposal_detail.see_votes_button')}
         </Anchor>}
       </div>

--- a/src/components/Section/ProposalResultSection.tsx
+++ b/src/components/Section/ProposalResultSection.tsx
@@ -3,6 +3,7 @@ import { Link } from 'gatsby-plugin-intl'
 import { Header } from 'decentraland-ui/dist/components/Header/Header'
 import { Loader } from 'decentraland-ui/dist/components/Loader/Loader'
 import { Button } from 'decentraland-ui/dist/components/Button/Button'
+import Anchor from 'decentraland-gatsby/dist/components/Text/Link'
 import useFormatMessage from 'decentraland-gatsby/dist/hooks/useFormatMessage'
 import useCountdown from 'decentraland-gatsby/dist/hooks/useCountdown'
 import Bold from 'decentraland-gatsby/dist/components/Text/Bold'
@@ -25,10 +26,11 @@ export type ProposalResultSectionProps = Omit<React.HTMLAttributes<HTMLDivElemen
   disabled?: boolean,
   changingVote?: boolean,
   onChangeVote?: (e: React.MouseEvent<any>, changing: boolean) => void,
+  onOpenVotesList?: () => void,
   onVote?: (e: React.MouseEvent<any>, choice: string, choiceIndex: number) => void
 }
 
-export default React.memo(function ProposalResultSection({ proposal, loading, disabled, votes, changingVote, votingPower, onChangeVote, onVote, ...props }: ProposalResultSectionProps) {
+export default React.memo(function ProposalResultSection({ proposal, loading, disabled, votes, changingVote, votingPower, onChangeVote, onVote, onOpenVotesList, ...props }: ProposalResultSectionProps) {
   const l = useFormatMessage()
   const [account, accountState] = useAuthContext()
   const choices = useMemo((): string[] => proposal?.snapshot_proposal?.choices || [], [proposal])
@@ -51,8 +53,11 @@ export default React.memo(function ProposalResultSection({ proposal, loading, di
   ])}>
     <div className="DetailsSection__Content">
       <Loader active={loading} />
-      <div>
+      <div className="DetailsSection__Flex_Header_Labels">
         <Header sub>{l('page.proposal_detail.result_label')}</Header>
+        {Object.keys(votes || {}).length > 0 && <Anchor style={{ marginBottom: '5px', textTransform: 'uppercase' }} onClick={onOpenVotesList} >
+          {l('page.proposal_detail.see_votes_button')}
+        </Anchor>}
       </div>
       {results.map((result) => {
         return <ChoiceProgress key={result.choice} color={result.color} choice={result.choice} votes={result.votes} power={result.power} progress={result.progress} />

--- a/src/entities/Votes/utils.ts
+++ b/src/entities/Votes/utils.ts
@@ -143,3 +143,19 @@ export function calculateResultWinner(choices: string[], votes: Record<string, V
     return winner
   }, result[0])
 }
+
+const SI_SYMBOL = ["", "k", "M", "G", "T", "P", "E"]
+
+export function abbreviateNumber(vp: number) {
+
+  const tier = Math.log10(Math.abs(vp)) / 3 | 0
+  
+  if (tier == 0) return vp
+
+  const suffix = SI_SYMBOL[tier];
+  const scale = Math.pow(10, tier * 3)
+
+  const scaled = vp / scale
+
+  return scaled.toFixed(1) + suffix
+}

--- a/src/intl/en.json
+++ b/src/intl/en.json
@@ -140,6 +140,8 @@
       "reject": "No thanks"
     },
     "votes_list": {
+      "vote": "Vote",
+      "votes": "Votes",
       "voter": "Voter",
       "voted": "Voted",
       "vp": "VP",

--- a/src/intl/en.json
+++ b/src/intl/en.json
@@ -140,8 +140,7 @@
       "reject": "No thanks"
     },
     "votes_list": {
-      "vote": "Vote",
-      "votes": "Votes",
+      "title": "{votes} {votes, plural, one {Vote} other {Votes}}",
       "voter": "Voter",
       "voted": "Voted",
       "vp": "VP",

--- a/src/intl/en.json
+++ b/src/intl/en.json
@@ -89,10 +89,10 @@
   },
   "category": {
     "poi": "POI",
-    "catalyst" : "Catalyst",
-    "ban_name" : "Ban Name",
-    "grant" : "Grant",
-    "poll" : "Poll",
+    "catalyst": "Catalyst",
+    "ban_name": "Ban Name",
+    "grant": "Grant",
+    "poll": "Poll",
     "all_title": "All proposals",
     "catalyst_title": "Catalyst Node",
     "catalyst_description": "Add a node to the network of community run servers",
@@ -138,6 +138,13 @@
       "description": "Thank you for voting! Want to add it to your Watchlist to follow the results?",
       "accept": "Add to Watchlist",
       "reject": "No thanks"
+    },
+    "votes_list": {
+      "voter": "Voter",
+      "voted": "Voted",
+      "vp": "VP",
+      "voted_yes": "Yes",
+      "voted_no": "No"
     }
   },
   "page": {
@@ -190,6 +197,7 @@
       "forum_button": "Discuss in the forum",
       "subscribe_button": "Add to my Watchlist",
       "subscribed_button": "Remove from my Watchlist",
+      "see_votes_button": "See Votes",
       "result_label": "Current result",
       "vote_change": "Change Vote",
       "vote_manage": "Manage",

--- a/src/pages/proposal.tsx
+++ b/src/pages/proposal.tsx
@@ -27,6 +27,7 @@ import { Snapshot } from "../api/Snapshot"
 import Markdown from "decentraland-gatsby/dist/components/Text/Markdown"
 import { VoteRegisteredModal } from "../components/Modal/VoteRegisteredModal"
 import { DeleteProposalModal } from "../components/Modal/DeleteProposalModal"
+import { VotesList } from "../components/Modal/VotesList"
 import useFormatMessage from "decentraland-gatsby/dist/hooks/useFormatMessage"
 import retry from "decentraland-gatsby/dist/utils/promise/retry"
 import locations from "../modules/locations"
@@ -47,13 +48,14 @@ type ProposalPageOptions = {
   confirmSubscription: boolean
   confirmDeletion: boolean
   confirmStatusUpdate: ProposalStatus | false
+  showVotesList: boolean
 }
 
 export default function ProposalPage() {
   const l = useFormatMessage()
   const location = useLocation()
   const params = useMemo(() => new URLSearchParams(location.search), [location.search])
-  const [options, patchOptions] = usePatchState<ProposalPageOptions>({ changing: false, confirmSubscription: false, confirmDeletion: false, confirmStatusUpdate: false })
+  const [options, patchOptions] = usePatchState<ProposalPageOptions>({ changing: false, confirmSubscription: false, confirmDeletion: false, confirmStatusUpdate: false, showVotesList: false })
   const [account, { provider }] = useAuthContext()
   const [proposal, proposalState] = useProposal(params.get('id'))
   const [committee] = useAsyncMemo(() => Governance.get().getCommittee(), [])
@@ -148,6 +150,10 @@ export default function ProposalPage() {
               subscribed={subscribed}
               onClick={() => subscribe(!subscribed)}
             />
+            {Object.keys(votes || {}).length > 0  &&  <Button primary size="small" style={{ width: '100%', textTransform: 'capitalize' }} onClick={() => patchOptions({ showVotesList: true })} >
+              {l('page.proposal_detail.see_votes_button')}
+            </Button>
+            }
             <ProposalResultSection
               disabled={!proposal || !votes}
               loading={voting || proposalState.loading || votesState.loading || votingPowerState.loading}
@@ -201,6 +207,11 @@ export default function ProposalPage() {
         </Grid.Row>
       </Grid>
     </ContentLayout>
+    <VotesList
+      open={options.showVotesList}
+      votes={votes}
+      onClose={() => patchOptions({ showVotesList: false })}
+    />
     <VoteRegisteredModal
       loading={subscribing}
       open={options.confirmSubscription}

--- a/src/pages/proposal.tsx
+++ b/src/pages/proposal.tsx
@@ -150,10 +150,6 @@ export default function ProposalPage() {
               subscribed={subscribed}
               onClick={() => subscribe(!subscribed)}
             />
-            {Object.keys(votes || {}).length > 0  &&  <Button primary size="small" style={{ width: '100%', textTransform: 'capitalize' }} onClick={() => patchOptions({ showVotesList: true })} >
-              {l('page.proposal_detail.see_votes_button')}
-            </Button>
-            }
             <ProposalResultSection
               disabled={!proposal || !votes}
               loading={voting || proposalState.loading || votesState.loading || votingPowerState.loading}
@@ -161,7 +157,8 @@ export default function ProposalPage() {
               votes={votes}
               votingPower={votingPower || 0}
               changingVote={options.changing}
-              onChangeVote={(_, changing) => patchOptions({ changing })}
+              onChangeVote={ (_, changing) => patchOptions({ changing }) }
+              onOpenVotesList={() => patchOptions({ showVotesList: true })}
               onVote={(_, choice, choiceIndex) => vote(choice, choiceIndex)}
             />
             <ProposalDetailSection proposal={proposal} />


### PR DESCRIPTION
This PR implements:

- see votes button to see the list of votes.
- A modal to show the list of votes.
- inside the modal, you will see the address, the vote and vp of the user that voted
- link to users VP page.

[issue 135](https://github.com/decentraland/governance/issues/135)

ps: I added this abbreviateNumber function because when the modal is in mobile screens if the number is high will break the text to another line even if the font is smaller in snapshot they do the same if you look at the screenshot.