### PR TITLE
fix: show updates on enacted grants and use last 7 chars of snapshot id on discourse title

### DIFF
--- a/src/entities/Proposal/templates/index.ts
+++ b/src/entities/Proposal/templates/index.ts
@@ -115,7 +115,7 @@ export type ForumTemplateProps = {
 }
 
 export const forumTitle = ({ type, configuration, snapshot_id }: ForumTemplateProps) =>
-  `[DAO: ${snapshot_id.slice(snapshot_id.length - 7, snapshot_id.length)}] ` + title({ type, configuration })
+  `[DAO] ` + title({ type, configuration }) + ` (${snapshot_id.slice(snapshot_id.length - 7, snapshot_id.length)})`
 
 export const forumDescription = async ({
   type,

--- a/src/entities/Proposal/templates/index.ts
+++ b/src/entities/Proposal/templates/index.ts
@@ -115,7 +115,7 @@ export type ForumTemplateProps = {
 }
 
 export const forumTitle = ({ type, configuration, snapshot_id }: ForumTemplateProps) =>
-  `[DAO: ${snapshot_id.slice(0, 7)}] ` + title({ type, configuration })
+  `[DAO: ${snapshot_id.slice(snapshot_id.length - 7, snapshot_id.length)}] ` + title({ type, configuration })
 
 export const forumDescription = async ({
   type,

--- a/src/pages/proposal.tsx
+++ b/src/pages/proposal.tsx
@@ -54,6 +54,8 @@ import { isUnderMaintenance } from '../modules/maintenance'
 import './index.css'
 import './proposal.css'
 
+const PROPOSAL_STATUS_WITH_UPDATES = new Set([ProposalStatus.Passed, ProposalStatus.Enacted])
+
 type ProposalPageOptions = {
   changing: boolean
   confirmSubscription: boolean
@@ -215,10 +217,9 @@ export default function ProposalPage() {
     )
   }
 
-  const showProposalUpdatesActions =
-    proposal?.status === ProposalStatus.Passed && proposal?.type === ProposalType.Grant && isOwner
-  const showProposalUpdates =
-    publicUpdates && proposal?.status === ProposalStatus.Passed && proposal?.type === ProposalType.Grant
+  const isProposalStatusWithUpdates = PROPOSAL_STATUS_WITH_UPDATES.has(proposal?.status as ProposalStatus)
+  const showProposalUpdatesActions = isProposalStatusWithUpdates && proposal?.type === ProposalType.Grant && isOwner
+  const showProposalUpdates = publicUpdates && isProposalStatusWithUpdates && proposal?.type === ProposalType.Grant
   const showImagesPreview =
     !proposalState.loading && proposal?.type === ProposalType.LinkedWearables && !!proposal.configuration.image_previews
 


### PR DESCRIPTION
<img width="599" alt="image" src="https://user-images.githubusercontent.com/8242162/181356833-f0ef63b6-1f03-4548-a909-d6e025a2dcd7.png">
