### PR TITLE
fix: hide survey topics on proposals created before 2023/04/05

### DIFF
--- a/src/pages/proposal.tsx
+++ b/src/pages/proposal.tsx
@@ -67,6 +67,7 @@ const EMPTY_VOTE_CHOICE_SELECTION: SelectedVoteChoice = { choice: undefined, cho
 const EMPTY_VOTE_CHOICES: string[] = []
 const MAX_ERRORS_BEFORE_SNAPSHOT_REDIRECT = 3
 const SECONDS_FOR_VOTING_RETRY = 5
+const SURVEY_TOPICS_FEATURE_LAUNCH = new Date(2023, 3, 5, 0, 0)
 
 export type ProposalPageState = {
   changingVote: boolean
@@ -270,7 +271,13 @@ export default function ProposalPage() {
 
   const responsive = useResponsive()
   const isMobile = responsive({ maxWidth: Responsive.onlyMobile.maxWidth })
-  const voteWithSurvey = !isLoadingSurveyTopics && !!surveyTopics && surveyTopics.length > 0 && !isMobile
+  const voteWithSurvey =
+    !isLoadingSurveyTopics &&
+    !!surveyTopics &&
+    surveyTopics.length > 0 &&
+    !isMobile &&
+    !!proposal &&
+    proposal.created_at > SURVEY_TOPICS_FEATURE_LAUNCH
 
   if (proposalState.error) {
     return (
@@ -336,7 +343,7 @@ export default function ProposalPage() {
                   isCoauthor={isCoauthor}
                 />
               )}
-              {proposal && (
+              {proposal && voteWithSurvey && (
                 <SurveyResults
                   votes={votes}
                   isLoadingVotes={votesState.loading}


### PR DESCRIPTION
Closes #928 

# Pre Launch Proposal doesn't show survey results
![image](https://user-images.githubusercontent.com/2858950/234081426-b98381ea-71a7-49ef-88b2-43c9c8c2fb4f.png)

# Post Launch proposal show survey results
![image](https://user-images.githubusercontent.com/2858950/234081557-5ea0ca0e-7f86-4e6d-bddb-6ef93dada985.png)
