### PR TITLE
fix: Break line when '\n' in proposals description

### DIFF
--- a/src/pages/proposal.css
+++ b/src/pages/proposal.css
@@ -34,6 +34,10 @@
   font-weight: 500;
 }
 
+.ProposalDetailPage .ProposalDetailDescription .dg.Paragraph {
+  white-space: pre-line;
+}
+
 .ProposalDetailPage .ProposalDetailDescription .dg.Paragraph,
 .ProposalDetailPage .ProposalDetailDescription .dg.ListItem {
   font-size: 15px;


### PR DESCRIPTION
Closes #789 

<img width="1164" alt="image" src="https://user-images.githubusercontent.com/45410089/225387612-61417a87-e519-4a50-a1ba-4730531ae749.png">
