### PR TITLE
Proposal status update date fix

### DIFF
--- a/src/entities/Proposal/routes.ts
+++ b/src/entities/Proposal/routes.ts
@@ -581,7 +581,7 @@ export function commentProposalUpdateInDiscourse(id: string) {
     const discourseComment: DiscourseComment = {
       topic_id: updatedProposal.discourse_topic_id,
       raw: updateMessage,
-      created_at: updatedProposal.created_at.toJSON(),
+      created_at: new Date().toJSON(),
     }
     await Discourse.get().commentOnPost(discourseComment, DISCOURSE_AUTH)
   })


### PR DESCRIPTION
Closes [issue](https://github.com/decentraland/governance/issues/337)

Fix: use update message creation date instead of proposal creation date

![image](https://user-images.githubusercontent.com/2858950/172675748-844c7e0f-b8ed-4b37-af41-e86b3bb28cb7.png)
