### PR TITLE
fix: disable promotion button only for pitch and tender proposals

### DIFF
--- a/src/components/Proposal/View/ProposalPromotionSection.tsx
+++ b/src/components/Proposal/View/ProposalPromotionSection.tsx
@@ -80,7 +80,7 @@ export default function ProposalPromotionSection({ proposal, loading }: Props) {
         size="small"
         loading={loading}
         onClick={() => handlePromoteClick()}
-        disabled={!PROMOTE_PITCH_ENABLED || type === ProposalType.Tender}
+        disabled={(type === ProposalType.Pitch && !PROMOTE_PITCH_ENABLED) || type === ProposalType.Tender}
       >
         {t(buttonLabel)}
       </Button>


### PR DESCRIPTION
Polls are promotable

<img width="1102" alt="image" src="https://user-images.githubusercontent.com/2858950/236211080-e2c16a4c-24bb-4345-8a23-85b7ffc46d75.png">

Pitch proposals are not
<img width="325" alt="image" src="https://user-images.githubusercontent.com/2858950/236214386-5ddabb2f-53ad-4ef6-aa60-6d73e9c1e917.png">

