### PR TITLE
fix: max image size in proposals

### DIFF
--- a/src/pages/proposal.css
+++ b/src/pages/proposal.css
@@ -37,6 +37,10 @@
   font-size: 15px;
 }
 
+.ProposalDetailPage .ProposalDetailDescription .dg.Paragraph img {
+  max-width: 100%;
+}
+
 @media only screen and (min-width: 320px) and (max-width: 767px) {
   .ProposalDetailPage .ui.grid > .row > .column.ProposalDetailDescription {
     width: 100% !important;


### PR DESCRIPTION
Before:
<img width="1175" alt="image" src="https://user-images.githubusercontent.com/8242162/173667610-e736aa95-49b7-4686-88a2-1b3623081987.png">

After:
<img width="913" alt="image" src="https://user-images.githubusercontent.com/8242162/173667505-37e3cbc7-2a39-49f2-b460-fd8b28d69980.png">
