### PR TITLE
Indexing fix in the submit POI page

### DIFF
--- a/src/entities/Sitemap/routes.ts
+++ b/src/entities/Sitemap/routes.ts
@@ -48,7 +48,8 @@ export async function getStaticSitemap() {
     `<url><loc>${governanceUrl(`/submit/ban-name/`)}</loc></url>`,
     `<url><loc>${governanceUrl(`/submit/catalyst/`)}</loc></url>`,
     `<url><loc>${governanceUrl(`/submit/grant/`)}</loc></url>`,
-    `<url><loc>${governanceUrl(`/submit/poi/`)}</loc></url>`,
+    `<url><loc>${governanceUrl(`/submit/poi/?request=add_poi`)}</loc></url>`,
+    `<url><loc>${governanceUrl(`/submit/poi/?request=remove_poi`)}</loc></url>`,
     `<url><loc>${governanceUrl(`/submit/poll/`)}</loc></url>`,
     '</urlset>',
   ].join('')


### PR DESCRIPTION
This PR addresses #195 

The URL `governance.decentraland.org/submit/poi/` in `governance.decentraland.org/sitemap.static.xml` is replaced by the URLs: 

- `governance.decentraland.org/submit/poi/?request=add_poi`
- `governance.decentraland.org/submit/poi/?request=remove_poi`