### PR TITLE
feat: chevron right circle outline svg

### DIFF
--- a/src/components/Delegation/DelegatorCardProfile.tsx
+++ b/src/components/Delegation/DelegatorCardProfile.tsx
@@ -2,9 +2,9 @@ import React from 'react'
 
 import Link from 'decentraland-gatsby/dist/components/Text/Link'
 import useFormatMessage, { useIntl } from 'decentraland-gatsby/dist/hooks/useFormatMessage'
-import { Back } from 'decentraland-ui/dist/components/Back/Back'
 
 import locations from '../../modules/locations'
+import ChevronRightCircleOutline from '../Icon/ChevronRightCircleOutline'
 import Username from '../User/Username'
 
 import './DelegatorCardProfile.css'
@@ -31,7 +31,7 @@ function DelegatorCardProfile({ address, vp }: Props) {
           </span>
         </div>
       </div>
-      <Back />
+      <ChevronRightCircleOutline />
     </Link>
   )
 }

--- a/src/components/Grants/GrantBeneficiaryItem.tsx
+++ b/src/components/Grants/GrantBeneficiaryItem.tsx
@@ -3,7 +3,6 @@ import React from 'react'
 import Markdown from 'decentraland-gatsby/dist/components/Text/Markdown'
 import useFormatMessage, { useIntl } from 'decentraland-gatsby/dist/hooks/useFormatMessage'
 import { Link } from 'decentraland-gatsby/dist/plugins/intl'
-import { Back } from 'decentraland-ui/dist/components/Back/Back'
 import { Mobile, NotMobile } from 'decentraland-ui/dist/components/Media/Media'
 
 import { TransparencyGrantsTiers } from '../../clients/DclData'
@@ -11,6 +10,7 @@ import { GrantAttributes } from '../../entities/Proposal/types'
 import { isProposalInCliffPeriod } from '../../entities/Proposal/utils'
 import locations from '../../modules/locations'
 import { abbreviateTimeDifference, formatDate } from '../../modules/time'
+import ChevronRightCircleOutline from '../Icon/ChevronRightCircleOutline'
 import Username from '../User/Username'
 
 import CliffProgress from './GrantCard/CliffProgress'
@@ -66,7 +66,7 @@ function GrantBeneficiaryItem({ grant }: Props) {
               </div>
             </ProgressBarTooltip>
           </div>
-          <Back />
+          <ChevronRightCircleOutline />
         </div>
       </NotMobile>
       <Mobile>
@@ -86,7 +86,7 @@ function GrantBeneficiaryItem({ grant }: Props) {
               </span>
             </span>
           </div>
-          <Back />
+          <ChevronRightCircleOutline />
         </div>
       </Mobile>
     </Link>

--- a/src/components/Icon/ChevronRightCircleOutline.css
+++ b/src/components/Icon/ChevronRightCircleOutline.css
@@ -1,0 +1,20 @@
+.ChevronRightCircleOutline__FixedSize {
+  min-width: 32px;
+  max-width: 32px;
+}
+
+g.ChevronRightCircleOutline__Circle {
+  opacity: 0.25;
+}
+
+g.ChevronRightCircleOutline__Circle:hover {
+  opacity: 0.5;
+}
+
+.svg-fill-white {
+  fill: var(--white-900);
+}
+
+.svg-stroke-black {
+  stroke: var(--black-800);
+}

--- a/src/components/Icon/ChevronRightCircleOutline.tsx
+++ b/src/components/Icon/ChevronRightCircleOutline.tsx
@@ -1,0 +1,47 @@
+import React from 'react'
+
+import TokenList from 'decentraland-gatsby/dist/utils/dom/TokenList'
+
+import './ChevronRightCircleOutline.css'
+
+interface Props {
+  resizable?: boolean
+}
+
+function ChevronRightCircleOutline({ resizable }: Props) {
+  return (
+    <svg
+      xmlns="http://www.w3.org/2000/svg"
+      x="0"
+      y="0"
+      width="32"
+      height="32"
+      viewBox="0 0 100 100"
+      preserveAspectRatio="xMidYMid meet"
+      className={TokenList.join([!resizable && 'ChevronRightCircleOutline__FixedSize'])}
+    >
+      <clipPath id="clip-path-202210-0615-2828-02987f6e-2a6a-4a00-87b8-69dcd369a988">
+        <circle cx="50" cy="50" r="50" stroke="#FFFFFF" className="svg-fill-white"></circle>
+      </clipPath>
+      <g
+        clipPath="url(#clip-path-202210-0615-2828-02987f6e-2a6a-4a00-87b8-69dcd369a988)"
+        transform="translate(0.00, 0.00) scale(1.00, 1.00)"
+        className="ChevronRightCircleOutline__Circle"
+      >
+        <circle stroke="#16141a" strokeWidth="8" className="svg-fill-white" cx="50" cy="50" r="50"></circle>
+      </g>
+      <g transform="translate(30.00, 22.50) scale(0.55, 0.55)">
+        <path
+          d="M27.7,13.4,64.3,50,27.7,86.6"
+          fill="none"
+          className="svg-stroke-black"
+          strokeLinecap="round"
+          strokeLinejoin="round"
+          strokeWidth="8"
+        />
+      </g>
+    </svg>
+  )
+}
+
+export default ChevronRightCircleOutline


### PR DESCRIPTION
It can be set to a fixed size, or it can resize preserving proportions.
<img width="1164" alt="image" src="https://user-images.githubusercontent.com/2858950/194370759-0701c664-73fb-42dc-adf4-960b81bedb5f.png">

It changes opacity on hover
<img width="136" alt="image" src="https://user-images.githubusercontent.com/2858950/194370798-9204559e-3038-4c5b-80cd-14288e9c8d7f.png">

And it's family friendly