### PR TITLE
feat: add out of budget to proposal status

### DIFF
--- a/src/components/Status/LeadingOption.tsx
+++ b/src/components/Status/LeadingOption.tsx
@@ -17,9 +17,13 @@ export default React.memo(function LeadingOption({ status, leadingOption, metVP,
   const t = useFormatMessage()
 
   const proposalFinished = useMemo(() => {
-    return [ProposalStatus.Passed, ProposalStatus.Rejected, ProposalStatus.Finished, ProposalStatus.Enacted].includes(
-      status
-    )
+    return [
+      ProposalStatus.Passed,
+      ProposalStatus.Rejected,
+      ProposalStatus.Finished,
+      ProposalStatus.OutOfBudget,
+      ProposalStatus.Enacted,
+    ].includes(status)
   }, [status])
 
   return (

--- a/src/components/Status/StatusMenu.tsx
+++ b/src/components/Status/StatusMenu.tsx
@@ -49,6 +49,10 @@ export default function StatusMenu(props: StatusMenu) {
           onClick={(e) => handleChange(e, ProposalStatus.Rejected)}
         />
         <Dropdown.Item
+          text={t(`status.${ProposalStatus.OutOfBudget}`)}
+          onClick={(e) => handleChange(e, ProposalStatus.OutOfBudget)}
+        />
+        <Dropdown.Item
           text={t(`status.${ProposalStatus.Enacted}`)}
           onClick={(e) => handleChange(e, ProposalStatus.Enacted)}
         />

--- a/src/components/Status/StatusPill.tsx
+++ b/src/components/Status/StatusPill.tsx
@@ -2,7 +2,8 @@ import React from 'react'
 
 import TokenList from 'decentraland-gatsby/dist/utils/dom/TokenList'
 
-import { ProposalStatus, isProposalStatus } from '../../entities/Proposal/types'
+import { ProposalStatus } from '../../entities/Proposal/types'
+import { isProposalStatus } from '../../entities/Proposal/utils'
 import Pill, { PillColor, Props as PillProps } from '../Common/Pill'
 import Check from '../Icon/Check'
 
@@ -13,12 +14,13 @@ type Props = {
 }
 
 const ColorsConfig: Record<ProposalStatus, PillColor> = {
-  [ProposalStatus.Rejected]: PillColor.Red,
   [ProposalStatus.Pending]: PillColor.Gray,
-  [ProposalStatus.Passed]: PillColor.Green,
-  [ProposalStatus.Finished]: PillColor.Gray,
   [ProposalStatus.Active]: PillColor.Gray,
+  [ProposalStatus.Finished]: PillColor.Gray,
+  [ProposalStatus.Passed]: PillColor.Green,
   [ProposalStatus.Enacted]: PillColor.Green,
+  [ProposalStatus.OutOfBudget]: PillColor.Yellow,
+  [ProposalStatus.Rejected]: PillColor.Red,
   [ProposalStatus.Deleted]: PillColor.Red,
 }
 
@@ -30,7 +32,7 @@ const StatusPill = ({ className, status, size }: Props) => {
   return (
     <Pill
       size={size || 'default'}
-      style={label === ProposalStatus.Enacted ? 'shiny' : 'outline'}
+      style={label === (ProposalStatus.Enacted || ProposalStatus.OutOfBudget) ? 'shiny' : 'outline'}
       className={TokenList.join(['StatusPill', className])}
       color={ColorsConfig[label]}
       icon={showIcon ? <Check color={iconColor} /> : null}

--- a/src/entities/Budget/routes.ts
+++ b/src/entities/Budget/routes.ts
@@ -6,7 +6,6 @@ import { Request } from 'express'
 import { TransparencyBudget } from '../../clients/DclData'
 import { BudgetService } from '../../services/BudgetService'
 import { QuarterBudgetAttributes } from '../QuarterBudget/types'
-import { QuarterCategoryBudgetAttributes } from '../QuarterCategoryBudget/types'
 import { toNewGrantCategory } from '../QuarterCategoryBudget/utils'
 
 import { CurrentBudget, CurrentCategoryBudget } from './types'

--- a/src/entities/Proposal/model.ts
+++ b/src/entities/Proposal/model.ts
@@ -20,8 +20,8 @@ import SubscriptionModel from '../Subscription/model'
 import { CoauthorStatus } from './../Coauthor/types'
 
 import tsquery from './tsquery'
-import { ProposalAttributes, ProposalStatus, isProposalStatus, isProposalType } from './types'
-import { SITEMAP_ITEMS_PER_PAGE } from './utils'
+import { ProposalAttributes, ProposalStatus, isProposalType } from './types'
+import { SITEMAP_ITEMS_PER_PAGE, isProposalStatus } from './utils'
 
 export type FilterProposalList = {
   type: string

--- a/src/entities/Proposal/routes.ts
+++ b/src/entities/Proposal/routes.ts
@@ -69,6 +69,7 @@ import {
   DEFAULT_CHOICES,
   MAX_PROPOSAL_LIMIT,
   MIN_PROPOSAL_OFFSET,
+  canLinkProposal,
   isAlreadyACatalyst,
   isAlreadyBannedName,
   isAlreadyPointOfInterest,
@@ -502,8 +503,11 @@ async function validateLinkedProposal(linkedProposalId: string, expectedProposal
       RequestError.NotFound
     )
   }
-  if (linkedProposal.status != ProposalStatus.Passed) {
-    throw new RequestError("Cannot link selected proposal since it's not in a PASSED status", RequestError.Forbidden)
+  if (!canLinkProposal(linkedProposal.status)) {
+    throw new RequestError(
+      "Cannot link selected proposal since it's not in a PASSED or OOB status",
+      RequestError.Forbidden
+    )
   }
 }
 

--- a/src/entities/Proposal/templates/messages.test.ts
+++ b/src/entities/Proposal/templates/messages.test.ts
@@ -1,10 +1,11 @@
 import { def, get } from 'bdd-lazy-var/getter'
 import Time from 'decentraland-gatsby/dist/utils/date/Time'
 
-import { GrantTierType, OldGrantCategory } from '../../Grant/types'
+import { GrantTierType, NewGrantCategory, OldGrantCategory } from '../../Grant/types'
 import VotesModel from '../../Votes/model'
 import ProposalModel from '../model'
 import {
+  GrantProposalConfiguration,
   INVALID_PROPOSAL_POLL_OPTIONS,
   ProposalAttributes,
   ProposalRequiredVP,
@@ -374,6 +375,46 @@ describe('getUpdateMessage', () => {
                 '* Invalid question/options 0% 0 VP (0 votes)\n'
             )
           })
+        })
+      })
+    })
+
+    describe('when the updated status is Out of Budget', () => {
+      def('votes', () => PASSED_VOTES)
+      def('proposalStatus', () => ProposalStatus.OutOfBudget)
+
+      describe('when the proposal is Grant', () => {
+        def('proposalType', () => ProposalType.Grant)
+        def('configuration', () => {
+          const grantConfiguration: GrantProposalConfiguration = {
+            title: 'Grant Title',
+            abstract: 'Grant Abstract',
+            category: NewGrantCategory.InWorldContent,
+            tier: GrantTierType.LowerTier,
+            size: 1000,
+            beneficiary: 'Grant Beneficiary',
+            description: 'Grant Description',
+            specification: 'Grant Specification',
+            personnel: 'Grant Personnel',
+            roadmap: 'Grant Roadmap',
+            choices: DEFAULT_CHOICES,
+            projectDuration: 6,
+            email: 'a@a.org',
+          }
+          return grantConfiguration
+        })
+
+        it('should return a message with the out of budget status and the results of the voting', () => {
+          expect(get.updateMessage).not.toContain(TESTING_COMMITTEE_USER)
+          expect(get.updateMessage).not.toContain(get.passedDescription)
+          expect(get.updateMessage).toContain(get.proposal.title)
+          expect(get.updateMessage).toBe(
+            'Test Proposal\n\n' +
+              'This proposal is now in status: OUT OF BUDGET.\n\n' +
+              'Voting Results:\n' +
+              '* Yes 97% 115,182 VP (3 votes)\n' +
+              '* No 3% 4,269 VP (1 votes)\n'
+          )
         })
       })
     })

--- a/src/entities/Proposal/templates/messages.ts
+++ b/src/entities/Proposal/templates/messages.ts
@@ -3,8 +3,7 @@ import { calculateResult } from '../../Votes/utils'
 import { ProposalAttributes, ProposalStatus } from '../types'
 
 function getProposalStatusDisplayName(proposalStatus: ProposalStatus) {
-  if (proposalStatus === ProposalStatus.OutOfBudget) return 'OUT OF BUDGET'
-  return proposalStatus.toUpperCase()
+  return proposalStatus.split('_').join(' ').toUpperCase()
 }
 
 export function getUpdateMessage(proposal: ProposalAttributes, votes: Record<string, Vote>) {

--- a/src/entities/Proposal/templates/messages.ts
+++ b/src/entities/Proposal/templates/messages.ts
@@ -2,10 +2,15 @@ import { Vote } from '../../Votes/types'
 import { calculateResult } from '../../Votes/utils'
 import { ProposalAttributes, ProposalStatus } from '../types'
 
+function getProposalStatusDisplayName(proposalStatus: ProposalStatus) {
+  if (proposalStatus === ProposalStatus.OutOfBudget) return 'OUT OF BUDGET'
+  return proposalStatus.toUpperCase()
+}
+
 export function getUpdateMessage(proposal: ProposalAttributes, votes: Record<string, Vote>) {
   let updatingUser: string | null
 
-  const statusDisplayName = proposal.status.toUpperCase()
+  const statusDisplayName = getProposalStatusDisplayName(proposal.status)
   if (proposal.enacted) {
     updatingUser = proposal.enacted_by
     if (!updatingUser) {
@@ -36,7 +41,7 @@ export function getUpdateMessage(proposal: ProposalAttributes, votes: Record<str
     return updatingUser
       ? getUserTriggeredUpdateMessage(statusDisplayName, updatingUser, proposal.rejected_description, proposal)
       : getJobTriggeredUpdateMessage(statusDisplayName, proposal, votes)
-  } else if (proposal.status === ProposalStatus.Finished) {
+  } else if (proposal.status === ProposalStatus.Finished || ProposalStatus.OutOfBudget) {
     return getJobTriggeredUpdateMessage(statusDisplayName, proposal, votes)
   } else {
     throw new Error(`Proposal update message builder received an invalid status: ${proposal.status}`)

--- a/src/entities/Proposal/types.ts
+++ b/src/entities/Proposal/types.ts
@@ -59,26 +59,9 @@ export enum ProposalStatus {
   Finished = 'finished',
   Rejected = 'rejected',
   Passed = 'passed',
+  OutOfBudget = 'out_of_budget',
   Enacted = 'enacted',
   Deleted = 'deleted',
-}
-
-export function isProposalStatus(value: string | null | undefined): boolean {
-  switch (value) {
-    case ProposalStatus.Pending:
-    case ProposalStatus.Finished:
-    case ProposalStatus.Active:
-    case ProposalStatus.Rejected:
-    case ProposalStatus.Passed:
-    case ProposalStatus.Enacted:
-      return true
-    default:
-      return false
-  }
-}
-
-export function toProposalStatus(value: string | null | undefined): ProposalStatus | null {
-  return isProposalStatus(value) ? (value as ProposalStatus) : null
 }
 
 export enum ProposalType {

--- a/src/entities/Proposal/utils.test.ts
+++ b/src/entities/Proposal/utils.test.ts
@@ -1,10 +1,10 @@
 import { ProposalStatus } from './types'
 import {
   canLinkProposal,
+  isProposalDeletable,
+  isProposalEnactable,
   isProposalStatus,
   isValidUpdateProposalStatus,
-  proposalCanBeDeleted,
-  proposalCanBeEnacted,
   proposalCanBePassedOrRejected,
   toProposalStatus,
 } from './utils'
@@ -69,28 +69,28 @@ describe('isValidUpdateProposalStatus', () => {
 
 describe('proposalCanBeDeleted', () => {
   it('should return true for active or pending proposals', () => {
-    expect(proposalCanBeDeleted(ProposalStatus.Active)).toBe(true)
-    expect(proposalCanBeDeleted(ProposalStatus.Pending)).toBe(true)
+    expect(isProposalDeletable(ProposalStatus.Active)).toBe(true)
+    expect(isProposalDeletable(ProposalStatus.Pending)).toBe(true)
   })
   it('should return false for all status other than active or pending', () => {
     Object.values(ProposalStatus)
       .filter((status) => status !== ProposalStatus.Active && status !== ProposalStatus.Pending)
       .forEach((status) => {
-        expect(proposalCanBeDeleted(status)).toBe(false)
+        expect(isProposalDeletable(status)).toBe(false)
       })
   })
 })
 
 describe('proposalCanBeEnacted', () => {
   it('should return true for enacted or passed proposals', () => {
-    expect(proposalCanBeEnacted(ProposalStatus.Passed)).toBe(true)
-    expect(proposalCanBeEnacted(ProposalStatus.Enacted)).toBe(true)
+    expect(isProposalEnactable(ProposalStatus.Passed)).toBe(true)
+    expect(isProposalEnactable(ProposalStatus.Enacted)).toBe(true)
   })
   it('should return false for all status other than active or pending', () => {
     Object.values(ProposalStatus)
       .filter((status) => status !== ProposalStatus.Passed && status !== ProposalStatus.Enacted)
       .forEach((status) => {
-        expect(proposalCanBeEnacted(status)).toBe(false)
+        expect(isProposalEnactable(status)).toBe(false)
       })
   })
 })

--- a/src/entities/Proposal/utils.ts
+++ b/src/entities/Proposal/utils.ts
@@ -14,7 +14,6 @@ import { MAX_NAME_SIZE, MIN_NAME_SIZE } from './constants'
 import { ProposalAttributes, ProposalStatus, ProposalType, TransparencyGrant } from './types'
 
 export const MIN_PROPOSAL_OFFSET = 0
-export const MIN_PROPOSAL_LIMIT = 0
 export const MAX_PROPOSAL_LIMIT = 100
 export const SITEMAP_ITEMS_PER_PAGE = 100
 
@@ -24,24 +23,6 @@ export const REGEX_NAME = new RegExp(`^([a-zA-Z0-9]){${MIN_NAME_SIZE},${MAX_NAME
 export const JOIN_DISCORD_URL = env('GATSBY_JOIN_DISCORD_URL') || 'https://dcl.gg/discord'
 
 export const CLIFF_PERIOD_IN_DAYS = 29
-
-export async function asyncSome<T>(arr: T[], predicate: (param: T) => Promise<boolean>) {
-  for (const item of arr) {
-    if (await predicate(item)) {
-      return true
-    }
-  }
-  return false
-}
-
-export async function asyncEvery<T>(arr: T[], predicate: (param: T) => Promise<boolean>) {
-  for (const item of arr) {
-    if (!(await predicate(item))) {
-      return false
-    }
-  }
-  return true
-}
 
 export function formatBalance(value: number | bigint) {
   return numeral(value).format('0,0')
@@ -91,7 +72,12 @@ export async function isAlreadyACatalyst(domain: string) {
 export function isValidUpdateProposalStatus(current: ProposalStatus, next: ProposalStatus) {
   switch (current) {
     case ProposalStatus.Finished:
-      return next === ProposalStatus.Rejected || next === ProposalStatus.Passed || next === ProposalStatus.Enacted
+      return (
+        next === ProposalStatus.Rejected ||
+        next === ProposalStatus.Passed ||
+        next === ProposalStatus.Enacted ||
+        next === ProposalStatus.OutOfBudget
+      )
     case ProposalStatus.Passed:
     case ProposalStatus.Enacted:
       return next === ProposalStatus.Enacted
@@ -162,4 +148,40 @@ export function isProposalInCliffPeriod(grant: TransparencyGrant) {
 
 export function isGovernanceProcessProposal(type: ProposalType) {
   return type === ProposalType.Poll || type === ProposalType.Draft || type === ProposalType.Governance
+}
+
+export function isProposalStatus(value: string | null | undefined): boolean {
+  switch (value) {
+    case ProposalStatus.Pending:
+    case ProposalStatus.Finished:
+    case ProposalStatus.Active:
+    case ProposalStatus.Rejected:
+    case ProposalStatus.Passed:
+    case ProposalStatus.OutOfBudget:
+    case ProposalStatus.Enacted:
+    case ProposalStatus.Deleted:
+      return true
+    default:
+      return false
+  }
+}
+
+export function toProposalStatus(value: string | null | undefined, orElse: () => any): ProposalStatus | any {
+  return isProposalStatus(value) ? (value as ProposalStatus) : orElse()
+}
+
+export function proposalCanBeDeleted(proposalStatus?: ProposalStatus) {
+  return proposalStatus === ProposalStatus.Pending || proposalStatus === ProposalStatus.Active
+}
+
+export function proposalCanBeEnacted(proposalStatus?: ProposalStatus) {
+  return proposalStatus === ProposalStatus.Passed || proposalStatus === ProposalStatus.Enacted
+}
+
+export function proposalCanBePassedOrRejected(proposalStatus?: ProposalStatus) {
+  return proposalStatus === ProposalStatus.Finished
+}
+
+export function canLinkProposal(status: ProposalStatus) {
+  return status === ProposalStatus.Passed || status === ProposalStatus.OutOfBudget
 }

--- a/src/entities/Proposal/utils.ts
+++ b/src/entities/Proposal/utils.ts
@@ -170,11 +170,11 @@ export function toProposalStatus(value: string | null | undefined, orElse: () =>
   return isProposalStatus(value) ? (value as ProposalStatus) : orElse()
 }
 
-export function proposalCanBeDeleted(proposalStatus?: ProposalStatus) {
+export function isProposalDeletable(proposalStatus?: ProposalStatus) {
   return proposalStatus === ProposalStatus.Pending || proposalStatus === ProposalStatus.Active
 }
 
-export function proposalCanBeEnacted(proposalStatus?: ProposalStatus) {
+export function isProposalEnactable(proposalStatus?: ProposalStatus) {
   return proposalStatus === ProposalStatus.Passed || proposalStatus === ProposalStatus.Enacted
 }
 

--- a/src/hooks/useSearchParams.ts
+++ b/src/hooks/useSearchParams.ts
@@ -2,8 +2,9 @@ import { useMemo } from 'react'
 
 import { useLocation } from '@gatsbyjs/reach-router'
 
-import { ProposalStatus, ProposalType, toProposalStatus, toProposalType } from '../entities/Proposal/types'
+import { ProposalStatus, ProposalType, toProposalType } from '../entities/Proposal/types'
 import { toProposalListPage } from '../modules/locations'
+import { toProposalStatus } from "../entities/Proposal/utils";
 
 export type SearchParams = {
   type: ProposalType | undefined
@@ -20,7 +21,7 @@ export function useSearchParams(): SearchParams {
   return useMemo(() => {
     const params = new URLSearchParams(location.search)
     const type = toProposalType(params.get('type')) ?? undefined
-    const status = toProposalStatus(params.get('status')) ?? undefined
+    const status = toProposalStatus(params.get('status'), () => undefined)
     const search = params.get('search') || ''
     const timeFrame = params.get('timeFrame') || ''
     const order = params.get('order') ? (params.get('order') === 'ASC' ? 'ASC' : 'DESC') : undefined

--- a/src/intl/en.json
+++ b/src/intl/en.json
@@ -286,7 +286,8 @@
     "active": "Active outcomes",
     "rejected": "Rejected outcomes",
     "passed": "Passed outcomes",
-    "enacted": "Enacted outcomes"
+    "enacted": "Enacted outcomes",
+    "out_of_budget": "OOB outcomes"
   },
   "grant_status": {
     "in_progress": "In progress",

--- a/src/pages/proposal.tsx
+++ b/src/pages/proposal.tsx
@@ -43,7 +43,12 @@ import VestingContract from '../components/Section/VestingContract'
 import StatusPill from '../components/Status/StatusPill'
 import { CoauthorStatus } from '../entities/Coauthor/types'
 import { ProposalStatus, ProposalType } from '../entities/Proposal/types'
-import { forumUrl } from '../entities/Proposal/utils'
+import {
+  forumUrl,
+  proposalCanBeDeleted,
+  proposalCanBeEnacted,
+  proposalCanBePassedOrRejected,
+} from '../entities/Proposal/utils'
 import useCoAuthorsByProposal from '../hooks/useCoAuthorsByProposal'
 import useIsCommittee from '../hooks/useIsCommittee'
 import useProposal from '../hooks/useProposal'
@@ -209,7 +214,8 @@ export default function ProposalPage() {
     )
   }
 
-  const isProposalStatusWithUpdates = PROPOSAL_STATUS_WITH_UPDATES.has(proposal?.status as ProposalStatus)
+  const proposalStatus = proposal?.status
+  const isProposalStatusWithUpdates = PROPOSAL_STATUS_WITH_UPDATES.has(proposalStatus as ProposalStatus)
   const showProposalUpdatesActions =
     isProposalStatusWithUpdates && proposal?.type === ProposalType.Grant && (isOwner || isCoauthor)
   const showProposalUpdates = publicUpdates && isProposalStatusWithUpdates && proposal?.type === ProposalType.Grant
@@ -293,32 +299,31 @@ export default function ProposalPage() {
                     basic
                     fluid
                     loading={deleting}
-                    disabled={proposal?.status !== ProposalStatus.Pending && proposal?.status !== ProposalStatus.Active}
+                    disabled={!proposalCanBeDeleted(proposalStatus)}
                     onClick={() => patchOptions({ confirmDeletion: true })}
                   >
                     {t('page.proposal_detail.delete')}
                   </Button>
                 )}
-                {isCommittee &&
-                  (proposal?.status === ProposalStatus.Passed || proposal?.status === ProposalStatus.Enacted) && (
-                    <Button
-                      basic
-                      loading={updatingStatus}
-                      fluid
-                      onClick={() =>
-                        patchOptions({
-                          confirmStatusUpdate: ProposalStatus.Enacted,
-                        })
-                      }
-                    >
-                      {t(
-                        proposal?.status === ProposalStatus.Passed
-                          ? 'page.proposal_detail.enact'
-                          : 'page.proposal_detail.edit_enacted_data'
-                      )}
-                    </Button>
-                  )}
-                {isCommittee && proposal?.status === ProposalStatus.Finished && (
+                {isCommittee && proposalCanBeEnacted(proposalStatus) && (
+                  <Button
+                    basic
+                    loading={updatingStatus}
+                    fluid
+                    onClick={() =>
+                      patchOptions({
+                        confirmStatusUpdate: ProposalStatus.Enacted,
+                      })
+                    }
+                  >
+                    {t(
+                      proposalStatus === ProposalStatus.Passed
+                        ? 'page.proposal_detail.enact'
+                        : 'page.proposal_detail.edit_enacted_data'
+                    )}
+                  </Button>
+                )}
+                {isCommittee && proposalCanBePassedOrRejected(proposalStatus) && (
                   <>
                     <Button
                       basic

--- a/src/pages/proposal.tsx
+++ b/src/pages/proposal.tsx
@@ -45,8 +45,8 @@ import { CoauthorStatus } from '../entities/Coauthor/types'
 import { ProposalStatus, ProposalType } from '../entities/Proposal/types'
 import {
   forumUrl,
-  proposalCanBeDeleted,
-  proposalCanBeEnacted,
+  isProposalDeletable,
+  isProposalEnactable,
   proposalCanBePassedOrRejected,
 } from '../entities/Proposal/utils'
 import useCoAuthorsByProposal from '../hooks/useCoAuthorsByProposal'
@@ -299,13 +299,13 @@ export default function ProposalPage() {
                     basic
                     fluid
                     loading={deleting}
-                    disabled={!proposalCanBeDeleted(proposalStatus)}
+                    disabled={!isProposalDeletable(proposalStatus)}
                     onClick={() => patchOptions({ confirmDeletion: true })}
                   >
                     {t('page.proposal_detail.delete')}
                   </Button>
                 )}
-                {isCommittee && proposalCanBeEnacted(proposalStatus) && (
+                {isCommittee && isProposalEnactable(proposalStatus) && (
                   <Button
                     basic
                     loading={updatingStatus}


### PR DESCRIPTION
Not sure if we should be able to link grant proposals with OOB status, but if the idea is to be able to resubmit and link to them, I think we should.

Moved frontend behavior depending on `ProposalStatus` to tested functions in `utils.ts`, so it's easier to refactor them later.