### PR TITLE
fix: images not resizing and overlapping with sidebar (#718)

### DIFF
--- a/src/pages/proposal.css
+++ b/src/pages/proposal.css
@@ -39,8 +39,9 @@
   font-size: 15px;
 }
 
-.ProposalDetailPage .ProposalDetailDescription .dg.Paragraph img {
+.ProposalDetailPage .ProposalDetailDescription img {
   max-width: 100%;
+  width: -webkit-fill-available;
 }
 
 .ProposalImagesPreview {


### PR DESCRIPTION
Closes #718 

<img width="1121" alt="image" src="https://user-images.githubusercontent.com/45410089/217594585-6ed6e139-c20b-4f99-9fa6-b11a8740405d.png">

