### PR TITLE
feat: support undo enacted proposals

### DIFF
--- a/src/entities/Proposal/utils.test.ts
+++ b/src/entities/Proposal/utils.test.ts
@@ -55,6 +55,10 @@ describe('isValidUpdateProposalStatus', () => {
     expect(isValidProposalStatusUpdate(ProposalStatus.Deleted, ProposalStatus.Enacted)).toBe(false)
   })
 
+  it('can update an enacted proposal back to passed', () => {
+    expect(isValidProposalStatusUpdate(ProposalStatus.Enacted, ProposalStatus.Passed)).toBe(true)
+  })
+
   it('returns false for Pending, Active, Rejected, OutOfBudget and Deleted statuses', () => {
     Object.values(ProposalStatus).forEach((status) => {
       expect(isValidProposalStatusUpdate(ProposalStatus.Pending, status)).toBe(false)

--- a/src/entities/Proposal/utils.ts
+++ b/src/entities/Proposal/utils.ts
@@ -81,8 +81,9 @@ export function isValidProposalStatusUpdate(current: ProposalStatus, next: Propo
         next === ProposalStatus.OutOfBudget
       )
     case ProposalStatus.Passed:
-    case ProposalStatus.Enacted:
       return next === ProposalStatus.Enacted
+    case ProposalStatus.Enacted:
+      return next === ProposalStatus.Enacted || next === ProposalStatus.Passed
     default:
       return false
   }

--- a/src/services/ProposalService.test.ts
+++ b/src/services/ProposalService.test.ts
@@ -1,0 +1,87 @@
+import ProposalModel from '../entities/Proposal/model'
+import { createTestProposal } from '../entities/Proposal/testHelpers'
+import { ProposalStatus, ProposalType, ProposalWithProject } from '../entities/Proposal/types'
+
+import { DiscourseService } from './DiscourseService'
+import { ProposalService } from './ProposalService'
+
+jest.mock('../services/discord', () => ({
+  DiscordService: {
+    init: jest.fn(),
+  },
+}))
+
+jest.mock('../services/events', () => ({
+  EventsService: {
+    projectEnacted: jest.fn(),
+  },
+}))
+
+jest.mock('../services/notification', () => ({
+  NotificationService: {
+    projectProposalEnacted: jest.fn(),
+  },
+}))
+
+jest.mock('../services/update', () => ({
+  UpdateService: {
+    createPendingUpdatesForVesting: jest.fn(),
+  },
+}))
+
+jest.mock('./DiscourseService', () => ({
+  DiscourseService: {
+    commentUpdatedProposal: jest.fn(),
+    createProposal: jest.fn(),
+  },
+}))
+
+describe('ProposalService', () => {
+  afterEach(() => {
+    jest.restoreAllMocks()
+  })
+
+  describe('updateProposalStatus', () => {
+    it('clears enactment metadata when an enacted proposal is reverted to passed', async () => {
+      const user = '0x2AC89522CB415AC333E64F52a1a5693218cEBD58'
+      const passedBy = '0x56d0B5eD3D525332F00C9BC938f93598ab16AAA7'
+      const proposal: ProposalWithProject = {
+        ...createTestProposal(ProposalType.Draft, ProposalStatus.Enacted),
+        enacted: true,
+        enacted_by: user,
+        enacted_description: 'Marked as enacted by mistake',
+        enacting_tx: '0x123',
+        passed_by: passedBy,
+        personnel: [],
+      }
+      const updateSpy = jest.spyOn(ProposalModel, 'update').mockResolvedValue({} as never)
+
+      const updatedProposal = await ProposalService.updateProposalStatus(
+        proposal,
+        { status: ProposalStatus.Passed },
+        user
+      )
+
+      expect(updateSpy).toHaveBeenCalledWith(
+        expect.objectContaining({
+          status: ProposalStatus.Passed,
+          enacted: false,
+          enacted_by: null,
+          enacted_description: null,
+          enacting_tx: null,
+        }),
+        { id: proposal.id }
+      )
+      expect(updateSpy.mock.calls[0][0]).not.toHaveProperty('passed_by')
+      expect(updatedProposal).toMatchObject({
+        status: ProposalStatus.Passed,
+        enacted: false,
+        enacted_by: null,
+        enacted_description: null,
+        enacting_tx: null,
+        passed_by: passedBy,
+      })
+      expect(DiscourseService.commentUpdatedProposal).toHaveBeenCalledWith(updatedProposal)
+    })
+  })
+})

--- a/src/services/ProposalService.ts
+++ b/src/services/ProposalService.ts
@@ -283,6 +283,7 @@ export class ProposalService {
     const { id } = proposal
     const isProject = isProjectProposal(proposal.type)
     const isEnactedStatus = newStatus === ProposalStatus.Enacted
+    const isRevertedEnactedStatus = proposal.status === ProposalStatus.Enacted && newStatus === ProposalStatus.Passed
     const updated_at = new Date()
     let update: Partial<ProposalAttributes> = {
       status: newStatus,
@@ -291,6 +292,8 @@ export class ProposalService {
 
     if (isEnactedStatus) {
       update = { ...update, ...this.getEnactedStatusData(proposal, vesting_addresses, user) }
+    } else if (isRevertedEnactedStatus) {
+      update = { ...update, ...this.getRevertedEnactedStatusData() }
     } else if (newStatus === ProposalStatus.Passed) {
       update.passed_by = user
     } else if (newStatus === ProposalStatus.Rejected) {
@@ -334,6 +337,15 @@ export class ProposalService {
       )
     }
     return update
+  }
+
+  private static getRevertedEnactedStatusData(): Partial<ProposalAttributes> {
+    return {
+      enacted: false,
+      enacted_by: null,
+      enacted_description: null,
+      enacting_tx: null,
+    }
   }
 
   static async findContributorsForProposalsByVestings(vestingAddresses: string[]) {

--- a/src/utils/validations.test.ts
+++ b/src/utils/validations.test.ts
@@ -1,8 +1,10 @@
 import RequestError from 'decentraland-gatsby/dist/entities/Route/error'
 
+import { createTestProposal } from '../entities/Proposal/testHelpers'
+import { ProposalStatus, ProposalType } from '../entities/Proposal/types'
 import { EventType } from '../shared/types/events'
 
-import { validateEventFilters, validateId } from './validations'
+import { validateEventFilters, validateId, validateStatusUpdate } from './validations'
 
 describe('validateProposalId', () => {
   const UUID = '00000000-0000-0000-0000-000000000000'
@@ -47,6 +49,32 @@ describe('validateEventTypesFilters', () => {
     const req = { query: { event_type: 'single_event' } } as never
 
     expect(() => validateEventFilters(req)).toThrow()
+  })
+})
+
+describe('validateStatusUpdate', () => {
+  it('allows reverting an enacted draft proposal back to passed', () => {
+    const proposal = createTestProposal(ProposalType.Draft, ProposalStatus.Enacted)
+
+    expect(() => validateStatusUpdate(proposal, { status: ProposalStatus.Passed })).not.toThrow()
+  })
+
+  it('does not allow poll proposals to be enacted', () => {
+    const proposal = createTestProposal(ProposalType.Poll, ProposalStatus.Passed)
+
+    expect(() => validateStatusUpdate(proposal, { status: ProposalStatus.Enacted })).toThrow(RequestError)
+  })
+
+  it('does not allow draft proposals to be enacted', () => {
+    const proposal = createTestProposal(ProposalType.Draft, ProposalStatus.Passed)
+
+    expect(() => validateStatusUpdate(proposal, { status: ProposalStatus.Enacted })).toThrow(RequestError)
+  })
+
+  it('allows governance proposals to be enacted', () => {
+    const proposal = createTestProposal(ProposalType.Governance, ProposalStatus.Passed)
+
+    expect(() => validateStatusUpdate(proposal, { status: ProposalStatus.Enacted })).not.toThrow()
   })
 })
 

--- a/src/utils/validations.ts
+++ b/src/utils/validations.ts
@@ -10,7 +10,7 @@ import { ALCHEMY_DELEGATIONS_WEBHOOK_SECRET, DISCOURSE_WEBHOOK_SECRET } from '..
 import isDAOCouncil from '../entities/Council/IsDAOCouncil'
 import isDebugAddress from '../entities/Debug/isDebugAddress'
 import { ProjectStatus } from '../entities/Grant/types'
-import { ProposalAttributes, ProposalStatus, ProposalStatusUpdate } from '../entities/Proposal/types'
+import { ProposalAttributes, ProposalStatus, ProposalStatusUpdate, ProposalType } from '../entities/Proposal/types'
 import { isProjectProposal, isValidProposalStatusUpdate } from '../entities/Proposal/utils'
 import { validateUniqueAddresses } from '../entities/Transparency/utils'
 import { ErrorService } from '../services/ErrorService'
@@ -186,6 +186,9 @@ export function validateStatusUpdate(proposal: ProposalAttributes, statusUpdate:
   const { status: newStatus, vesting_addresses } = statusUpdate
   if (!isValidProposalStatusUpdate(proposal.status, newStatus)) {
     throw new RequestError(`${proposal.status} can't be updated to ${newStatus}`, RequestError.BadRequest, statusUpdate)
+  }
+  if (newStatus === ProposalStatus.Enacted && [ProposalType.Poll, ProposalType.Draft].includes(proposal.type)) {
+    throw new RequestError(`${proposal.type} proposals can't be enacted`, RequestError.BadRequest, statusUpdate)
   }
   if (newStatus === ProposalStatus.Enacted && isProjectProposal(proposal.type)) {
     if (!vesting_addresses || vesting_addresses.length === 0) {


### PR DESCRIPTION
## Summary

Adds backend support for undoing accidental proposal enactment and prevents POLL/DRAFT proposals from being enacted going forward.

## Context

Proposal enactment is stored as metadata in the Governance API database, not in Snapshot. A DRAFT proposal was accidentally marked as ENACTED, which left it stuck in a DRAFT-ENACTED state and unable to continue the normal governance process toward a GOVERNANCE proposal.

Affected proposal: https://decentraland.org/governance/proposal/?id=917e38cf-c777-4d81-b4e2-bbc740d66599

## Changes

- Allows proposal status updates from `enacted` back to `passed`.
- Clears local enactment metadata when reverting an enacted proposal:
  - `enacted`
  - `enacted_by`
  - `enacted_description`
  - `enacting_tx`
- Prevents `poll` and `draft` proposals from being enacted going forward.
- Keeps `governance` proposals enactable.
- Adds tests for the rollback flow and the new enactment restrictions.

## Testing

- `npm run build`
- `npm test`