### PR TITLE
Transparency monthly total fix

### DIFF
--- a/README.md
+++ b/README.md
@@ -81,6 +81,12 @@ user your `user:pwd` for the connection string, it should look like this:
 postgres://usr:pwd@localhost:5432/snapshot
 ````
 
+If you installed postgres using brew, you might need to create a role for npm to run the migrations
+To do so, run this in psql 
+```sql
+CREATE USER postgres SUPERUSER;
+```
+
 once you have a `CONNECTION_STRING` you can setup you database tables using the following command
 
 ```bash

--- a/src/components/Section/DetailItem.css
+++ b/src/components/Section/DetailItem.css
@@ -2,7 +2,7 @@
   display: flex;
   margin-top: 0.25em;
   justify-content: space-between;
-  align-items: center;
+  align-items: baseline;
 }
 
 .DetailItem .DetailItem__Value {

--- a/src/components/Transparency/MonthlyTotal.css
+++ b/src/components/Transparency/MonthlyTotal.css
@@ -1,5 +1,10 @@
 .MonthlyTotal {
   width: 100%;
+  display: flex;
+}
+
+.content.MonthlyTotal_Headers {
+  flex-grow: 0 !important;
 }
 
 .ui.header.huge.MonthlyTotal__Header {
@@ -19,7 +24,7 @@
 }
 
 
-@media only screen and (min-width: 768px) {
+@media only screen and (min-width: 992px) {
   .MonthlyTotal:last-of-type {
     margin-left: 2em;
   }

--- a/src/components/Transparency/MonthlyTotal.tsx
+++ b/src/components/Transparency/MonthlyTotal.tsx
@@ -18,7 +18,7 @@ export default React.memo(function MonthlyTotal({title, monthlyTotal }: MonthlyT
 
   return <div className="MonthlyTotal">
     <Card>
-      <Card.Content>
+      <Card.Content className="MonthlyTotal_Headers">
         <div>
           <Header className="MonthlyTotal__Header">{title}</Header>
           <Header size="huge" className="MonthlyTotal__Header">

--- a/src/intl/en.json
+++ b/src/intl/en.json
@@ -390,7 +390,7 @@
     },
     "transparency": {
       "mission": {
-          "title": "Our Mission",
+          "title": "Transparency",
           "description": "To support and facilitate the continual growth of the Decentraland platform.",
           "join_discord_button": "Join our Discord",
           "docs_button": "Check our docs",

--- a/src/pages/transparency.css
+++ b/src/pages/transparency.css
@@ -47,6 +47,10 @@
 	margin-bottom: 8px;
 }
 
+.ui.stackable.grid.TransparencyGrid {
+	flex-grow: 1
+}
+
 @media only screen and (min-width: 992px) {
 	.ui.container.TransparencyContainer .ActionableLayout {
 		flex: 0 0 32%;
@@ -77,7 +81,6 @@
 .MonthlyTotals {
 	display: flex;
 	flex-direction: column;
-	align-items: flex-end;
 }
 
 .ui.card.TransparencyCard {

--- a/src/pages/transparency.tsx
+++ b/src/pages/transparency.tsx
@@ -58,7 +58,7 @@ export default function WrappingPage() {
       />
       <Navigation activeTab={NavigationTab.Transparency} />
       <Container className="TransparencyContainer">
-        <Grid stackable>
+        <Grid className="TransparencyGrid" stackable>
           <Grid.Row columns={2}>
             <Grid.Column tablet="4">
               <div>
@@ -102,8 +102,8 @@ export default function WrappingPage() {
         </Grid>
       </Container>
 
-      <Container>
-        <Grid stackable>
+      <Container className="TransparencyContainer">
+        <Grid className="TransparencyGrid" stackable>
           <Grid.Row columns={2}>
             <Grid.Column tablet="4">
               <div>
@@ -144,8 +144,8 @@ export default function WrappingPage() {
         </Grid>
       </Container>
 
-      <Container>
-        <Grid stackable>
+      <Container className="TransparencyContainer">
+        <Grid className="TransparencyGrid" stackable>
           <Grid.Row columns={2}>
             <Grid.Column tablet="4">
               <div>


### PR DESCRIPTION
### Monthly Total cards now grow to match bigger card

Card 2 bigger
![image](https://user-images.githubusercontent.com/2858950/153968569-8789bd0b-b8ac-4e31-ba90-873c8de4cb14.png)

Card 1 bigger
![image](https://user-images.githubusercontent.com/2858950/153970914-269f4516-d5d6-4931-bb1f-c50c3da6bc3c.png)

Mobile View
![image](https://user-images.githubusercontent.com/2858950/153970968-e7d164fb-8432-448d-9478-066af3e6ff5d.png)


### Fixed span and alignment for tablet. 
Previously:
![image](https://user-images.githubusercontent.com/2858950/153968752-f0514436-1194-4dd5-99a5-dfad887def2e.png)

Now:
![image](https://user-images.githubusercontent.com/2858950/153968864-3aecd6fa-5f9a-40df-811b-eedf700fed03.png)

Mobile view
![image](https://user-images.githubusercontent.com/2858950/153969626-1e226682-e587-4cf7-82c1-cf9c62677b02.png)

### Fixed detail items text vertical alignment
Previously:
![image](https://user-images.githubusercontent.com/2858950/153970382-e91b3103-88bd-45dc-b689-52f060d231a0.png)

Now:
![image](https://user-images.githubusercontent.com/2858950/153970696-5f1449f9-1b14-474a-bc39-4eb57f305e05.png)

Tablet
![image](https://user-images.githubusercontent.com/2858950/153970445-fbef083e-5a15-47a1-9dba-1d43a5f25be9.png)

Mobile view with long texts
![image](https://user-images.githubusercontent.com/2858950/153970634-a3eb7860-3a7d-4e27-9e63-692683b06fe7.png)

