### PR TITLE
Fix: category assessment markdown

### DIFF
--- a/src/components/Proposal/CategoryAssessment.css
+++ b/src/components/Proposal/CategoryAssessment.css
@@ -2,7 +2,7 @@
   margin-top: 26px !important;
   font-size: 13px;
   text-transform: uppercase;
-  font-weight: var(--weight-normal);
+  font-weight: var(--weight-semi-bold);
   color: var(--black-600);
 }
 

--- a/src/components/Proposal/CategoryAssessment.css
+++ b/src/components/Proposal/CategoryAssessment.css
@@ -7,11 +7,6 @@
 }
 
 .CategoryAssessment__Text {
-  color: var(--text);
-  font-size: 15px;
-  font-weight: var(--weight-light);
-  font-stretch: normal;
-  font-style: normal;
-  line-height: 1.81;
-  letter-spacing: 0.3px;
+  font-size: 15px !important;
+  line-height: 1.81 !important;
 }

--- a/src/components/Proposal/CategoryAssessment.tsx
+++ b/src/components/Proposal/CategoryAssessment.tsx
@@ -2,6 +2,7 @@ import React from 'react'
 
 import { NewGrantCategory } from '../../entities/Grant/types'
 import useFormatMessage from '../../hooks/useFormatMessage'
+import Markdown from '../Common/Typography/Markdown'
 
 import './CategoryAssessment.css'
 
@@ -14,7 +15,12 @@ const CategoryAssessmentItem = ({ label, children }: { label: string; children: 
   return (
     <>
       <h2 className="CategoryAssessment__Question">{label}</h2>
-      <p className="CategoryAssessment__Text">{children}</p>
+      <Markdown
+        className="CategoryAssessment__Text"
+        componentsClassNames={{ h1: 'Heading--sm', h2: 'Heading--xs', h3: 'Heading--xs' }}
+      >
+        {children}
+      </Markdown>
     </>
   )
 }


### PR DESCRIPTION
Changed heading styles to be smaller (so they are not much bigger than the section title) and title weights to match proposal sections titles

![image](https://github.com/decentraland/governance/assets/2858950/b002b936-f0a2-4f8c-8274-66b82c333519)

![image](https://github.com/decentraland/governance/assets/2858950/575260bd-d715-48cc-a9a2-27e5e236986d)
