### PR TITLE
fix: delegation events dates

### DIFF
--- a/src/back/routes/webhooks.ts
+++ b/src/back/routes/webhooks.ts
@@ -17,12 +17,11 @@ export default routes((route) => {
 async function delegationUpdate(req: Request) {
   try {
     validateAlchemyWebhookSignature(req)
-
     const block = req.body.event.data.block as AlchemyBlock
-    if (block.logs.length === 0) {
+    if (block.transactions.length === 0) {
       return
     }
-    return await EventsService.delegationUpdate(block.logs)
+    return await EventsService.delegationUpdate(block)
   } catch (error) {
     ErrorService.report('Something failed on delegation update webhook', { error, category: ErrorCategory.Webhook })
   }

--- a/src/back/services/events.ts
+++ b/src/back/services/events.ts
@@ -15,6 +15,7 @@ import { ErrorService } from '../../services/ErrorService'
 import { DiscourseWebhookPost } from '../../shared/types/discourse'
 import {
   ActivityTickerEvent,
+  AlchemyBlock,
   AlchemyLog,
   CommentedEvent,
   DelegationClearEvent,
@@ -130,14 +131,14 @@ export class EventsService {
     }
   }
 
-  static async delegationSet(new_delegate: string, delegator: string, transaction_hash: string) {
+  static async delegationSet(new_delegate: string, delegator: string, transaction_hash: string, created_at: Date) {
     try {
       const delegationSetEvent: DelegationSetEvent = {
         id: crypto.randomUUID(),
         address: delegator,
         event_type: EventType.DelegationSet,
         event_data: { new_delegate, transaction_hash },
-        created_at: new Date(),
+        created_at,
       }
       await EventModel.create(delegationSetEvent)
     } catch (error) {
@@ -145,14 +146,19 @@ export class EventsService {
     }
   }
 
-  static async delegationClear(removed_delegate: string, delegator: string, transaction_hash: string) {
+  static async delegationClear(
+    removed_delegate: string,
+    delegator: string,
+    transaction_hash: string,
+    created_at: Date
+  ) {
     try {
       const delegationClearEvent: DelegationClearEvent = {
         id: crypto.randomUUID(),
         address: delegator,
         event_type: EventType.DelegationClear,
         event_data: { removed_delegate, transaction_hash },
-        created_at: new Date(),
+        created_at,
       }
       await EventModel.create(delegationClearEvent)
     } catch (error) {
@@ -258,27 +264,43 @@ export class EventsService {
     }
   }
 
-  static async delegationUpdate(alchemyLogs: AlchemyLog[]) {
-    const txHash = alchemyLogs[0].transaction.hash
-    if (await EventModel.isDelegationTxRegistered(txHash)) {
-      return
-    }
-    for (const log of alchemyLogs) {
-      const spaceId = ethers.utils.parseBytes32String(log.topics[2])
-      if (spaceId !== SNAPSHOT_SPACE) {
+  static async delegationUpdate(block: AlchemyBlock) {
+    const blockTimestamp = block.timestamp
+    for (const transaction of block.transactions) {
+      const txHash = transaction.hash
+      if (await EventModel.isDelegationTxRegistered(txHash)) {
         continue
       }
-      const methodSignature = log.topics[0]
-      const delegator = this.decodeTopicToAddress(log.topics[1])
-      const delegate = this.decodeTopicToAddress(log.topics[3])
-
-      if (methodSignature === CLEAR_DELEGATE_SIGNATURE_HASH) {
-        await this.delegationClear(delegate, delegator, txHash)
-      }
-      if (methodSignature === SET_DELEGATE_SIGNATURE_HASH) {
-        await this.delegationSet(delegate, delegator, txHash)
+      for (const log of transaction.logs) {
+        const { spaceId, methodSignature, delegator, delegate } = this.decodeLogTopics(log.topics)
+        if (spaceId !== SNAPSHOT_SPACE) {
+          continue
+        }
+        const creationDate = this.getContractEventDate(blockTimestamp, log)
+        if (methodSignature === CLEAR_DELEGATE_SIGNATURE_HASH) {
+          await this.delegationClear(delegate, delegator, txHash, creationDate)
+        }
+        if (methodSignature === SET_DELEGATE_SIGNATURE_HASH) {
+          await this.delegationSet(delegate, delegator, txHash, creationDate)
+        }
       }
     }
+  }
+
+  private static decodeLogTopics(topics: string[]) {
+    const methodSignature = topics[0]
+    const delegator = this.decodeTopicToAddress(topics[1])
+    const spaceId = ethers.utils.parseBytes32String(topics[2])
+    const delegate = this.decodeTopicToAddress(topics[3])
+    return { spaceId, methodSignature, delegator, delegate }
+  }
+
+  /**
+   * This is so each log event is chronologically ordered, and has the closest date
+   * to the block timestamp
+   */
+  private static getContractEventDate(blockTimestamp: number, log: AlchemyLog) {
+    return new Date(blockTimestamp * 1000 + log.index)
   }
 
   private static decodeTopicToAddress(topic: string) {

--- a/src/entities/Proposal/jobs.ts
+++ b/src/entities/Proposal/jobs.ts
@@ -172,12 +172,21 @@ async function prepareProposalsAndBudgetsUpdates(
   }
 }
 
+function logFinishableProposals(finishableProposals: ProposalAttributes[]) {
+  if (isProdEnv()) {
+    logger.log(`Finishable proposals:`)
+    finishableProposals.forEach((proposal, index) => {
+      console.log(`${index}: ${proposal.id} - ${proposal.title}`)
+    })
+  }
+}
+
 export async function finishProposal() {
   logger.log(`Running finish proposal job...`)
 
   try {
     const finishableProposals = await ProposalModel.getFinishableProposals()
-    logger.log(`Finishable proposals`, finishableProposals)
+    logFinishableProposals(finishableProposals)
     if (finishableProposals.length === 0) {
       return
     }

--- a/src/shared/types/events.ts
+++ b/src/shared/types/events.ts
@@ -88,7 +88,7 @@ export type AlchemyBlock = {
   hash: string
   number: number
   timestamp: number
-  logs: AlchemyLog[]
+  transactions: AlchemyTransaction[]
 }
 
 export type AlchemyLog = {
@@ -105,4 +105,5 @@ export type AlchemyTransaction = {
   from: {
     address: string
   }
+  logs: AlchemyLog[]
 }


### PR DESCRIPTION
This PR requires a change in `ops-param-governance-alchemy-delegations-webhook-secret` for prd and zone

Events are now saved in order of tx confirmation.

Creation date is almost the same for events of the same transaction, with a ms difference according to the log index. There shouldn't be more than two events for each tx log (clear/set).

Also, there shouldn't be a problem if there are two tx confirmed in the same block (though it would be very unlikely). 
Worst case scenario, we have 2 `clear` events with same created_at and 2 `set` events with same created_at, but different tx hashes and for different addresses, so it would read:

```md
X set delegation to A
Z set delegation to B
X removed delegation from Y
Z removed delegation from W
```

<img width="1334" alt="image" src="https://github.com/decentraland/governance/assets/2858950/615cde31-f9bd-4d40-a4b5-60ecd48c62f5">

<img width="1440" alt="image" src="https://github.com/decentraland/governance/assets/2858950/ee529836-f060-476d-80ae-e90ba7dccec9">

