### PR TITLE
feat: display budget and category on all finished grants

### DIFF
--- a/src/components/Proposal/View/Budget/ProposalBudget.tsx
+++ b/src/components/Proposal/View/Budget/ProposalBudget.tsx
@@ -4,7 +4,7 @@ import { Desktop } from 'decentraland-ui/dist/components/Media/Media'
 import snakeCase from 'lodash/snakeCase'
 
 import { BudgetWithContestants } from '../../../../entities/Budget/types'
-import { ProposalAttributes } from '../../../../entities/Proposal/types'
+import { ProposalAttributes, ProposalStatus } from '../../../../entities/Proposal/types'
 import { ContentSection } from '../../../Layout/ContentLayout'
 
 import CategoryTotalCard from './CategoryTotalCard'
@@ -28,7 +28,7 @@ export default function ProposalBudget({ proposal, budget }: Props) {
         <CategoryTotalCard proposal={proposal} budget={budget} />
       </div>
       <Desktop>
-        {contestantsAmount > 0 && (
+        {contestantsAmount > 0 && proposal.status === ProposalStatus.Active && (
           <div className="ProposalBudget__Row">
             <CompetingProposals proposal={proposal} budget={budget} />
           </div>

--- a/src/components/Proposal/View/Budget/RequestedBudgetCard.tsx
+++ b/src/components/Proposal/View/Budget/RequestedBudgetCard.tsx
@@ -23,7 +23,7 @@ function requestedAndTotalItems(requestedBudget: number, totalCategoryBudget: nu
   return [
     {
       value: requestedBudget,
-      className: TokenList.join(['RequestedBudgetBar']),
+      className: 'RequestedBudgetBar',
       selected: true,
     },
     {

--- a/src/components/Proposal/View/Budget/RequestedBudgetCard.tsx
+++ b/src/components/Proposal/View/Budget/RequestedBudgetCard.tsx
@@ -4,7 +4,7 @@ import useFormatMessage from 'decentraland-gatsby/dist/hooks/useFormatMessage'
 import TokenList from 'decentraland-gatsby/dist/utils/dom/TokenList'
 import snakeCase from 'lodash/snakeCase'
 
-import { BudgetWithContestants } from '../../../../entities/Budget/types'
+import { BudgetWithContestants, CategoryBudgetWithContestants } from '../../../../entities/Budget/types'
 import { ProposalAttributes, ProposalStatus } from '../../../../entities/Proposal/types'
 import { getFormattedPercentage } from '../../../../helpers'
 import DistributionBar from '../../../Common/DistributionBar/DistributionBar'
@@ -19,8 +19,47 @@ interface Props {
   budget: BudgetWithContestants
 }
 
+function requestedAndTotalItems(requestedBudget: number, totalCategoryBudget: number) {
+  return [
+    {
+      value: requestedBudget,
+      className: TokenList.join(['RequestedBudgetBar']),
+      selected: true,
+    },
+    {
+      value: totalCategoryBudget - requestedBudget,
+      className: 'RemainingBudgetBar',
+    },
+  ]
+}
+
+function allocatedRequestedAndRemainingItems(
+  allocatedCategoryBudget: number,
+  isOverBudget: boolean,
+  categoryBudget: CategoryBudgetWithContestants,
+  requestedBudget: number,
+  remainingBudgetDisplayed: number
+) {
+  return [
+    {
+      value: allocatedCategoryBudget,
+      className: TokenList.join(['AllocatedBudgetBar', isOverBudget && 'AllocatedBudgetBar--overbudget']),
+    },
+    {
+      value: isOverBudget ? categoryBudget.available : requestedBudget,
+      className: TokenList.join(['RequestedBudgetBar', isOverBudget && 'RequestedBudgetBar--overbudget']),
+      selected: true,
+    },
+    {
+      value: remainingBudgetDisplayed,
+      className: 'RemainingBudgetBar',
+    },
+  ]
+}
+
 export default function RequestedBudgetCard({ proposal, budget }: Props) {
   const t = useFormatMessage()
+  const isProposalActive = proposal.status === ProposalStatus.Active
   const grantCategory = proposal.configuration.category
   const categoryBudget = budget.categories[snakeCase(grantCategory)]
   const totalCategoryBudget = categoryBudget?.total || 0
@@ -31,31 +70,30 @@ export default function RequestedBudgetCard({ proposal, budget }: Props) {
   const isOverBudget = remainingBudget < 0
 
   const items: DistributionBarItemProps[] = useMemo(() => {
-    return [
-      {
-        value: allocatedCategoryBudget,
-        className: TokenList.join(['AllocatedBudgetBar', isOverBudget && 'AllocatedBudgetBar--overbudget']),
-      },
-      {
-        value: isOverBudget ? categoryBudget.available : requestedBudget,
-        className: TokenList.join(['RequestedBudgetBar', isOverBudget && 'RequestedBudgetBar--overbudget']),
-        selected: true,
-      },
-      {
-        value: remainingBudgetDisplayed,
-        className: 'RemainingBudgetBar',
-      },
-    ]
-  }, [allocatedCategoryBudget, requestedBudget, remainingBudgetDisplayed, categoryBudget.available, isOverBudget])
+    return isProposalActive
+      ? allocatedRequestedAndRemainingItems(
+          allocatedCategoryBudget,
+          isOverBudget,
+          categoryBudget,
+          requestedBudget,
+          remainingBudgetDisplayed
+        )
+      : requestedAndTotalItems(requestedBudget, totalCategoryBudget)
+  }, [
+    isProposalActive,
+    allocatedCategoryBudget,
+    requestedBudget,
+    remainingBudgetDisplayed,
+    categoryBudget,
+    isOverBudget,
+  ])
 
   return (
     <GrantRequestSectionCard
       title={
         <div className="RequestedBudgetCard__Title">
-          {proposal.status === ProposalStatus.Active
-            ? t('page.proposal_detail.grant.requested_budget.active_title')
-            : t('page.proposal_detail.grant.requested_budget.finished_title')}
-          {isOverBudget && (
+          {t(`page.proposal_detail.grant.requested_budget.${isProposalActive ? 'active_title' : 'finished_title'}`)}
+          {isProposalActive && isOverBudget && (
             <Pill style="outline" color={PillColor.Yellow} size={'small'}>
               {t('page.proposal_detail.grant.requested_budget.overbudget_pill')}
             </Pill>
@@ -69,16 +107,12 @@ export default function RequestedBudgetCard({ proposal, budget }: Props) {
         </div>
       }
       subtitle={
-        !isOverBudget
-          ? t('page.proposal_detail.grant.requested_budget.subtitle', {
+        isProposalActive && isOverBudget
+          ? t('page.proposal_detail.grant.requested_budget.overbudget_subtitle', {
+              amount: t('general.number', { value: categoryBudget.available }),
+            })
+          : t('page.proposal_detail.grant.requested_budget.subtitle', {
               percentage: getFormattedPercentage(requestedBudget, totalCategoryBudget, 0),
-            })
-          : proposal.status === ProposalStatus.Active
-          ? t('page.proposal_detail.grant.requested_budget.active_overbudget_subtitle', {
-              amount: t('general.number', { value: categoryBudget.available }),
-            })
-          : t('page.proposal_detail.grant.requested_budget.finished_overbudget_subtitle', {
-              amount: t('general.number', { value: categoryBudget.available }),
             })
       }
     />

--- a/src/components/Proposal/View/Budget/RequestedBudgetCard.tsx
+++ b/src/components/Proposal/View/Budget/RequestedBudgetCard.tsx
@@ -5,7 +5,7 @@ import TokenList from 'decentraland-gatsby/dist/utils/dom/TokenList'
 import snakeCase from 'lodash/snakeCase'
 
 import { BudgetWithContestants } from '../../../../entities/Budget/types'
-import { ProposalAttributes } from '../../../../entities/Proposal/types'
+import { ProposalAttributes, ProposalStatus } from '../../../../entities/Proposal/types'
 import { getFormattedPercentage } from '../../../../helpers'
 import DistributionBar from '../../../Common/DistributionBar/DistributionBar'
 import { DistributionBarItemProps } from '../../../Common/DistributionBar/DistributionBarItem'
@@ -52,7 +52,9 @@ export default function RequestedBudgetCard({ proposal, budget }: Props) {
     <GrantRequestSectionCard
       title={
         <div className="RequestedBudgetCard__Title">
-          {t('page.proposal_detail.grant.requested_budget.title')}
+          {proposal.status === ProposalStatus.Active
+            ? t('page.proposal_detail.grant.requested_budget.active_title')
+            : t('page.proposal_detail.grant.requested_budget.finished_title')}
           {isOverBudget && (
             <Pill style="outline" color={PillColor.Yellow} size={'small'}>
               {t('page.proposal_detail.grant.requested_budget.overbudget_pill')}
@@ -71,7 +73,11 @@ export default function RequestedBudgetCard({ proposal, budget }: Props) {
           ? t('page.proposal_detail.grant.requested_budget.subtitle', {
               percentage: getFormattedPercentage(requestedBudget, totalCategoryBudget, 0),
             })
-          : t('page.proposal_detail.grant.requested_budget.overbudget_subtitle', {
+          : proposal.status === ProposalStatus.Active
+          ? t('page.proposal_detail.grant.requested_budget.active_overbudget_subtitle', {
+              amount: t('general.number', { value: categoryBudget.available }),
+            })
+          : t('page.proposal_detail.grant.requested_budget.finished_overbudget_subtitle', {
               amount: t('general.number', { value: categoryBudget.available }),
             })
       }

--- a/src/intl/en.json
+++ b/src/intl/en.json
@@ -806,12 +806,14 @@
       },
       "grant": {
         "requested_budget": {
-          "title": "Requesting",
+          "active_title": "Requesting",
+          "finished_title": "Requested",
           "overbudget_pill": "Over Budget",
           "requested": "Requested Budget",
           "total": "Total Budget",
           "subtitle": "{percentage} of quarterly category budget",
-          "overbudget_subtitle": "There's only ${amount} left"
+          "active_overbudget_subtitle": "There's only ${amount} left",
+          "finished_overbudget_subtitle": "There were only ${amount} left"
         },
         "category_budget": {
           "title": "{category} Initiative",

--- a/src/intl/en.json
+++ b/src/intl/en.json
@@ -812,8 +812,7 @@
           "requested": "Requested Budget",
           "total": "Total Budget",
           "subtitle": "{percentage} of quarterly category budget",
-          "active_overbudget_subtitle": "There's only ${amount} left",
-          "finished_overbudget_subtitle": "There were only ${amount} left"
+          "overbudget_subtitle": "There's only ${amount} left"
         },
         "category_budget": {
           "title": "{category} Initiative",

--- a/src/pages/proposal.tsx
+++ b/src/pages/proposal.tsx
@@ -287,10 +287,7 @@ export default function ProposalPage() {
 
   const showImagesPreview =
     !proposalState.loading && proposal?.type === ProposalType.LinkedWearables && !!proposal.configuration.image_previews
-  const showProposalBudget =
-    proposal?.type === ProposalType.Grant &&
-    !isLoadingBudgetWithContestants &&
-    proposal.status === ProposalStatus.Active
+  const showProposalBudget = proposal?.type === ProposalType.Grant && !isLoadingBudgetWithContestants
 
   return (
     <>


### PR DESCRIPTION
Closes #923 

Display requested budget and grant category card on all finished/rejected/passed/enacted grants
