### PR TITLE
Make number colors configurable for MonthlyTotal

### DIFF
--- a/src/components/Transparency/MonthlyTotal.tsx
+++ b/src/components/Transparency/MonthlyTotal.tsx
@@ -11,10 +11,15 @@ import { formatBalance } from '../../entities/Proposal/utils'
 export type MonthlyTotalProps = React.HTMLAttributes<HTMLDivElement> & {
   title: string
   monthlyTotal: MonthlyTotal
+  invertDiffColors?: boolean
 }
 
-export default React.memo(function MonthlyTotal({ title, monthlyTotal }: MonthlyTotalProps) {
+const RED = `Number--Red`
+const GREEN = `Number--Green`
+
+export default React.memo(function MonthlyTotal({ title, monthlyTotal, invertDiffColors = false }: MonthlyTotalProps) {
   const t = useFormatMessage()
+  const [belowZeroColor, zeroOrOverColor] = invertDiffColors ? [GREEN, RED] : [RED, GREEN]
 
   return (
     <div className="MonthlyTotal">
@@ -30,8 +35,8 @@ export default React.memo(function MonthlyTotal({ title, monthlyTotal }: Monthly
               <strong
                 className={TokenList.join([
                   'Number',
-                  monthlyTotal.previous < 0 && `Number--Red`,
-                  monthlyTotal.previous >= 0 && `Number--Green`,
+                  monthlyTotal.previous < 0 && belowZeroColor,
+                  monthlyTotal.previous >= 0 && zeroOrOverColor,
                 ])}
               >
                 {formatBalance(monthlyTotal.previous) + '% '}

--- a/src/pages/transparency.tsx
+++ b/src/pages/transparency.tsx
@@ -1,4 +1,4 @@
-import React, { useMemo, useContext, useEffect } from 'react'
+import React, { useMemo } from 'react'
 import { Header } from 'decentraland-ui/dist/components/Header/Header'
 import { Loader } from 'decentraland-ui/dist/components/Loader/Loader'
 import { Card } from 'decentraland-ui/dist/components/Card/Card'
@@ -143,6 +143,7 @@ export default function WrappingPage() {
                         <MonthlyTotal
                           title={t('page.transparency.mission.monthly_expenses') || ''}
                           monthlyTotal={data.expenses}
+                          invertDiffColors={true}
                         />
                       </Grid.Row>
                     </Grid.Column>


### PR DESCRIPTION
This PR closes [this issue](https://github.com/decentraland/governance/issues/268)

It can be [tested here](http://pr269.test.decentraland.vote/transparency/)

- Positive income difference shows green, positive expenses difference shows red

<img width="713" alt="image" src="https://user-images.githubusercontent.com/2858950/164475042-63c35a27-3b21-4837-ad96-1f31d8e01471.png">

- Negative income difference shows red, negative expenses difference shows green

<img width="716" alt="image" src="https://user-images.githubusercontent.com/2858950/164475301-8c02c9ce-f1ca-447d-82ef-cbfd715b86aa.png">
