### PR TITLE
chore: limit activity ticker latest events to 50

### DIFF
--- a/src/back/models/Event.ts
+++ b/src/back/models/Event.ts
@@ -3,6 +3,8 @@ import { SQL, table } from 'decentraland-gatsby/dist/entities/Database/utils'
 
 import { Event } from '../../shared/types/events'
 
+const LATEST_EVENTS_LIMIT = 50
+
 export default class EventModel extends Model<Event> {
   static tableName = 'events'
   static withTimestamps = false
@@ -14,6 +16,7 @@ export default class EventModel extends Model<Event> {
       FROM ${table(EventModel)}
       WHERE created_at >= NOW() - INTERVAL '7 day'
       ORDER BY created_at DESC
+      LIMIT ${LATEST_EVENTS_LIMIT}
     `
     const result = await this.namedQuery<Event>('get_latest_events', query)
     return result


### PR DESCRIPTION

If limited to 5, then
<img width="585" alt="image" src="https://github.com/decentraland/governance/assets/2858950/39d90897-2fd2-4556-a902-edd42e4534db">

Ticker works fine
<img width="1455" alt="image" src="https://github.com/decentraland/governance/assets/2858950/7785a307-269d-45b0-af46-0a33126a141d">
