### PR TITLE
199 - Add button to show all comments on proposal

### DIFF
--- a/src/components/Proposal/ProposalComments.css
+++ b/src/components/Proposal/ProposalComments.css
@@ -35,3 +35,12 @@
   border: 1px solid rgba(115,110,125,.32);
   width: 100%;
 }
+
+@media only screen and (max-width: 425px) {
+  .ProposalComments .ui.button {
+    font-size: 14px;
+  }
+  .ProposalComments .ui.header {
+    font-size: 17px;
+  }
+}

--- a/src/components/Proposal/ProposalComments.tsx
+++ b/src/components/Proposal/ProposalComments.tsx
@@ -117,7 +117,7 @@ export default React.memo(function ProposalComments({ proposal, loading, ...prop
                 rel="noopener noreferrer"
                 href={(proposal && forumUrl(proposal)) || ''}
               >
-                {t('page.proposal_comments.join_discussion_label')}
+                {t('page.proposal_comments.comment_on_this_proposal_label')}
               </Button>
             )}
           </div>

--- a/src/components/Proposal/ProposalComments.tsx
+++ b/src/components/Proposal/ProposalComments.tsx
@@ -1,4 +1,4 @@
-import React, { useMemo } from 'react'
+import React, { useMemo, useState, useEffect } from 'react'
 import { Header } from 'decentraland-ui/dist/components/Header/Header'
 import TokenList from 'decentraland-gatsby/dist/utils/dom/TokenList'
 import { ProposalAttributes } from '../../entities/Proposal/types'
@@ -12,6 +12,8 @@ import useAsyncMemo from 'decentraland-gatsby/dist/hooks/useAsyncMemo'
 import { Governance } from '../../api/Governance'
 import { forumUrl } from '../../entities/Proposal/utils'
 
+const DEFAULT_SHOWN_COMMENTS = 5
+
 export type ProposalResultSectionProps = Omit<React.HTMLAttributes<HTMLDivElement>, 'children'> & {
   proposal?: ProposalAttributes | null
   loading?: boolean
@@ -19,12 +21,26 @@ export type ProposalResultSectionProps = Omit<React.HTMLAttributes<HTMLDivElemen
 
 export default React.memo(function ProposalComments({ proposal, loading, ...props }: ProposalResultSectionProps) {
   const t = useFormatMessage()
-  const [comments] = useAsyncMemo(
-    async () => (proposal ? Governance.get().getProposalComments(proposal!.id) : null),
-    [proposal]
-  )
-  let renderComments = useMemo(() => comments && comments.totalComments > 0, [comments])
+  const [comments] = useAsyncMemo(async () => (proposal ? Governance.get().getProposalComments(proposal!.id) : null), [
+    proposal,
+  ])
+  const renderComments = useMemo(() => comments && comments.totalComments > 0, [comments])
   const commentsCount = useMemo(() => (renderComments ? comments!.totalComments : ''), [renderComments])
+  const [showAllComments, setShowAllComments] = useState(true)
+
+  useEffect(() => {
+    if (comments && comments.totalComments > DEFAULT_SHOWN_COMMENTS) {
+      setShowAllComments(false)
+    }
+  }, [comments])
+
+  const renderedComments = useMemo(() => {
+    if (comments && comments.totalComments > 0) {
+      return showAllComments ? comments!.comments : comments!.comments.slice(0, DEFAULT_SHOWN_COMMENTS)
+    } else {
+      return null
+    }
+  }, [comments, showAllComments])
 
   return (
     <div>
@@ -67,8 +83,8 @@ export default React.memo(function ProposalComments({ proposal, loading, ...prop
                   </Button>
                 </div>
               )}
-              {renderComments &&
-                comments!.firstComments.map((comment, index) => (
+              {renderedComments &&
+                renderedComments.map((comment, index) => (
                   <ProposalComment
                     key={'comment_' + index}
                     avatar_url={comment.avatar_url}
@@ -78,7 +94,21 @@ export default React.memo(function ProposalComments({ proposal, loading, ...prop
                   />
                 ))}
             </div>
-            {renderComments && (
+            {renderComments && !showAllComments && (
+              <Button
+                basic
+                className="ProposalComments__ReadMore"
+                disabled={!proposal}
+                target="_blank"
+                rel="noopener noreferrer"
+                onClick={() => {
+                  setShowAllComments(true)
+                }}
+              >
+                {t('page.proposal_comments.read_more_label')}
+              </Button>
+            )}
+            {renderComments && showAllComments && (
               <Button
                 basic
                 className="ProposalComments__ReadMore"
@@ -87,7 +117,7 @@ export default React.memo(function ProposalComments({ proposal, loading, ...prop
                 rel="noopener noreferrer"
                 href={(proposal && forumUrl(proposal)) || ''}
               >
-                {t('page.proposal_comments.read_more_label')}
+                {t('page.proposal_comments.join_discussion_label')}
               </Button>
             )}
           </div>

--- a/src/entities/Discourse/utils.test.ts
+++ b/src/entities/Discourse/utils.test.ts
@@ -25,22 +25,22 @@ describeIf(DISCOURSE_API_KEY !== 'DISCOURSE_API_KEY')('filterUserComments', () =
     });
 
     it('should contain the base discourse avatar url in the user avatar url', () => {
-      expect(filteredComments.firstComments[0].avatar_url).toContain(BASE_AVATAR_URL)
+      expect(filteredComments.comments[0].avatar_url).toContain(BASE_AVATAR_URL)
     });
 
     it('should return a parsed list of the user comments with avatar, username, user comment, and comment date', () => {
-      expect(filteredComments.firstComments[0].username).toBe('yemel')
-      expect(filteredComments.firstComments[0].avatar_url).toBe('https://sea1.discourse-cdn.com/standard10/user_avatar/forum.decentraland.vote/yemel/45/1_2.png')
-      expect(filteredComments.firstComments[0].created_at).toBe('2021-11-19T21:36:13.181Z')
-      expect(filteredComments.firstComments[0].cooked).toBe('<p>I am commenting as Yemel</p>')
+      expect(filteredComments.comments[0].username).toBe('yemel')
+      expect(filteredComments.comments[0].avatar_url).toBe('https://sea1.discourse-cdn.com/standard10/user_avatar/forum.decentraland.vote/yemel/45/1_2.png')
+      expect(filteredComments.comments[0].created_at).toBe('2021-11-19T21:36:13.181Z')
+      expect(filteredComments.comments[0].cooked).toBe('<p>I am commenting as Yemel</p>')
     });
 
     it('should only retrieve the user comment ', () => {
-      filteredComments.firstComments.map(comment => expect(comment.username).not.toEqual(DISCOURSE_USER))
+      filteredComments.comments.map(comment => expect(comment.username).not.toEqual(DISCOURSE_USER))
     });
   });
 
-  describe('when there are more than three user comments on a discourse topic', () => {
+  describe('when there are several user comments on a discourse topic', () => {
     beforeAll(() => {
       posts = SEVERAL_USERS_POST
     })
@@ -49,14 +49,14 @@ describeIf(DISCOURSE_API_KEY !== 'DISCOURSE_API_KEY')('filterUserComments', () =
       expect(filteredComments.totalComments).toBe(4)
     });
 
-    it('should only retrieve the first three comments ', () => {
-      expect(filteredComments.firstComments.length).toBe(3)
-      expect(filteredComments.firstComments[0].created_at).toEqual('2021-11-19T21:36:13.181Z')
+    it('should retrieve all user comments ', () => {
+      expect(filteredComments.comments.length).toBe(4)
+      expect(filteredComments.comments[0].created_at).toEqual('2021-11-19T21:36:13.181Z')
     });
 
     describe('when there is a user without an avatar defined in the forum', () => {
       it('should use the forum generic letter avatar in size 45', () => {
-        expect(filteredComments.firstComments[2].avatar_url).toBe("https://avatars.discourse-cdn.com/v4/letter/n/b782af/45.png")
+        expect(filteredComments.comments[2].avatar_url).toBe("https://avatars.discourse-cdn.com/v4/letter/n/b782af/45.png")
       });
     });
   })
@@ -69,7 +69,7 @@ describeIf(DISCOURSE_API_KEY !== 'DISCOURSE_API_KEY')('filterUserComments', () =
       expect(filteredComments.totalComments).toBe(0)
     });
     it('returns an empty list', () => {
-      expect(filteredComments.firstComments).toHaveLength(0)
+      expect(filteredComments.comments).toHaveLength(0)
     });
   });
 })

--- a/src/entities/Discourse/utils.ts
+++ b/src/entities/Discourse/utils.ts
@@ -25,10 +25,9 @@ function setAvatarUrl(post: DiscoursePostInTopic) {
 
 export function filterComments(comments: DiscourseTopic):ProposalCommentsInDiscourse {
   const posts = comments.post_stream.posts
-  let filteredComments = posts.filter((post) =>
+  const userPosts = posts.filter((post) =>
     ![DISCOURSE_USER.toLowerCase(), 'system'].includes(post.username.toLowerCase()))
 
-  const userPosts: DiscoursePostInTopic[] = filteredComments.slice(0, 3)
 
   const proposalComments: ProposalComment[] = userPosts.map(post => {
     return {
@@ -40,7 +39,7 @@ export function filterComments(comments: DiscourseTopic):ProposalCommentsInDisco
   })
 
   return {
-    totalComments: filteredComments.length,
-    firstComments: proposalComments
+    totalComments: userPosts.length,
+    comments: proposalComments
   }
 }

--- a/src/entities/Proposal/types.ts
+++ b/src/entities/Proposal/types.ts
@@ -701,5 +701,5 @@ export type ProposalComment = {
 
 export type ProposalCommentsInDiscourse = {
   totalComments: number,
-  firstComments: ProposalComment[]
+  comments: ProposalComment[]
 }

--- a/src/intl/en.json
+++ b/src/intl/en.json
@@ -406,6 +406,7 @@
     "proposal_comments": {
       "title": "{count} {count, plural, one {Comment} other {Comments}}",
       "join_discussion_label": "Join the discussion",
+      "comment_on_this_proposal_label": "Comment on this Proposal",
       "read_more_label": "Read More",
       "no_comments_text": "No comments yet, you have the chance to be the first one!"
     },


### PR DESCRIPTION
This PR closes [this issue](https://github.com/decentraland/governance/issues/199)
Ready to be tested at: http://pr199.test.decentraland.vote/

When comments are equal or less than 3, it reads "Join the discussion"
<img width="979" alt="image" src="https://user-images.githubusercontent.com/2858950/160199048-2fd55cdc-425f-4752-8ac9-9511059898b3.png">

When there are more than 3 comments available for display, it changes to "Read More"
<img width="963" alt="image" src="https://user-images.githubusercontent.com/2858950/160199185-f32dda3d-c477-4402-a5d7-c89bdb9b8a92.png">

With several comments
<img width="814" alt="image" src="https://user-images.githubusercontent.com/2858950/160183726-2f249dcd-0ecf-463f-8040-673c95489d3e.png">

when opened:
<img width="641" alt="image" src="https://user-images.githubusercontent.com/2858950/160183778-71b7c584-25b3-430c-bdc5-73ca0bf14c0b.png">

Made some tweaks to mobile font sizes:
<img width="559" alt="image" src="https://user-images.githubusercontent.com/2858950/160183837-5d555682-0833-4a24-85f9-8541221a0160.png">

when opened:
<img width="357" alt="image" src="https://user-images.githubusercontent.com/2858950/160183884-c2431ee9-e114-48b2-9447-c65fcedc380e.png">
