### PR TITLE
chore: add basic project info to proposal data on proposals endpoint

### DIFF
--- a/src/back/routes/proposal.ts
+++ b/src/back/routes/proposal.ts
@@ -131,7 +131,7 @@ export default routes((route) => {
   route.post('/proposals/hiring', withAuth, handleAPI(createProposalHiring))
   route.get('/proposals/priority/:address?', handleJSON(getPriorityProposals))
   route.get('/proposals/grants/:address', handleAPI(getGrantsByUser))
-  route.get('/proposals/:proposal', handleAPI(getProposal))
+  route.get('/proposals/:proposal', handleAPI(getProposalWithProject))
   route.patch('/proposals/:proposal', withAuth, handleAPI(updateProposalStatus))
   route.delete('/proposals/:proposal', withAuth, handleAPI(removeProposal))
   route.get('/proposals/:proposal/comments', handleAPI(getProposalComments))
@@ -528,6 +528,15 @@ export async function getProposal(req: Request<{ proposal: string }>) {
   const id = validateProposalId(req.params.proposal)
   try {
     return await ProposalService.getProposal(id)
+  } catch (e) {
+    throw new RequestError(`Proposal "${id}" not found`, RequestError.NotFound)
+  }
+}
+
+export async function getProposalWithProject(req: Request<{ proposal: string }>) {
+  const id = validateProposalId(req.params.proposal)
+  try {
+    return await ProposalService.getProposalWithProject(id)
   } catch (e) {
     throw new RequestError(`Proposal "${id}" not found`, RequestError.NotFound)
   }

--- a/src/entities/Proposal/types.ts
+++ b/src/entities/Proposal/types.ts
@@ -70,6 +70,11 @@ export type ProposalAttributes<C extends Record<string, unknown> = any> = {
   textsearch: SQLStatement | string | null | undefined
 }
 
+export interface ProposalWithProject extends ProposalAttributes {
+  project_id?: string | null
+  project_status?: ProjectStatus | null
+}
+
 export type ProposalListFilter = {
   user: string
   type: ProposalType

--- a/src/services/ProposalService.ts
+++ b/src/services/ProposalService.ts
@@ -217,6 +217,15 @@ export class ProposalService {
     return ProposalModel.parse(proposal)
   }
 
+  static async getProposalWithProject(id: string) {
+    const proposal = await ProposalModel.getProposalWithProject(id)
+    if (!proposal) {
+      throw new Error(`Proposal not found: "${id}"`)
+    }
+    console.log('proposal', proposal)
+    return proposal
+  }
+
   static getFinishProposalQueries(proposalsWithOutcome: ProposalWithOutcome[]) {
     const proposalUpdateQueriesByStatus: SQLStatement[] = []
     Object.values(ProposalStatus).forEach((proposalStatus) => {


### PR DESCRIPTION
Part of #1763 

Change single proposal endpoint to include basic project attributes on the response, so we can link to the project from the proposal page

<img width="477" alt="image" src="https://github.com/decentraland/governance/assets/2858950/2140985f-0b40-4af5-bce6-4f50d030ce31">

<img width="322" alt="image" src="https://github.com/decentraland/governance/assets/2858950/217f42db-20a9-4134-89f8-148c2494c6b9">
