### PR TITLE
chore: remove old discourse comments endpoint

### DIFF
--- a/src/back/routes/events.ts
+++ b/src/back/routes/events.ts
@@ -5,14 +5,11 @@ import routes from 'decentraland-gatsby/dist/entities/Route/routes'
 import { EventsService } from '../services/events'
 import { validateDebugAddress, validateProposalId, validateRequiredString } from '../utils/validations'
 
-import { discourseComment } from './webhooks'
-
 export default routes((route) => {
   const withAuth = auth()
   route.get('/events', handleAPI(getLatestEvents))
   route.get('/events/all', withAuth, handleAPI(getAllEvents))
   route.post('/events/voted', withAuth, handleAPI(voted))
-  route.post('/events/discourse/new', handleAPI(discourseComment)) //TODO: deprecate
 })
 
 async function getLatestEvents() {


### PR DESCRIPTION
Prod discourse webhook has been updated ✅ 