### PR TITLE
fix: re-render in draft promotion forms

### DIFF
--- a/src/pages/submit/draft.tsx
+++ b/src/pages/submit/draft.tsx
@@ -143,7 +143,8 @@ export default function SubmitDraftProposal() {
     if (preselectedLinkedProposalId) {
       editor.set({ linked_proposal_id: preselectedLinkedProposalId })
     }
-  }, [editor, preselectedLinkedProposalId])
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [preselectedLinkedProposalId])
 
   useEffect(() => {
     if (state.validated) {
@@ -165,7 +166,8 @@ export default function SubmitDraftProposal() {
           setFormDisabled(false)
         })
     }
-  }, [editor, state.validated, state.value])
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [state.validated])
 
   if (accountState.loading) {
     return (

--- a/src/pages/submit/governance.tsx
+++ b/src/pages/submit/governance.tsx
@@ -203,7 +203,8 @@ export default function SubmitGovernanceProposal() {
           editor.error({ '*': err.body?.error || err.message })
         })
     }
-  }, [editor, preselectedLinkedProposalId])
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [preselectedLinkedProposalId])
 
   useEffect(() => {
     if (state.validated) {
@@ -225,7 +226,8 @@ export default function SubmitGovernanceProposal() {
           setFormDisabled(false)
         })
     }
-  }, [editor, state.validated, state.value])
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [state.validated])
 
   if (accountState.loading) {
     return (


### PR DESCRIPTION
Quick fix. We should check later why adding those variables as dependencies are causing re-renders.