### PR TITLE
Fix: Underscore removed on category labels

### DIFF
--- a/src/components/Category/CategoryLabel.tsx
+++ b/src/components/Category/CategoryLabel.tsx
@@ -9,6 +9,9 @@ export type CategoryLabelProps = Omit<React.HTMLAttributes<HTMLDivElement>, 'chi
 }
 
 export default React.memo(function CategoryLabel({ type, ...props }: CategoryLabelProps) {
+
+  const label = type.replaceAll('_', ' ')
+
   return <div
     {...props}
     className={TokenList.join([
@@ -16,6 +19,6 @@ export default React.memo(function CategoryLabel({ type, ...props }: CategoryLab
       `CategoryLabel--${type}`
     ])}
   >
-    <span>{type}</span>
+    <span>{label}</span>
   </div>
 })


### PR DESCRIPTION
![image](https://user-images.githubusercontent.com/45410089/161982036-470ca63a-b966-43da-8dfe-4bc0049aad0a.png)
![image](https://user-images.githubusercontent.com/45410089/161982068-06bc6349-5b6c-40e7-92a3-0baabe328750.png)
