### PR TITLE
Remove addresses from transparency page

### DIFF
--- a/src/api/DclData.ts
+++ b/src/api/DclData.ts
@@ -13,7 +13,7 @@ export type MonthlyTotal = {
 }
 
 export type Member = {
-  address: string,
+  avatar: string,
   name: string
 }
 

--- a/src/components/Transparency/MemberCard.css
+++ b/src/components/Transparency/MemberCard.css
@@ -17,11 +17,6 @@
   }
 }
 
-.MemberCard .MemberCard_header {
-  display: flex;
-  align-items: baseline;
-}
-
 .MemberCard .MemberCard_description {
   display: flex;
   flex-direction: column;

--- a/src/components/Transparency/MemberCard.tsx
+++ b/src/components/Transparency/MemberCard.tsx
@@ -1,25 +1,21 @@
 import React from 'react'
-import { Header } from 'decentraland-ui/dist/components/Header/Header'
 import Avatar from 'decentraland-gatsby/dist/components/User/Avatar'
-import { Address } from 'decentraland-ui/dist/components/Address/Address'
 
 import './MemberCard.css'
 
 export type MemberCardProps = React.HTMLAttributes<HTMLDivElement> & {
   member: {
-    address: string,
+    avatar: string,
     name: string
   }
 }
 
 export default function MemberCard({ member }: MemberCardProps) {
+  let color = (member.name.split('').reduce((a, b) => a + b.charCodeAt(0), 0) % 16).toString(16);
   return (
     <div className="MemberCard">
-      <Avatar address={member.address} size="medium" />
+      <Avatar src={member.avatar} size="medium" address={'0x' + color}/>
       <div className="MemberCard_description">
-        <div className="MemberCard_header">
-          <Header sub><Address value={member.address}/></Header>
-        </div>
         <span>{member.name}</span>
       </div>
     </div>

--- a/src/components/Transparency/MembersSection.tsx
+++ b/src/components/Transparency/MembersSection.tsx
@@ -39,7 +39,7 @@ export default function MembersSection({ title, description, members }: MembersS
           members.map((member, index) => {
             return <MemberCard
               key={[title.trim(), member.name.trim(), index].join('::')}
-              member={{ address: member.address, name: member.name }}
+              member={{ avatar: member.avatar, name: member.name }}
             />
           })
         }


### PR DESCRIPTION
* Remove addresses from the members list.
* Render the avatar using the URL directly.

Looks like this:

<img width="696" alt="Screen Shot 2022-02-17 at 16 08 12" src="https://user-images.githubusercontent.com/279449/154553040-17a1b0c8-1637-4e3f-98f6-5c20584cdf8f.png">

