### PR TITLE
chore: pin node 24 base image to sha256 digest

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM node:24-alpine as compiler
+FROM node:24-alpine@sha256:5fa278c599dbba0c8f873d8717d50ecbb57c5ae6a53b7ab240c25135e0b65995 as compiler
 ARG version_number
 ARG heroku_app_name
 ARG FRONT_BUILD_NODE_OPTIONS="--max-old-space-size=4096"
@@ -36,7 +36,7 @@ COPY ./.babelrc.json                          /app/.babelrc.json
 RUN NODE_OPTIONS="--max-old-space-size=4096" npm run build
 RUN npm prune --production --ignore-scripts
 
-FROM node:24-alpine
+FROM node:24-alpine@sha256:5fa278c599dbba0c8f873d8717d50ecbb57c5ae6a53b7ab240c25135e0b65995
 WORKDIR /app
 
 RUN rm -rf \


### PR DESCRIPTION
Pins both `node:24-alpine` stages (compiler + runtime) to an immutable sha256 digest (`5fa278…`) for reproducible builds. No variant change — the repo already builds its native deps against musl on alpine.