### PR TITLE
Fix dependency path of package-lock.json

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -18108,7 +18108,7 @@
       "resolved": "https://registry.npmjs.org/eth-sig-util/-/eth-sig-util-1.4.2.tgz",
       "integrity": "sha1-jZWCAsftuq6Dlwf7pvCf8ydgYhA=",
       "requires": {
-        "ethereumjs-abi": "ethereumjs-abi@git+https://github.com/ethereumjs/ethereumjs-abi.git",
+        "ethereumjs-abi": "git+https://github.com/ethereumjs/ethereumjs-abi.git",
         "ethereumjs-util": "^5.1.1"
       },
       "dependencies": {
@@ -18196,8 +18196,8 @@
       }
     },
     "ethereumjs-abi": {
-      "version": "git+ssh://git@github.com/ethereumjs/ethereumjs-abi.git#ee3994657fa7a427238e6ba92a84d0b529bbcde0",
-      "from": "ethereumjs-abi@git+https://github.com/ethereumjs/ethereumjs-abi.git",
+      "version": "git+https://github.com/ethereumjs/ethereumjs-abi.git#ee3994657fa7a427238e6ba92a84d0b529bbcde0",
+      "from": "git+https://github.com/ethereumjs/ethereumjs-abi.git",
       "requires": {
         "bn.js": "^4.11.8",
         "ethereumjs-util": "^6.0.0"


### PR DESCRIPTION
This PR implements:

- Fix the dependency path of ethereumjs-abi.
- Enable the project to install all the dependencies without issues.

This PR resolves issue #142 