### PR TITLE
Add sorting to proposals

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -18108,7 +18108,7 @@
       "resolved": "https://registry.npmjs.org/eth-sig-util/-/eth-sig-util-1.4.2.tgz",
       "integrity": "sha1-jZWCAsftuq6Dlwf7pvCf8ydgYhA=",
       "requires": {
-        "ethereumjs-abi": "ethereumjs-abi@git+https://github.com/ethereumjs/ethereumjs-abi.git",
+        "ethereumjs-abi": "git+https://github.com/ethereumjs/ethereumjs-abi.git",
         "ethereumjs-util": "^5.1.1"
       },
       "dependencies": {
@@ -18196,8 +18196,8 @@
       }
     },
     "ethereumjs-abi": {
-      "version": "git+ssh://git@github.com/ethereumjs/ethereumjs-abi.git#ee3994657fa7a427238e6ba92a84d0b529bbcde0",
-      "from": "ethereumjs-abi@git+https://github.com/ethereumjs/ethereumjs-abi.git",
+      "version": "git+https://github.com/ethereumjs/ethereumjs-abi.git#ee3994657fa7a427238e6ba92a84d0b529bbcde0",
+      "from": "git+https://github.com/ethereumjs/ethereumjs-abi.git",
       "requires": {
         "bn.js": "^4.11.8",
         "ethereumjs-util": "^6.0.0"

--- a/src/components/SortingMenu/SortingMenu.tsx
+++ b/src/components/SortingMenu/SortingMenu.tsx
@@ -1,0 +1,26 @@
+import React from 'react'
+import { Dropdown } from 'decentraland-ui/dist/components/Dropdown/Dropdown'
+import useFormatMessage from 'decentraland-gatsby/dist/hooks/useFormatMessage'
+import { ProposalSorting } from '../../entities/Proposal/types'
+
+export type SortingMenu = {
+  style?: React.CSSProperties,
+  value?: ProposalSorting | null,
+  onChange?: (e: React.MouseEvent<any>, props: { value: ProposalSorting | null }) => void,
+}
+
+export default function StatusMenu(props: SortingMenu) {
+  // const l = useFormatMessage()
+  function handleChange(e: React.MouseEvent<any>, value: ProposalSorting | null) {
+    if (props.onChange) {
+      props.onChange(e, { value })
+    }
+  }
+
+  return <Dropdown text="latest" style={props.style}>
+    <Dropdown.Menu>
+      <Dropdown.Item text="Latest" onClick={(e) => handleChange(e, null)} />
+      <Dropdown.Item text="PARTICIPATION" onClick={(e) => handleChange(e, ProposalSorting.TotalVp)} />
+    </Dropdown.Menu>
+  </Dropdown>
+}

--- a/src/components/SortingMenu/SortingMenu.tsx
+++ b/src/components/SortingMenu/SortingMenu.tsx
@@ -10,17 +10,17 @@ export type SortingMenu = {
 }
 
 export default function StatusMenu(props: SortingMenu) {
-  // const l = useFormatMessage()
+  const l = useFormatMessage()
   function handleChange(e: React.MouseEvent<any>, value: ProposalSorting | null) {
     if (props.onChange) {
       props.onChange(e, { value })
     }
   }
 
-  return <Dropdown text="latest" style={props.style}>
+  return <Dropdown text={l(`sort.${props.value || 'latest'}`) || ''} style={props.style}>
     <Dropdown.Menu>
-      <Dropdown.Item text="Latest" onClick={(e) => handleChange(e, null)} />
-      <Dropdown.Item text="PARTICIPATION" onClick={(e) => handleChange(e, ProposalSorting.TotalVp)} />
+      <Dropdown.Item text={l(`sort.latest`)} onClick={(e) => handleChange(e, null)} />
+      <Dropdown.Item text={l(`sort.participation`)} onClick={(e) => handleChange(e, ProposalSorting.Participation)} />
     </Dropdown.Menu>
   </Dropdown>
 }

--- a/src/components/Status/StatusMenu.tsx
+++ b/src/components/Status/StatusMenu.tsx
@@ -17,6 +17,8 @@ export default function StatusMenu(props: StatusMenu) {
     }
   }
 
+  
+
   return <Dropdown text={l(`status.${props.value || 'all'}`) || ''} style={props.style}>
     <Dropdown.Menu>
       <Dropdown.Item text={l(`status.all`)} onClick={(e) => handleChange(e, null)} />

--- a/src/entities/Proposal/model.ts
+++ b/src/entities/Proposal/model.ts
@@ -62,6 +62,31 @@ export default class ProposalModel extends Model<ProposalAttributes> {
     return this.rowCount(query)
   }
 
+  static async getActiveProposal() {
+    const query = SQL`
+      SELECT * FROM ${table(ProposalModel)}
+      WHERE "status" = ${ProposalStatus.Active}
+    `
+
+    const result = await this.query(query)
+    return result.map(ProposalModel.parse)
+  }
+
+
+  static async updateVpProposal(proposalId: string, totalVp: number) {
+    const query = SQL`
+      UPDATE ${table(ProposalModel)}
+      SET
+        "total_vp" = ${totalVp},
+        "updated_at" = now()
+      WHERE
+        "id" = ${proposalId}
+        AND "status" = ${ProposalStatus.Active}
+    `
+
+    return this.rowCount(query)
+  }
+
   static async getFinishedProposal() {
     const query = SQL`
       SELECT *

--- a/src/entities/Proposal/routes.ts
+++ b/src/entities/Proposal/routes.ts
@@ -379,6 +379,7 @@ export async function createProposal(data: Pick<ProposalAttributes, 'type' | 'us
     passed_description: null,
     rejected_by: null,
     rejected_description: null,
+    total_vp: 0,
     created_at: start.toJSON() as any,
     updated_at: start.toJSON() as any,
   }

--- a/src/entities/Proposal/templates/messages.test.ts
+++ b/src/entities/Proposal/templates/messages.test.ts
@@ -56,6 +56,7 @@ export function initProposalAttributes(proposalStatus: ProposalStatus,
     rejected_description: rejectedDescription,
     created_at: start.toJSON() as any,
     updated_at: start.toJSON() as any,
+    total_vp: 0,
   }
 }
 

--- a/src/entities/Proposal/types.ts
+++ b/src/entities/Proposal/types.ts
@@ -30,6 +30,7 @@ export type ProposalAttributes<C extends {} = any> = {
   required_to_pass: number | null
   created_at: Date
   updated_at: Date
+  total_vp: number
 }
 
 export enum ProposalStatus {

--- a/src/entities/Proposal/types.ts
+++ b/src/entities/Proposal/types.ts
@@ -63,14 +63,12 @@ export function toProposalStatus(value: string | null | undefined): ProposalStat
 }
 
 export enum ProposalSorting {
-  Date = 'date',
-  TotalVp = 'total_vp',
+  Participation = 'participation',
 }
 
 export function isProposalSorting(value:  string | null | undefined): boolean {
   switch (value) {
-    case ProposalSorting.Date:
-    case ProposalSorting.TotalVp:
+    case ProposalSorting.Participation:
       return true
     default:
       return false

--- a/src/entities/Proposal/types.ts
+++ b/src/entities/Proposal/types.ts
@@ -62,6 +62,28 @@ export function toProposalStatus(value: string | null | undefined): ProposalStat
     null
 }
 
+export enum ProposalSorting {
+  Date = 'date',
+  TotalVp = 'total_vp',
+}
+
+export function isProposalSorting(value:  string | null | undefined): boolean {
+  switch (value) {
+    case ProposalSorting.Date:
+    case ProposalSorting.TotalVp:
+      return true
+    default:
+      return false
+  }
+}
+
+export function toProposalSorting(value: string | null | undefined): ProposalSorting | null {
+  return isProposalSorting(value)?
+    value as ProposalSorting :
+    null
+}
+
+
 export enum ProposalType {
   POI = 'poi',
   Catalyst = 'catalyst',

--- a/src/intl/en.json
+++ b/src/intl/en.json
@@ -114,6 +114,10 @@
     "passed": "Passed outcomes",
     "enacted": "Enacted outcomes"
   },
+  "sort": {
+    "latest": "Latest",
+    "participation": "Participation"
+  },
   "modal": {
     "new_proposal": {
       "title": "New Proposal",

--- a/src/migrations/1616763227514_create-proposals.ts
+++ b/src/migrations/1616763227514_create-proposals.ts
@@ -75,6 +75,11 @@ export async function up(pgm: MigrationBuilder): Promise<void> {
     enacted_description: {
       type: 'TEXT',
     },
+    total_vp: {
+      type: 'INT',
+      notNull: true,
+      default: 0
+    },
     deleted: {
       type: 'BOOLEAN',
       notNull: true,

--- a/src/migrations/1616763227514_create-proposals.ts
+++ b/src/migrations/1616763227514_create-proposals.ts
@@ -75,11 +75,6 @@ export async function up(pgm: MigrationBuilder): Promise<void> {
     enacted_description: {
       type: 'TEXT',
     },
-    total_vp: {
-      type: 'INT',
-      notNull: true,
-      default: 0
-    },
     deleted: {
       type: 'BOOLEAN',
       notNull: true,

--- a/src/migrations/1638748368715_add-total-vp-to-proposals.ts
+++ b/src/migrations/1638748368715_add-total-vp-to-proposals.ts
@@ -1,0 +1,18 @@
+/* eslint-disable @typescript-eslint/camelcase */
+import { MigrationBuilder, ColumnDefinitions } from 'node-pg-migrate';
+import Model from '../entities/Proposal/model'
+
+export const shorthands: ColumnDefinitions | undefined = undefined;
+
+export async function up(pgm: MigrationBuilder): Promise<void> {
+  pgm.addColumns(Model.tableName, {
+    total_vp: {
+      type: 'INT',
+      default: 0
+    },
+  })
+}
+
+export async function down(pgm: MigrationBuilder): Promise<void> {
+  pgm.dropColumns(Model.tableName, [ 'total_vp' ])
+}

--- a/src/pages/index.tsx
+++ b/src/pages/index.tsx
@@ -78,10 +78,7 @@ export default function IndexPage() {
   //     navigate(locations.proposals(newParams))
   //   }
   // }
-
-  // console.log('params', params);
   
-
   function handlePageFilter(page: number) {
     const newParams = new URLSearchParams(params)
     page !== 1 ? newParams.set('page', String(page)) : newParams.delete('page')

--- a/src/pages/index.tsx
+++ b/src/pages/index.tsx
@@ -12,9 +12,10 @@ import Navigation, { NavigationTab } from "../components/Layout/Navigation"
 import locations, { ProposalListView, toProposalListPage, toProposalListView, WELCOME_STORE_KEY, WELCOME_STORE_VERSION } from "../modules/locations"
 import ActionableLayout from "../components/Layout/ActionableLayout"
 import CategoryOption from "../components/Category/CategoryOption"
-import { ProposalStatus, ProposalType, toProposalStatus, toProposalType } from "../entities/Proposal/types"
+import { ProposalStatus, ProposalType, toProposalStatus, toProposalType, ProposalSorting, toProposalSorting } from "../entities/Proposal/types"
 import useFormatMessage from "decentraland-gatsby/dist/hooks/useFormatMessage"
 import StatusMenu from "../components/Status/StatusMenu"
+import SortingMenu from "../components/SortingMenu/SortingMenu"
 import CategoryBanner from "../components/Category/CategoryBanner"
 import ProposalItem from "../components/Proposal/ProposalItem"
 import useSubscriptions from "../hooks/useSubscriptions"
@@ -45,6 +46,7 @@ export default function IndexPage() {
   const type = toProposalType(params.get('type')) ?? undefined
   const view = toProposalListView(params.get('view')) ?? undefined
   const status = view ? ProposalStatus.Enacted : toProposalStatus(params.get('status')) ?? undefined
+  const sort = toProposalSorting(params.get('sort')) ?? undefined
   const page = toProposalListPage(params.get('page')) ?? undefined
   const [ proposals, proposalsState ] = useProposals({ type, status, page, itemsPerPage: ITEMS_PER_PAGE })
   const [ subscriptions, subscriptionsState ] = useSubscriptions()
@@ -77,6 +79,9 @@ export default function IndexPage() {
   //   }
   // }
 
+  // console.log('params', params);
+  
+
   function handlePageFilter(page: number) {
     const newParams = new URLSearchParams(params)
     page !== 1 ? newParams.set('page', String(page)) : newParams.delete('page')
@@ -96,6 +101,15 @@ export default function IndexPage() {
     newParams.delete('page')
     return navigate(locations.proposals(newParams))
   }
+
+  function handleSortingFilter(sort: ProposalSorting | null) {
+    const newParams = new URLSearchParams(params)
+    sort ? newParams.set('sort', sort) : newParams.delete('sort')
+    newParams.delete('page')
+    return navigate(locations.proposals(newParams))
+  }
+  
+  
 
   // if (showOnboarding === Onboarding.Loading) {
   //   return <Container className="WelcomePage">
@@ -176,6 +190,7 @@ export default function IndexPage() {
               </Header>}
               rightAction={view !== ProposalListView.Enacted && <>
                 <StatusMenu style={{ marginRight: '1rem' }} value={status} onChange={(_, { value }) => handleStatusFilter(value)} />
+                <SortingMenu style={{ marginRight: '1rem' }} value={sort} onChange={(_, { value }) => handleSortingFilter(value)}  />
                 <Button primary size="small" as={Link} href={locations.submit()} onClick={prevent(() => navigate(locations.submit()))}>
                   {l(`page.proposal_list.new_proposal`)}
                 </Button>

--- a/src/pages/index.tsx
+++ b/src/pages/index.tsx
@@ -109,8 +109,6 @@ export default function IndexPage() {
     return navigate(locations.proposals(newParams))
   }
   
-  
-
   // if (showOnboarding === Onboarding.Loading) {
   //   return <Container className="WelcomePage">
   //     <div>
@@ -199,7 +197,12 @@ export default function IndexPage() {
               <Loader active={!proposals || proposalsState.loading} />
               {type && <CategoryBanner type={type} active />}
               {proposals && proposals.data.length === 0 && <Empty description={l(`page.proposal_list.no_proposals_yet`)} />}
-              {proposals && proposals.data.map(proposal => {
+              {proposals && proposals.data.sort((a, b) => {
+                if (sort) {
+                  return b.total_vp - a.total_vp
+                }
+                return b.created_at.getTime() - a.created_at.getTime()
+              }).map(proposal => {
                 return <ProposalItem
                   key={proposal.id}
                   proposal={proposal}

--- a/src/server.ts
+++ b/src/server.ts
@@ -16,11 +16,12 @@ import subscription from './entities/Subscription/routes'
 import committee from './entities/Committee/routes'
 import social from './entities/Social/routes'
 import sitemap from './entities/Sitemap/routes'
-import { activateProposals, finishProposal } from './entities/Proposal/jobs'
+import { activateProposals, finishProposal, updateTotalVpVotesProposals } from './entities/Proposal/jobs'
 
 const jobs = manager()
 jobs.cron('@eachMinute', activateProposals)
 jobs.cron('@eachMinute', finishProposal)
+jobs.cron('@eachMinute', updateTotalVpVotesProposals)
 
 const app = express()
 app.set('x-powered-by', false)


### PR DESCRIPTION
This PR implements:

- add total_vp field to the proposals table and migration.
- create a subscription method to update the total_vp of votes each minute.
- Create a SortingMenu component to filter in the front end to sort by latest (created_at) and participation (total_vp).

This PR resolves issue #116 