### PR TITLE
fix: use timing-safe webhook signature comparison and block image-validation redirects

### DIFF
--- a/src/utils/validations.ts
+++ b/src/utils/validations.ts
@@ -137,7 +137,9 @@ export function validateDiscourseWebhookSignature(req: Request) {
     crypto.createHmac('sha256', DISCOURSE_WEBHOOK_SECRET).update(JSON.stringify(payload)).digest('hex')
   )
 
-  if (providedSignature !== calculatedSignature) {
+  const provided = Buffer.from(providedSignature)
+  const calculated = Buffer.from(calculatedSignature)
+  if (provided.length !== calculated.length || !crypto.timingSafeEqual(provided, calculated)) {
     ErrorService.report('Invalid discourse webhook signature', { category: ErrorCategory.Discourse })
     throw new RequestError('Invalid signature', RequestError.Forbidden)
   }
@@ -152,7 +154,9 @@ export function validateAlchemyWebhookSignature(req: Request) {
   const hmac = crypto.createHmac('sha256', ALCHEMY_DELEGATIONS_WEBHOOK_SECRET)
   hmac.update(body, 'utf8')
   const digest = hmac.digest('hex')
-  if (signature !== digest) {
+  const provided = Buffer.from(signature || '')
+  const digestBuffer = Buffer.from(digest)
+  if (provided.length !== digestBuffer.length || !crypto.timingSafeEqual(provided, digestBuffer)) {
     ErrorService.report('Invalid alchemy webhook signature', { category: ErrorCategory.Webhook })
     throw new RequestError('Invalid signature', RequestError.Forbidden)
   }
@@ -289,8 +293,14 @@ export async function isValidImage(imageUrl: string) {
   }
 
   return new Promise<boolean>((resolve) => {
-    fetch(imageUrl)
+    // Do not follow redirects: a URL on a trusted domain could 3xx-redirect to an
+    // internal host (e.g. 169.254.169.254), turning this check into an SSRF.
+    fetch(imageUrl, { redirect: 'manual' })
       .then((response) => {
+        if (!response.ok) {
+          resolve(false)
+          return
+        }
         const mime = response.headers.get('content-type')
         resolve(!!mime && allowedImageTypes.has(mime))
       })

--- a/src/utils/validations.ts
+++ b/src/utils/validations.ts
@@ -127,6 +127,13 @@ export function validateDebugAddress(user: string | undefined) {
   }
 }
 
+// Constant-time comparison of two signature strings (guards against length leak).
+function timingSafeStringEqual(a: string, b: string): boolean {
+  const bufA = Buffer.from(a)
+  const bufB = Buffer.from(b)
+  return bufA.length === bufB.length && crypto.timingSafeEqual(bufA, bufB)
+}
+
 export function validateDiscourseWebhookSignature(req: Request) {
   const providedSignature = req.get('X-Discourse-Event-Signature') || ''
   if (!DISCOURSE_WEBHOOK_SECRET || DISCOURSE_WEBHOOK_SECRET.length === 0) {
@@ -137,9 +144,7 @@ export function validateDiscourseWebhookSignature(req: Request) {
     crypto.createHmac('sha256', DISCOURSE_WEBHOOK_SECRET).update(JSON.stringify(payload)).digest('hex')
   )
 
-  const provided = Buffer.from(providedSignature)
-  const calculated = Buffer.from(calculatedSignature)
-  if (provided.length !== calculated.length || !crypto.timingSafeEqual(provided, calculated)) {
+  if (!timingSafeStringEqual(providedSignature, calculatedSignature)) {
     ErrorService.report('Invalid discourse webhook signature', { category: ErrorCategory.Discourse })
     throw new RequestError('Invalid signature', RequestError.Forbidden)
   }
@@ -154,9 +159,7 @@ export function validateAlchemyWebhookSignature(req: Request) {
   const hmac = crypto.createHmac('sha256', ALCHEMY_DELEGATIONS_WEBHOOK_SECRET)
   hmac.update(body, 'utf8')
   const digest = hmac.digest('hex')
-  const provided = Buffer.from(signature || '')
-  const digestBuffer = Buffer.from(digest)
-  if (provided.length !== digestBuffer.length || !crypto.timingSafeEqual(provided, digestBuffer)) {
+  if (!timingSafeStringEqual(signature || '', digest)) {
     ErrorService.report('Invalid alchemy webhook signature', { category: ErrorCategory.Webhook })
     throw new RequestError('Invalid signature', RequestError.Forbidden)
   }


### PR DESCRIPTION
## What

Two hardening fixes in `src/utils/validations.ts`:

1. **Webhook signature comparison was not constant-time.** `validateDiscourseWebhookSignature` and `validateAlchemyWebhookSignature` compared the provided HMAC against the computed one with `!==` on strings, which short-circuits on the first differing byte (timing side-channel on the webhook secret). A forged Alchemy webhook can inject delegation events; a forged Discourse webhook can inject comment events.

2. **Image validation could be used as an SSRF.** `isValidImage` validated only the initial hostname against an allowlist and then `fetch`ed the URL following redirects. A URL on a trusted domain that 3xx-redirects to an internal host (e.g. `169.254.169.254`) would be fetched. Reached via image URLs in proposal markdown.

## Change

1. Compare signatures with `crypto.timingSafeEqual` over equal-length buffers.
2. `fetch(imageUrl, { redirect: 'manual' })` and reject non-2xx, so a redirect from a trusted domain is not followed.

Note: if any legitimate trusted image host relies on 3xx redirects, validation of those URLs will now fail — adjust if needed.

## Verification

- `tsc --noEmit` clean; eslint clean on the changed file.