### PR TITLE
chore: get profile address checks

### DIFF
--- a/src/entities/Proposal/routes.ts
+++ b/src/entities/Proposal/routes.ts
@@ -318,6 +318,9 @@ export async function createProposalHiring(req: WithAuth) {
   }
 
   if (!configuration.name) {
+    if (!isEthereumAddress(configuration.address)) {
+      throw new RequestError('Invalid address')
+    }
     try {
       const profile = await getProfile(configuration.address)
       configuration.name = profile?.name

--- a/src/hooks/useProfile.ts
+++ b/src/hooks/useProfile.ts
@@ -1,4 +1,5 @@
 import { useQuery } from '@tanstack/react-query'
+import isEthereumAddress from 'validator/lib/isEthereumAddress'
 
 import { ErrorClient } from '../clients/ErrorClient'
 import { createDefaultAvatar, getProfile } from '../utils/Catalyst'
@@ -8,7 +9,7 @@ import { DEFAULT_QUERY_STALE_TIME } from './constants'
 
 export default function useProfile(address?: string | null) {
   const fetchProfile = async () => {
-    if (!address) return null
+    if (!address || !isEthereumAddress(address)) return null
 
     try {
       const profile = await getProfile(address)


### PR DESCRIPTION
We are fetching profiles for invalid addresses

<img width="697" alt="image" src="https://github.com/decentraland/governance/assets/2858950/507028e9-9b77-4c14-aa2a-af8ef340d872">

- Added check for valid address before trying to fetch profile
- Added backend validation for hiring address (if it's not valid, don't attempt to fetch profile and avoid creating a proposal)