### PR TITLE
fix: Badge description with URL

### DIFF
--- a/src/components/User/Badges/BadgeDetail.tsx
+++ b/src/components/User/Badges/BadgeDetail.tsx
@@ -13,7 +13,17 @@ interface Props {
 }
 
 function addNewLinesAfterFirstDot(text: string): string {
-  const dotIndex = text.indexOf('.')
+  const urlRegex = /https?:\/\/[^\s)]+/g
+
+  let dotIndex = text.indexOf('.')
+  let match: RegExpExecArray | null = null
+
+  while ((match = urlRegex.exec(text)) !== null) {
+    if (dotIndex > match.index && dotIndex < match.index + match[0].length) {
+      dotIndex = text.indexOf('.', match.index + match[0].length)
+    }
+  }
+
   if (dotIndex === -1) return text
 
   const firstPart = text.substring(0, dotIndex + 1)


### PR DESCRIPTION
### Before
![image](https://github.com/decentraland/governance/assets/45410089/983d0b3b-eed4-4ee3-8f4a-71f553c13d91)

### After
![image](https://github.com/decentraland/governance/assets/45410089/fabde497-80c7-423a-b67f-56ccc2fe839d)
