### PR TITLE
feat: Added coauthors list option to proposals API endpoint

### DIFF
--- a/src/entities/Proposal/model.ts
+++ b/src/entities/Proposal/model.ts
@@ -240,7 +240,9 @@ export default class ProposalModel extends Model<ProposalAttributes> {
     return (!!result && result[0] && Number(result[0].total)) || 0
   }
 
-  static async getProposalList(filter: Partial<FilterProposalList & FilterPagination> = {}) {
+  static async getProposalList(
+    filter: Partial<FilterProposalList & FilterPagination> = {}
+  ): Promise<(ProposalAttributes & { coauthors?: string[] | null })[]> {
     if (filter.user && !isEthereumAddress(filter.user)) {
       return []
     }

--- a/src/entities/Proposal/types.ts
+++ b/src/entities/Proposal/types.ts
@@ -63,6 +63,7 @@ export type ProposalAttributes<C extends Record<string, unknown> = any> = {
   created_at: Date
   updated_at: Date
   textsearch: SQLStatement | string | null | undefined
+  coauthors?: string[] | null
 }
 
 export enum ProposalStatus {

--- a/src/entities/Proposal/types.ts
+++ b/src/entities/Proposal/types.ts
@@ -63,7 +63,6 @@ export type ProposalAttributes<C extends Record<string, unknown> = any> = {
   created_at: Date
   updated_at: Date
   textsearch: SQLStatement | string | null | undefined
-  coauthors?: string[] | null
 }
 
 export enum ProposalStatus {


### PR DESCRIPTION
When the query param `coauthor=true` is added to the `/proposals` endpoint, the list of approved co-authors (if any) is displayed.

This is a required modification in order to display the list of coauthors in the transparency proposals sheet.

<img width="452" alt="image" src="https://user-images.githubusercontent.com/45410089/217244262-2078e2b6-8f20-419b-9e14-c05536de8fe1.png">
