### PR TITLE
Grant size validation on the fly

### DIFF
--- a/src/pages/submit/grant.tsx
+++ b/src/pages/submit/grant.tsx
@@ -85,7 +85,10 @@ const validate = createValidator<GrantState>({
     undefined
   }),
   size: (state) => ({
-    size: assert(!state.size || Number.isFinite(asNumber(state.size)), 'error.grant.size_invalid')
+    size: assert(!state.size || Number.isFinite(asNumber(state.size)), 'error.grant.size_invalid') ||
+    assert(!state.size || asNumber(state.size) > schema.size.min, 'error.grant.size_too_low') ||
+    assert(!state.size || (!!state.tier && isGrantSizeValid(state.tier, state.size)), 'error.grant.size_tier_invalid') ||
+    undefined
   }),
   title: (state) => ({
     title: assert(state.title.length <= schema.title.maxLength, 'error.grant.title_too_large') ||
@@ -244,6 +247,7 @@ export default function SubmitBanName() {
         value={state.value.tier || undefined}
         placeholder={l('page.submit_grant.tier_placeholder') || undefined}
         onChange={(_, { value }) => editor.set({ tier: String(value)})}
+        onBlur={() => editor.set({ size: state.value.size })}
         options={tiers}
         error={!!state.error.tier}
         message={l.optional(state.error.tier)}
@@ -298,6 +302,7 @@ export default function SubmitBanName() {
         type="number"
         value={state.value.size}
         onChange={(_, { value }) => editor.set({ size: value })}
+        onBlur={() => editor.set({ size: state.value.size })}
         error={!!state.error.size}
         action={<Paragraph tiny secondary>USD</Paragraph>}
         onAction={() => null}


### PR DESCRIPTION
In the `Request a grant` form, the behavior of the `Grant Size` field is now similar to that of the `Beneficiary address` field. As soon as you start typing, it validates the constrains and displays feedback to the user without the user having to press the Submit proposal button.