### PR TITLE
chore: get avatars from forum

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -29,7 +29,6 @@ GATSBY_DISCOURSE_CATEGORY=14
 GATSBY_DISCOURSE_USER=dao
 GATSBY_DISCOURSE_API=https://forum.decentraland.org
 DISCOURSE_API_KEY=
-DISCOURSE_BASE_AVATAR_URL=https://sjc6.discourse-cdn.com/standard10
 
 # Decentraland's mailchimp integration
 GATSBY_DECENTRALAND_API=https://subscription.decentraland.org

--- a/src/entities/Discourse/utils.test.ts
+++ b/src/entities/Discourse/utils.test.ts
@@ -1,9 +1,14 @@
 import { DiscoursePostInTopic, DiscourseTopic } from '../../clients/Discourse'
+import { FORUM_URL } from '../../constants'
 import { ProposalCommentsInDiscourse } from '../Proposal/types'
 
 import { ONE_USER_POST, SEVERAL_USERS_POST, createWithPosts } from './__data__/discourse_samples'
 
-import { BASE_AVATAR_URL, DISCOURSE_USER, filterComments } from './utils'
+import { DISCOURSE_USER, filterComments } from './utils'
+
+jest.mock('../../constants', () => ({
+  FORUM_URL: 'https://forum.test.url',
+}))
 
 describe('filterUserComments', () => {
   let discourseTopic: DiscourseTopic
@@ -24,14 +29,14 @@ describe('filterUserComments', () => {
       expect(filteredComments.totalComments).toBe(1)
     })
 
-    it('should contain the base discourse avatar url in the user avatar url', () => {
-      expect(filteredComments.comments[0].avatar_url).toContain(BASE_AVATAR_URL)
+    it('should contain the base discourse forum url in the user avatar url', () => {
+      expect(filteredComments.comments[0].avatar_url).toContain(FORUM_URL)
     })
 
     it('should return a parsed list of the user comments with avatar, username, user comment, and comment date', () => {
       expect(filteredComments.comments[0].username).toBe('yemel')
       expect(filteredComments.comments[0].avatar_url).toBe(
-        'https://sjc6.discourse-cdn.com/standard10/user_avatar/forum.decentraland.vote/yemel/45/1_2.png'
+        `${FORUM_URL}/user_avatar/forum.decentraland.vote/yemel/45/1_2.png`
       )
       expect(filteredComments.comments[0].created_at).toBe('2021-11-19T21:36:13.181Z')
       expect(filteredComments.comments[0].cooked).toBe('<p>I am commenting as Yemel</p>')

--- a/src/entities/Discourse/utils.ts
+++ b/src/entities/Discourse/utils.ts
@@ -4,7 +4,6 @@ import { env } from '../../modules/env'
 import { ProposalComment, ProposalCommentsInDiscourse } from '../Proposal/types'
 
 export const DISCOURSE_USER = process.env.GATSBY_DISCOURSE_USER || env('GATSBY_DISCOURSE_USER') || ''
-export const BASE_AVATAR_URL = process.env.DISCOURSE_BASE_AVATAR_URL || 'https://sjc6.discourse-cdn.com/standard10'
 export const DISCOURSE_API = process.env.GATSBY_DISCOURSE_API || env('GATSBY_DISCOURSE_API') || ''
 const DEFAULT_AVATAR_SIZE = '45'
 
@@ -16,9 +15,9 @@ export function getUserProfileUrl(user: string) {
   return `${FORUM_URL}/u/${user}`
 }
 
-function setAvatarUrl(post: DiscoursePostInTopic) {
+function getAvatarUrl(post: DiscoursePostInTopic) {
   const defaultSizeUrl = getDefaultAvatarSizeUrl(post.avatar_template)
-  return defaultSizeUrl.includes('letter') ? defaultSizeUrl : BASE_AVATAR_URL + defaultSizeUrl
+  return defaultSizeUrl.includes('letter') ? defaultSizeUrl : FORUM_URL + defaultSizeUrl
 }
 
 export function filterComments(posts: DiscoursePostInTopic[]): ProposalCommentsInDiscourse {
@@ -29,7 +28,7 @@ export function filterComments(posts: DiscoursePostInTopic[]): ProposalCommentsI
   const proposalComments: ProposalComment[] = userPosts.map((post) => {
     return {
       username: post.username,
-      avatar_url: setAvatarUrl(post),
+      avatar_url: getAvatarUrl(post),
       created_at: post.created_at,
       cooked: post.cooked,
     }


### PR DESCRIPTION
Now it uses the forum URL to generate the url when the user has a custom avatar set, like https://forum.decentraland.vote/user_avatar/forum.decentraland.vote/lemu/45/5_2.png

If the user does not have a custom avatar, uses the url provided by discourse:
https://avatars.discourse-cdn.com/v4/letter/1/ec9cab/45.png

![image](https://user-images.githubusercontent.com/2858950/226422227-6bbf4db8-a522-4e03-8c18-35ab7a2c8b59.png)
