### PR TITLE
fix: rename rollbar body vars

### DIFF
--- a/src/clients/ErrorClient.ts
+++ b/src/clients/ErrorClient.ts
@@ -5,13 +5,13 @@ import { Governance } from './Governance'
 export class ErrorClient {
   static isServerSide = DAO_ROLLBAR_TOKEN && DAO_ROLLBAR_TOKEN.length > 0
 
-  public static report(errorMsg: string, data?: Record<string, unknown>) {
+  public static report(errorMsg: string, extraInfo?: Record<string, unknown>) {
     try {
       if (!this.isServerSide) {
-        Governance.get().reportErrorToServer(errorMsg, data)
+        Governance.get().reportErrorToServer(errorMsg, extraInfo)
       } else {
         const ErrorService = require('../services/ErrorService.ts')
-        ErrorService.report(errorMsg, data)
+        ErrorService.report(errorMsg, extraInfo)
       }
     } catch (e) {
       console.error('Error reporting error', e)

--- a/src/clients/Governance.ts
+++ b/src/clients/Governance.ts
@@ -417,10 +417,10 @@ export class Governance extends API {
     return response.data
   }
 
-  async reportErrorToServer(message: string, data?: Record<string, unknown>) {
+  async reportErrorToServer(message: string, extraInfo?: Record<string, unknown>) {
     const response = await this.fetch<ApiResponse<string>>(
       `/debug/report-error`,
-      this.options().method('POST').authorization({ sign: true }).json({ message, data })
+      this.options().method('POST').authorization({ sign: true }).json({ message, extraInfo })
     )
     return response.data
   }

--- a/src/components/Debug/ErrorReporting.tsx
+++ b/src/components/Debug/ErrorReporting.tsx
@@ -15,8 +15,8 @@ interface Props {
 
 export default function ErrorReporting({ className }: Props) {
   const [message, setMessage] = useState<string>('')
+  const [errorData, setErrorData] = useState<string>('{}')
   const [errorMessage, setErrorMessage] = useState<any>()
-  const [errorData, setErrorData] = useState<any>()
   const [formDisabled, setFormDisabled] = useState(false)
 
   async function reportError() {

--- a/src/entities/Debug/routes.ts
+++ b/src/entities/Debug/routes.ts
@@ -17,5 +17,5 @@ export default routes((router) => {
 })
 
 function reportClientError(req: WithAuth<Request>): void {
-  ErrorService.report(req.body.message, { client: true, ...req.body.data })
+  ErrorService.report(req.body.message, { frontend: true, ...req.body.extraInfo })
 }

--- a/src/services/ErrorService.ts
+++ b/src/services/ErrorService.ts
@@ -35,7 +35,7 @@ export class ErrorService {
 
   public static report(errorMsg: string, extraInfo?: Record<string, unknown>) {
     if (DAO_ROLLBAR_TOKEN) {
-      this.client.error(errorMsg, extraInfo)
+      this.client.error(errorMsg, { extraInfo })
     } else {
       if (isProdEnv()) logger.error('Rollbar server access token not found')
     }

--- a/src/services/ErrorService.ts
+++ b/src/services/ErrorService.ts
@@ -33,13 +33,13 @@ export class ErrorService {
     return 'production'
   }
 
-  public static report(errorMsg: string, data?: Record<string, unknown>) {
+  public static report(errorMsg: string, extraInfo?: Record<string, unknown>) {
     if (DAO_ROLLBAR_TOKEN) {
-      this.client.error(errorMsg, data)
+      this.client.error(errorMsg, extraInfo)
     } else {
       if (isProdEnv()) logger.error('Rollbar server access token not found')
     }
-    logger.error(errorMsg, data)
+    logger.error(errorMsg, extraInfo)
   }
 
   public static reportAndThrow(errorMsg: string, data: Record<string, any>) {


### PR DESCRIPTION
We are getting this in rollbar
<img width="450" alt="image" src="https://github.com/decentraland/governance/assets/2858950/c743758a-4d9d-4165-87f5-e08d2b783723">

- Errors coming from the frontend cannot be tagged with `{client: true}`, apparently it confuses rollbar. Changed it to `{frontend: true}`.
- Renamed `data` to `extraInfo`, to disencourage use of "data" tag since it is a reserved name - Grouped custom data in an `extraInfo` field.

<img width="839" alt="image" src="https://github.com/decentraland/governance/assets/2858950/b32f0d63-879b-4ba4-bf1d-e42b35e36e94">

<img width="940" alt="image" src="https://github.com/decentraland/governance/assets/2858950/e4f64789-a505-43de-b88c-13865154f75b">


Also, `DAO_ROLLBAR_TOKEN` constant is getting to the frontend when testing locally (though it should not get to the frontend in production environment). So reporting from the frontend using the ErrorClient is not working (it thinks it's in the backend and calls ErrorService, failing).

<img width="581" alt="image" src="https://github.com/decentraland/governance/assets/2858950/049a2e66-4a8a-4fd7-8282-7af35e4ce59d">

We should figure a different way to check if we are in the frontend+local from the ErrorClient.
This would work but it makes me sad:

```typescript
public static report(errorMsg: string, extraInfo?: Record<string, unknown>) {
if (isLocalEnv()) {
      try {
        const ErrorService = require('../services/ErrorService.ts')
        ErrorService.report(errorMsg, extraInfo)
      } catch (e) {
        Governance.get().reportErrorToServer(errorMsg, extraInfo)
      }
    } else {
      try {
        if (!this.isServerSide) {
          Governance.get().reportErrorToServer(errorMsg, extraInfo)
        } else {
          const ErrorService = require('../services/ErrorService.ts')
          ErrorService.report(errorMsg, extraInfo)
        }
      } catch (e) {
        console.error('Error reporting error', e)
      }
    }
}
```