### PR TITLE
feat: save action box expanded state

### DIFF
--- a/src/components/Common/ActionBox.tsx
+++ b/src/components/Common/ActionBox.tsx
@@ -23,9 +23,11 @@ interface Props {
 const ACTION_BOX_EXPANDED_STATE_KEY = 'org.decentraland.governance.action_box.expanded'
 
 function getDefaultExpanded(collapsible: boolean | undefined, localStorageKey: string) {
-  return collapsible && !!localStorage.getItem(localStorageKey)
-    ? localStorage.getItem(localStorageKey) === 'true'
-    : true
+  if (typeof window !== 'undefined') {
+    const storedState = localStorage.getItem(localStorageKey)
+    return collapsible && !!storedState ? storedState === 'true' : true
+  }
+  return true
 }
 
 export function ActionBox({ id, title, collapsedTitle, info, action, children, className, collapsible }: Props) {

--- a/src/components/Common/ActionBox.tsx
+++ b/src/components/Common/ActionBox.tsx
@@ -1,4 +1,4 @@
-import { useState } from 'react'
+import { useEffect, useState } from 'react'
 
 import classNames from 'classnames'
 
@@ -10,6 +10,7 @@ import ButtonWithArrow from './ButtonWithArrow'
 import Divider from './Divider'
 
 interface Props {
+  id?: string
   title: React.ReactNode
   collapsedTitle?: React.ReactNode
   info?: string
@@ -19,10 +20,28 @@ interface Props {
   collapsible?: boolean
 }
 
-export function ActionBox({ children, title, collapsedTitle, info, action, className, collapsible }: Props) {
-  const t = useFormatMessage()
-  const [expanded, setExpanded] = useState(true)
+const ACTION_BOX_EXPANDED_STATE_KEY = 'org.decentraland.governance.action_box.expanded'
+
+function getDefaultExpanded(collapsible: boolean | undefined, localStorageKey: string) {
+  return collapsible && !!localStorage.getItem(localStorageKey)
+    ? localStorage.getItem(localStorageKey) === 'true'
+    : true
+}
+
+export function ActionBox({ id, title, collapsedTitle, info, action, children, className, collapsible }: Props) {
+  const localStorageKey = `${ACTION_BOX_EXPANDED_STATE_KEY}-${id}`
+  const defaultExpanded = getDefaultExpanded(collapsible, localStorageKey)
   const displayedTitle = typeof title === 'string' ? <span>{title}</span> : title
+
+  const t = useFormatMessage()
+  const [expanded, setExpanded] = useState(defaultExpanded)
+
+  useEffect(() => {
+    if (collapsible && id) {
+      localStorage.setItem(localStorageKey, expanded.toString())
+    }
+  }, [id, expanded, localStorageKey, collapsible])
+
   return (
     <>
       <div className={classNames('ActionBox__Container', className)}>

--- a/src/components/Profile/PriorityProposalsBox.tsx
+++ b/src/components/Profile/PriorityProposalsBox.tsx
@@ -177,7 +177,8 @@ function PriorityProposalsBox({ address, collapsible = false }: Props) {
           collapsible
           collapsedTitle={
             <span className="PriorityProposalsBox__Title">
-              <Counter count={displayedProposals?.length} />
+              {isLoadingVotes && <Loader size="mini" active inline />}
+              {!isLoadingVotes && <Counter count={displayedProposals?.length} />}
               {t('component.priority_proposals.title')}
             </span>
           }

--- a/src/components/Profile/PriorityProposalsBox.tsx
+++ b/src/components/Profile/PriorityProposalsBox.tsx
@@ -165,6 +165,7 @@ function PriorityProposalsBox({ address, collapsible = false }: Props) {
     <div className="ProposalsPage__Priority">
       {collapsible ? (
         <ActionBox
+          id={'priority-proposals-box'}
           title={
             <span className="PriorityProposalsBox__Title">
               {isLoadingVotes && <Loader size="mini" active inline />}


### PR DESCRIPTION
<img width="1217" alt="image" src="https://github.com/decentraland/governance/assets/2858950/3125d1b9-bc71-4be4-a2f3-2458590127c8">

<img width="1214" alt="image" src="https://github.com/decentraland/governance/assets/2858950/1330b08e-1017-44de-9368-08ba653c87ba">

Also added loader to collapsed widget 

<img width="1331" alt="image" src="https://github.com/decentraland/governance/assets/2858950/833e87d6-2767-499b-acd7-dc55f6cd5a11">
