### PR TITLE
chore: remove strategic unit badge cid from fetched badges

### DIFF
--- a/src/constants.ts
+++ b/src/constants.ts
@@ -53,7 +53,6 @@ export const CORE_UNITS_BADGE_CID = [
   'bafyreidmzou4wiy2prxq4jdyg66z7s3wulpfq2a7ar6sdkrixrj3b5mgwe', // Governance Squad
   'bafyreih5t62qmeiugca6bp7dtubrd3ponqfndbim54e3vg4cfbroledohq', // Grant Support Squad
   'bafyreicsrpymlwm4hutebi2qio3e5hhzpqtyr6fv3ei6nsybb3vannhfgy', // Facilitation Squad
-  'bafyreigm5fqqryvoboszxbrzeks5jihsc4mwb4mq26csdmooaju5g7ksja', // Strategic Unit Squad
 ]
 export const DEBUG_ADDRESSES = (process.env.DEBUG_ADDRESSES || '')
   .split(',')


### PR DESCRIPTION
Once merged, cache key `core-units-badges` needs to be invalidated in prod (or wait 24hs)

<img width="1437" alt="image" src="https://github.com/decentraland/governance/assets/2858950/034bc1b9-ec34-4263-85da-66a2d07f4b64">
