### PR TITLE
fix: line charts date display bug in firefox

### DIFF
--- a/src/components/Charts/LineChart.tsx
+++ b/src/components/Charts/LineChart.tsx
@@ -44,7 +44,11 @@ function LineChart({ label, data, unit, colors }: Props) {
 
   const configuration = useMemo(
     () => ({
-      labels: Object.keys(data).map((label) => intl.formatDate(new Date(label), { year: 'numeric', month: 'short' })),
+      labels: Object.keys(data).map((label) => {
+        const formattedLabel = label.concat('/01')
+        const date = new Date(formattedLabel)
+        return intl.formatDate(date, { year: 'numeric', month: 'short' })
+      }),
       datasets: [
         {
           label,

--- a/src/components/Home/Charts.css
+++ b/src/components/Home/Charts.css
@@ -38,6 +38,12 @@
   padding: 12px;
 }
 
+@media (max-width: 425px) {
+  .ui.card.HomeCharts > .dcl.tabs {
+    padding: 0 0;
+  }
+}
+
 @media screen and (min-width: 768px) {
   .ui.card.HomeCharts > .dcl.tabs .tabs-left {
     display: unset;

--- a/src/components/Home/Charts.tsx
+++ b/src/components/Home/Charts.tsx
@@ -22,8 +22,8 @@ const end = new Date(now.getFullYear(), now.getMonth(), 1)
 
 function Charts() {
   const [selectedTab, setSelectedTab] = useState(ChartType.ParticipatingVP)
-  const { participatingVP } = useParticipatingVP(start, end)
-  const { votesPerProposal } = useVotesPerProposal(start, end)
+  const { participatingVP, isLoadingParticipatingVP } = useParticipatingVP(start, end)
+  const { votesPerProposal, isLoadingVotesPerProposal } = useVotesPerProposal(start, end)
   const t = useFormatMessage()
 
   return (
@@ -49,7 +49,7 @@ function Charts() {
           </Header>
         </Tabs.Right>
       </Tabs>
-      {selectedTab === ChartType.ParticipatingVP && (
+      {selectedTab === ChartType.ParticipatingVP && !isLoadingParticipatingVP && (
         <LineChart
           label={t('page.home.community_engagement.participating_vp')}
           data={participatingVP}
@@ -57,7 +57,7 @@ function Charts() {
           colors={['#FF2D55', '#C640CD']}
         />
       )}
-      {selectedTab === ChartType.VotesPerProposal && (
+      {selectedTab === ChartType.VotesPerProposal && !isLoadingVotesPerProposal && (
         <LineChart
           label={t('page.home.community_engagement.votes_per_proposal_title')}
           data={votesPerProposal}

--- a/src/entities/Snapshot/utils.ts
+++ b/src/entities/Snapshot/utils.ts
@@ -60,6 +60,12 @@ export function median(array: number[]) {
   return (array[half - 1] + array[half]) / 2.0
 }
 
+function parseYearMonth(proposalDate: Date) {
+  const month = ('0' + (proposalDate.getMonth() + 1)).slice(-2)
+  const year = proposalDate.getFullYear()
+  return `${year}/${month}`
+}
+
 export function groupProposalsByMonth(proposals: Partial<SnapshotProposal>[], field: keyof SnapshotProposal) {
   const ERROR_KEY = 'groupProposalsByMonth'
   const data: Record<string, number[]> = {}
@@ -67,9 +73,7 @@ export function groupProposalsByMonth(proposals: Partial<SnapshotProposal>[], fi
   for (const proposal of proposals) {
     if (proposal.created) {
       const proposalDate = new Date(proposal.created * 1000)
-      const month = proposalDate.getMonth()
-      const year = proposalDate.getFullYear()
-      const key = `${year}/${month + 1}`
+      const key = parseYearMonth(proposalDate)
       const value = proposal[field]
       if (typeof value === 'number') {
         data[key] = [...(data[key] || []), value]


### PR DESCRIPTION
Firefox is not supporting date parsing without the day

![image](https://user-images.githubusercontent.com/2858950/184410714-f12920ab-c618-45dd-8150-2771d6be75e8.png)

![image](https://user-images.githubusercontent.com/2858950/184411555-147bebac-829b-4de3-8ca0-13fa37011d2f.png)

![image](https://user-images.githubusercontent.com/2858950/184411594-2fbd8a16-81d5-4438-8045-ec23b701f045.png)
