### PR TITLE
Update votes and vp on proposal snapshot endpoint

### DIFF
--- a/src/clients/SnapshotGraphql.ts
+++ b/src/clients/SnapshotGraphql.ts
@@ -72,7 +72,7 @@ export class SnapshotGraphql extends API {
     return result?.data?.space || null
   }
 
-  fetchProposalVotes = async (params: { proposal: string }, skip: number, batchSize: number) => {
+  fetchProposalVotes = async (proposal: string, skip: number, batchSize: number) => {
     const query = `
       query ProposalVotes($space: String!, $proposal: String!, $first: Int!, $skip: Int!) {
         votes (
@@ -94,7 +94,7 @@ export class SnapshotGraphql extends API {
         .method('POST')
         .json({
           query,
-          variables: { space: SNAPSHOT_SPACE, proposal: params.proposal, skip, first: batchSize },
+          variables: { space: SNAPSHOT_SPACE, proposal: proposal, skip, first: batchSize },
         })
     )
 
@@ -103,7 +103,7 @@ export class SnapshotGraphql extends API {
 
   async getProposalVotes(proposalId: string): Promise<SnapshotVote[]> {
     const batchSize = 5000
-    return await inBatches(this.fetchProposalVotes, { proposal: proposalId }, batchSize)
+    return await inBatches(this.fetchProposalVotes, proposalId, batchSize)
   }
 
   async getProposalScores(proposalId: string) {
@@ -284,7 +284,7 @@ export class SnapshotGraphql extends API {
     const variables = {
       space: SNAPSHOT_SPACE,
       voter: address,
-      proposal: proposalId ? proposalId : '',
+      proposal: proposalId || '',
     }
 
     const result = await this.fetch<SnapshotVpResponse>(

--- a/src/clients/SnapshotGraphql.ts
+++ b/src/clients/SnapshotGraphql.ts
@@ -100,9 +100,9 @@ export class SnapshotGraphql extends API {
     return result?.data?.votes
   }
 
-  async getProposalVotes(proposal: string) {
+  async getProposalVotes(proposalId: string): Promise<SnapshotVote[]> {
     const batchSize = 5000
-    return await inBatches(this.fetchProposalVotes, { proposal }, batchSize)
+    return await inBatches(this.fetchProposalVotes, { proposal: proposalId }, batchSize)
   }
 
   async getProposalScores(proposalId: string) {
@@ -267,12 +267,13 @@ export class SnapshotGraphql extends API {
     return await this.fetchProposals({ start, end, fields, scoresState: SnapshotScoresState.Pending }, 0, limit)
   }
 
-  async getVpDistribution(address: string): Promise<VpDistribution> {
+  async getVpDistribution(address: string, proposalId?: string): Promise<VpDistribution> {
     const query = `
-     query getVpDistribution($space: String!, $voter: String!){
+     query getVpDistribution($space: String!, $voter: String!, $proposal: String){
         vp (
           voter: $voter,
-          space: $space
+          space: $space,
+          proposal: $proposal
         ) {
           vp
           vp_by_strategy
@@ -282,6 +283,7 @@ export class SnapshotGraphql extends API {
     const variables = {
       space: SNAPSHOT_SPACE,
       voter: address,
+      proposal: proposalId ? proposalId : '',
     }
 
     const result = await this.fetch<SnapshotVpResponse>(

--- a/src/clients/SnapshotGraphql.ts
+++ b/src/clients/SnapshotGraphql.ts
@@ -82,6 +82,7 @@ export class SnapshotGraphql extends API {
           voter
           created
           choice
+          vp
           vp_by_strategy
         }
       }
@@ -311,33 +312,5 @@ export class SnapshotGraphql extends API {
       delegated: Math.floor(vpByStrategy[StrategyOrder.Delegation]),
       l1Wearables: Math.floor(vpByStrategy[StrategyOrder.L1Wearables]),
     }
-  }
-
-  async getProposalSpaceAndStrategies(proposalSnapshotId: string) {
-    const query = `
-      query Proposal($proposal_snapshot_id: String!) {
-        proposal(id: $proposal_snapshot_id){
-          space {
-            id
-            network
-          }
-          strategies {
-            name
-            params
-          }
-        }
-      }
-    `
-
-    const result = await this.fetch<
-      SnapshotQueryResponse<{ proposal: Pick<SnapshotProposal, 'space' | 'strategies'> }>
-    >(
-      GRAPHQL_ENDPOINT,
-      this.options()
-        .method('POST')
-        .json({ query, variables: { proposal_snapshot_id: proposalSnapshotId } })
-    )
-
-    return result?.data?.proposal
   }
 }

--- a/src/clients/SnapshotGraphqlTypes.ts
+++ b/src/clients/SnapshotGraphqlTypes.ts
@@ -25,6 +25,7 @@ export type SnapshotVote = {
   voter: string
   created: number
   vp?: number
+  vp_by_strategy?: number[]
   choice: number
   proposal?: {
     id: string

--- a/src/components/Home/DaoDelegates.tsx
+++ b/src/components/Home/DaoDelegates.tsx
@@ -7,7 +7,7 @@ import { Modal } from 'decentraland-ui/dist/components/Modal/Modal'
 
 import { CANDIDATE_ADDRESSES } from '../../constants'
 import useDelegatesInfo from '../../hooks/useDelegatesInfo'
-import useVotingPowerInformation from '../../hooks/useVotingPowerInformation'
+import useVotingPowerDistribution from '../../hooks/useVotingPowerDistribution'
 import FullWidthButton from '../Common/FullWidthButton'
 import VotingPowerDelegationDetail from '../Modal/VotingPowerDelegationDetail/VotingPowerDelegationDetail'
 import VotingPowerDelegationModal, { Candidate } from '../Modal/VotingPowerDelegationModal/VotingPowerDelegationModal'
@@ -24,7 +24,7 @@ const DaoDelegates = () => {
   const [isFullListOpened, setIsFullListOpened] = useState(false)
   const [selectedCandidate, setSelectedCandidate] = useState<Candidate | null>(null)
   const [address, authState] = useAuthContext()
-  const { vpDistribution, isLoadingVpDistribution } = useVotingPowerInformation(address)
+  const { vpDistribution, isLoadingVpDistribution } = useVotingPowerDistribution(address)
   const loading = !delegates && authState.loading && isLoadingVpDistribution
 
   const toggleFullList = (state: boolean) => {

--- a/src/components/Section/ProposalVoting/DelegationsLabel.tsx
+++ b/src/components/Section/ProposalVoting/DelegationsLabel.tsx
@@ -2,8 +2,9 @@ import React from 'react'
 
 import Markdown from 'decentraland-gatsby/dist/components/Text/Markdown'
 import useFormatMessage from 'decentraland-gatsby/dist/hooks/useFormatMessage'
+import { Popup } from 'decentraland-ui/dist/components/Popup/Popup'
 
-import Helper from '../../Helper/Helper'
+import Info from '../../Icon/Info'
 import VotingPower from '../../Token/VotingPower'
 import Username from '../../User/Username'
 
@@ -64,12 +65,17 @@ const DelegationsLabel = ({ delegateLabel, delegatorsLabel, infoMessage }: Deleg
       </span>
 
       {infoMessage && (
-        <Helper
-          text={t(infoMessage.id, formattedInfoValues)}
+        <Popup
+          content={t(infoMessage.id, formattedInfoValues)}
           position="left center"
-          size="14"
-          containerClassName="DelegationsLabel__HelperContainer"
-          iconClassName="DelegationsLabel__HelperIcon"
+          trigger={
+            <div className={'DelegationsLabel__HelperContainer'}>
+              <Info className={'DelegationsLabel__HelperIcon'} size={'14'} />
+            </div>
+          }
+          on="hover"
+          hoverable
+          className={`DelegationsLabel__HelperContainer--Popup`}
         />
       )}
     </div>

--- a/src/entities/Votes/routes.ts
+++ b/src/entities/Votes/routes.ts
@@ -32,7 +32,7 @@ export async function getProposalVotes(req: Request<{ proposal: string }>) {
 
   let snapshotVotes: SnapshotVote[]
   try {
-    snapshotVotes = await getSnapshotProposalVotes(proposal)
+    snapshotVotes = await SnapshotGraphql.get().getProposalVotes(proposal.snapshot_id)
   } catch (err) {
     return latestVotes?.votes || {}
   }
@@ -43,10 +43,6 @@ export async function getProposalVotes(req: Request<{ proposal: string }>) {
   }
 
   return updateSnapshotProposalVotes(proposal, snapshotVotes)
-}
-
-export async function getSnapshotProposalVotes(proposal: ProposalAttributes) {
-  return SnapshotGraphql.get().getProposalVotes(proposal.snapshot_space, proposal.snapshot_id)
 }
 
 export async function updateSnapshotProposalVotes(proposal: ProposalAttributes, snapshotVotes: SnapshotVote[]) {

--- a/src/entities/Votes/routes.ts
+++ b/src/entities/Votes/routes.ts
@@ -11,7 +11,7 @@ import { ProposalAttributes } from '../Proposal/types'
 
 import VotesModel from './model'
 import { Vote, VoteAttributes } from './types'
-import { createVotes, getProposalScores, toProposalIds } from './utils'
+import { createVotes, toProposalIds } from './utils'
 
 export default routes((route) => {
   route.get('/proposals/:proposal/votes', handleAPI(getProposalVotes))
@@ -48,11 +48,7 @@ export async function getProposalVotes(req: Request<{ proposal: string }>) {
 export async function updateSnapshotProposalVotes(proposal: ProposalAttributes, snapshotVotes: SnapshotVote[]) {
   const now = new Date()
   const hash = VotesModel.hashVotes(snapshotVotes)
-  const balance = await getProposalScores(
-    proposal,
-    snapshotVotes.map((vote) => vote.voter)
-  )
-  const votes = createVotes(snapshotVotes, balance)
+  const votes = createVotes(snapshotVotes)
   await VotesModel.update<VoteAttributes>(
     {
       hash,

--- a/src/hooks/useVotingPowerDistribution.ts
+++ b/src/hooks/useVotingPowerDistribution.ts
@@ -15,11 +15,11 @@ export const EMPTY_DISTRIBUTION = {
   l1Wearables: 0,
 }
 
-export default function useVotingPowerDistribution(address?: string | null) {
+export default function useVotingPowerDistribution(address?: string | null, proposalSnapshotId?: string) {
   const [vpDistribution, state] = useAsyncMemo<VpDistribution>(
     async () => {
       if (!address) return EMPTY_DISTRIBUTION
-      return await SnapshotGraphql.get().getVpDistribution(address)
+      return await SnapshotGraphql.get().getVpDistribution(address, proposalSnapshotId)
     },
     [address],
     { callWithTruthyDeps: true, initialValue: EMPTY_DISTRIBUTION }

--- a/src/hooks/useVotingPowerInformation.ts
+++ b/src/hooks/useVotingPowerInformation.ts
@@ -5,9 +5,8 @@ import useVotingPowerDistribution from './useVotingPowerDistribution'
 export default function useVotingPowerInformation(address?: string | null) {
   const { vpDistribution, isLoadingVpDistribution } = useVotingPowerDistribution(address)
   const [delegation, delegationState] = useDelegation(address)
-  const { votingPower: scores, isLoadingVotingPower: isLoadingScores } = useVotingPowerBalanceList(
-    delegation.delegatedFrom.map((d) => d.delegator)
-  )
+  const delegatorsToAddress = delegation.delegatedFrom.map((d) => d.delegator)
+  const { votingPower: scores, isLoadingVotingPower: isLoadingScores } = useVotingPowerBalanceList(delegatorsToAddress)
 
   return {
     vpDistribution,

--- a/src/hooks/useVotingPowerOnProposal.ts
+++ b/src/hooks/useVotingPowerOnProposal.ts
@@ -3,6 +3,7 @@ import useAsyncMemo from 'decentraland-gatsby/dist/hooks/useAsyncMemo'
 import { SnapshotGraphql } from '../clients/SnapshotGraphql'
 import { SnapshotVote, StrategyOrder, VpDistribution } from '../clients/SnapshotGraphqlTypes'
 import { ProposalAttributes } from '../entities/Proposal/types'
+import { isSameAddress } from '../entities/Snapshot/utils'
 import { MINIMUM_VP_REQUIRED_TO_VOTE } from '../entities/Votes/constants'
 import { Vote } from '../entities/Votes/types'
 
@@ -67,11 +68,8 @@ function getDelegatedVotingPowerOnProposal(
   let delegatedVotingPower = 0
   if (votes && !!delegators && vpDistribution) {
     delegatedVotingPower = vpDistribution.delegated
-    //TODO checksum addresses?
-    console.log('delegators', delegators)
-    console.log('votes', votes)
     for (const vote of votes) {
-      if (delegators.find((delegator) => delegator === vote.voter)) {
+      if (delegators.find((delegator) => isSameAddress(delegator, vote.voter))) {
         const voterDelegatedVp = getVoteDelegatableVp(vote)
         delegatedVotingPower -= voterDelegatedVp
       }

--- a/src/hooks/useVotingPowerOnProposal.ts
+++ b/src/hooks/useVotingPowerOnProposal.ts
@@ -67,9 +67,11 @@ function getDelegatedVotingPowerOnProposal(
   let delegatedVotingPower = 0
   if (votes && !!delegators && vpDistribution) {
     delegatedVotingPower = vpDistribution.delegated
+    //TODO checksum addresses?
+    console.log('delegators', delegators)
+    console.log('votes', votes)
     for (const vote of votes) {
       if (delegators.find((delegator) => delegator === vote.voter)) {
-        //TODO CHECKsum addresses?
         const voterDelegatedVp = getVoteDelegatableVp(vote)
         delegatedVotingPower -= voterDelegatedVp
       }

--- a/src/modules/contracts/index.ts
+++ b/src/modules/contracts/index.ts
@@ -8,6 +8,7 @@ export { default as RegisterABI } from './abi/Register.abi.json'
 export const MANA: Record<number, string | null | undefined> = {
   [ChainId.ETHEREUM_MAINNET]: '0x0f5d2fb29fb7d3cfee444a200298f468908cc942',
   [ChainId.ETHEREUM_RINKEBY]: '0x28BcE5263f5d7F4EB7e8C6d5d78275CA455BAc63',
+  [ChainId.ETHEREUM_GOERLI]: '0xe7fDae84ACaba2A5Ba817B6E6D8A2d415DBFEdbe',
 }
 
 export const wMANA: Record<number, string | null | undefined> = {
@@ -17,8 +18,10 @@ export const wMANA: Record<number, string | null | undefined> = {
 
 export const LAND: Record<number, string | null | undefined> = {
   [ChainId.ETHEREUM_MAINNET]: '0xf87e31492faf9a91b02ee0deaad50d51d56d5d4d',
+  [ChainId.ETHEREUM_GOERLI]: '0x25b6B4bac4aDB582a0ABd475439dA6730777Fbf7',
 }
 
 export const ESTATE: Record<number, string | null | undefined> = {
   [ChainId.ETHEREUM_MAINNET]: '0x959e104e1a4db6317fa58f8295f586e1a978c297',
+  [ChainId.ETHEREUM_GOERLI]: '0xC9A46712E6913c24d15b46fF12221a79c4e251DC',
 }

--- a/src/modules/votes/utils.ts
+++ b/src/modules/votes/utils.ts
@@ -16,10 +16,10 @@ export function getEnvironmentChainId() {
   switch (CHAIN_ID) {
     case ChainId.ETHEREUM_MAINNET.valueOf():
       return ChainId.ETHEREUM_MAINNET
-    case ChainId.ETHEREUM_RINKEBY:
-      return ChainId.ETHEREUM_RINKEBY
+    case ChainId.ETHEREUM_GOERLI:
+      return ChainId.ETHEREUM_GOERLI
     default:
-      throw new Error(`GATSBY_DEFAULT_CHAIN_ID is not Mainnet or Rinkeby: ${DEFAULT_CHAIN_ID}`)
+      throw new Error(`GATSBY_DEFAULT_CHAIN_ID is not Mainnet or Goerli: ${DEFAULT_CHAIN_ID}`)
   }
 }
 


### PR DESCRIPTION
Update `updateSnapshotProposalVotes` and `useVotingPowerOnProposal` to stop using `snapshot.utils.getScores`

Things are looking OK in Goerliland

Account 1 with 1k VP, delegated to account 2
<img width="323" alt="image" src="https://user-images.githubusercontent.com/2858950/198132121-7a0eda35-2954-4a17-9fdc-510e4849581e.png">
<img width="351" alt="image" src="https://user-images.githubusercontent.com/2858950/198132097-d08b3971-e192-42cb-97d6-8ba403fcff0e.png">

Account 2 with 200vp, delegated to account 3 (and overruled vote)
<img width="321" alt="image" src="https://user-images.githubusercontent.com/2858950/198132292-6b4e61d7-7e03-48d7-a9ee-f565510c041f.png">
<img width="335" alt="image" src="https://user-images.githubusercontent.com/2858950/198132338-d88debbe-4951-4e83-aa68-680a362895ef.png">

Account 3 with 350vp
<img width="342" alt="image" src="https://user-images.githubusercontent.com/2858950/198132466-fbca82e2-7d6a-40cb-8c01-02d96888ce98.png">
<img width="319" alt="image" src="https://user-images.githubusercontent.com/2858950/198132528-949b2c22-0df2-4a64-8ba5-1fa52620ec80.png">


