### PR TITLE
fix: rename progress bar for status 4

### DIFF
--- a/src/components/Status/Progress.css
+++ b/src/components/Status/Progress.css
@@ -42,7 +42,7 @@
   background-color: #76b7b2;
 }
 
-.Progress.Progress--status-3 .Progress--bar {
+.Progress.Progress--status-4 .Progress--bar {
   background-color: #59a14f;
 }
 


### PR DESCRIPTION
Before
![image](https://user-images.githubusercontent.com/2858950/217347291-7b7a854b-6e43-4b95-b95e-8d85f18b382b.png)

After
![image](https://user-images.githubusercontent.com/2858950/217347323-e564c142-6bb9-49bf-9168-d3f5e61716fb.png)
