### PR TITLE
fix: security and correctness hardening from backend audit

### DIFF
--- a/src/clients/API.ts
+++ b/src/clients/API.ts
@@ -9,6 +9,7 @@ import { toBase64 } from './base64'
 
 type HttpMethod = 'GET' | 'POST' | 'PUT' | 'DELETE' | 'PATCH'
 const METHODS_WITH_BODY: HttpMethod[] = ['POST', 'PUT', 'PATCH']
+const DEFAULT_REQUEST_TIMEOUT_MS = 30000
 
 export type ApiOptions = {
   method: HttpMethod
@@ -37,11 +38,22 @@ export default abstract class API {
       ...authAndSignatureHeaders,
     }
 
-    const response = await fetch(this.url(endpoint), {
-      method,
-      headers: finalHeaders,
-      body: json ? JSON.stringify(json) : undefined,
-    })
+    const controller = new AbortController()
+    const timeoutId = setTimeout(() => controller.abort(), DEFAULT_REQUEST_TIMEOUT_MS)
+    let response: Response
+    try {
+      response = await fetch(this.url(endpoint), {
+        method,
+        headers: finalHeaders,
+        body: json ? JSON.stringify(json) : undefined,
+        // Do not follow redirects: these requests carry secret headers (e.g. Discourse
+        // Api-Key, Snapshot x-api-key) that would be re-sent to a redirect target.
+        redirect: 'manual',
+        signal: controller.signal,
+      })
+    } finally {
+      clearTimeout(timeoutId)
+    }
 
     await this.checkForErrors(response)
 

--- a/src/clients/OtterspaceSubgraph.ts
+++ b/src/clients/OtterspaceSubgraph.ts
@@ -1,7 +1,7 @@
 import { OTTERSPACE_DAO_RAFT_ID, OTTERSPACE_QUERY_ENDPOINT } from '../entities/Snapshot/constants'
 import { isProdEnv } from '../utils/governanceEnvs'
 
-import { inBatches, trimLastForwardSlash } from './utils'
+import { fetchWithTimeout, inBatches, trimLastForwardSlash } from './utils'
 
 const BADGES_QUERY = `
 query Badges($raft_id: String!, $address: Bytes!, $first: Int!, $skip: Int!) {
@@ -160,7 +160,7 @@ export class OtterspaceSubgraph {
   async getBadgesForAddress(address: string) {
     const badges: OtterspaceBadge[] = await inBatches(
       async (vars, skip, first) => {
-        const response = await fetch(this.queryEndpoint, {
+        const response = await fetchWithTimeout(this.queryEndpoint, {
           method: 'post',
           headers: { 'Content-Type': 'application/json' },
           body: JSON.stringify({
@@ -184,7 +184,7 @@ export class OtterspaceSubgraph {
   async getBadges(badgeCid: string) {
     return await inBatches(
       async (vars, skip, first) => {
-        const response = await fetch(this.queryEndpoint, {
+        const response = await fetchWithTimeout(this.queryEndpoint, {
           method: 'post',
           headers: { 'Content-Type': 'application/json' },
           body: JSON.stringify({
@@ -205,7 +205,7 @@ export class OtterspaceSubgraph {
   async getRecipientsBadgeIds(badgeCid: string, addresses: string[]): Promise<BadgeOwnership[]> {
     const badges: Pick<OtterspaceBadge, 'id' | 'owner'>[] = await inBatches(
       async (vars, skip, first) => {
-        const response = await fetch(this.queryEndpoint, {
+        const response = await fetchWithTimeout(this.queryEndpoint, {
           method: 'post',
           headers: { 'Content-Type': 'application/json' },
           body: JSON.stringify({
@@ -230,7 +230,7 @@ export class OtterspaceSubgraph {
   async getBadgeSpecByTitle(title: string) {
     const badgeSpecs: OtterspaceBadgeSpec[] = await inBatches(
       async (vars, skip, first) => {
-        const response = await fetch(this.queryEndpoint, {
+        const response = await fetchWithTimeout(this.queryEndpoint, {
           method: 'post',
           headers: { 'Content-Type': 'application/json' },
           body: JSON.stringify({

--- a/src/clients/PolygonGasStation.ts
+++ b/src/clients/PolygonGasStation.ts
@@ -5,6 +5,8 @@ import { ErrorService } from '../services/ErrorService'
 import { PolygonGasStationResponse } from '../types/PolygonGasStation'
 import { ErrorCategory } from '../utils/errorCategories'
 
+import { fetchWithTimeout } from './utils'
+
 const POLYGON_GAS_STATION_URL = 'https://gasstation.polygon.technology/v2'
 
 // Gwei has 9 decimals; the gas station returns floats that can exceed that precision,
@@ -16,7 +18,7 @@ function parseGwei(value: number): ethers.BigNumber {
 export class PolygonGasStation {
   static async getPolygonGasData(): Promise<PolygonGasData> {
     try {
-      const response = await fetch(POLYGON_GAS_STATION_URL, {
+      const response = await fetchWithTimeout(POLYGON_GAS_STATION_URL, {
         method: 'GET',
         headers: {
           'Content-Type': 'application/json',

--- a/src/clients/SnapshotSubgraph.ts
+++ b/src/clients/SnapshotSubgraph.ts
@@ -2,7 +2,7 @@ import { SNAPSHOT_QUERY_ENDPOINT } from '../entities/Snapshot/constants'
 import { PICKED_BY_QUERY, getDelegatedQuery } from '../entities/Snapshot/queries'
 
 import { Delegation } from './SnapshotTypes'
-import { inBatches, trimLastForwardSlash } from './utils'
+import { inBatches, queryGraphql, trimLastForwardSlash } from './utils'
 
 export type DelegationQueryResult = {
   delegatedTo: Delegation[]
@@ -50,16 +50,10 @@ export class SnapshotSubgraph {
   ) {
     const delegations: Delegation[] = await inBatches(
       async (vars, skip, first) => {
-        const response = await fetch(this.queryEndpoint, {
-          method: 'post',
-          headers: { 'Content-Type': 'application/json' },
-          body: JSON.stringify({
-            query: getDelegatedQuery(key, variables.blockNumber),
-            variables: { ...vars, skip, first },
-          }),
+        const body = await queryGraphql<{ data?: Record<string, Delegation[]> }>(this.queryEndpoint, {
+          query: getDelegatedQuery(key, variables.blockNumber),
+          variables: { ...vars, skip, first },
         })
-
-        const body = await response.json()
         return body?.data?.[key] || []
       },
       { ...variables },
@@ -76,16 +70,10 @@ export class SnapshotSubgraph {
 
     const delegations: Delegation[] = await inBatches(
       async (vars, skip, batchSize) => {
-        const response = await fetch(this.queryEndpoint, {
-          method: 'post',
-          headers: { 'Content-Type': 'application/json' },
-          body: JSON.stringify({
-            query: PICKED_BY_QUERY,
-            variables: { ...vars, skip, first: batchSize },
-          }),
+        const body = await queryGraphql<{ data?: { delegatedFrom?: Delegation[] } }>(this.queryEndpoint, {
+          query: PICKED_BY_QUERY,
+          variables: { ...vars, skip, first: batchSize },
         })
-
-        const body = await response.json()
         return body?.data?.delegatedFrom || []
       },
       { address: addresses, space },

--- a/src/clients/Transparency.ts
+++ b/src/clients/Transparency.ts
@@ -2,6 +2,7 @@ import { TokenInWallet } from '../entities/Transparency/types'
 import { ErrorCategory } from '../utils/errorCategories'
 
 import { ErrorClient } from './ErrorClient'
+import { fetchWithTimeout } from './utils'
 
 export type Detail = {
   name: string
@@ -81,7 +82,7 @@ const API_URL = process.env.GATSBY_DCL_DATA_API || 'https://data.decentraland.vo
 export class Transparency {
   static async getData() {
     try {
-      const response = (await (await fetch(`${API_URL}/api.json`)).json()) as TransparencyData
+      const response = (await (await fetchWithTimeout(`${API_URL}/api.json`)).json()) as TransparencyData
       return response
     } catch (error) {
       ErrorClient.report('Failed to fetch transparency data', { error, category: ErrorCategory.Transparency })
@@ -91,7 +92,7 @@ export class Transparency {
 
   static async getBudgets() {
     try {
-      const response = (await (await fetch(`${API_URL}/budgets.json`)).json()) as TransparencyBudget[]
+      const response = (await (await fetchWithTimeout(`${API_URL}/budgets.json`)).json()) as TransparencyBudget[]
       return response
     } catch (error) {
       ErrorClient.report('Failed to fetch transparency budgets data', { error, category: ErrorCategory.Transparency })
@@ -101,7 +102,7 @@ export class Transparency {
 
   static async getTeams() {
     try {
-      const response = (await (await fetch(`${API_URL}/teams.json`)).json()) as TransparencyTeams
+      const response = (await (await fetchWithTimeout(`${API_URL}/teams.json`)).json()) as TransparencyTeams
       return response
     } catch (error) {
       ErrorClient.report('Failed to fetch transparency data', { error, category: ErrorCategory.Transparency })

--- a/src/clients/VestingsSubgraph.ts
+++ b/src/clients/VestingsSubgraph.ts
@@ -2,7 +2,7 @@ import { VESTINGS_QUERY_ENDPOINT } from '../entities/Snapshot/constants'
 import Time from '../utils/date/Time'
 
 import { SubgraphVesting } from './VestingSubgraphTypes'
-import { trimLastForwardSlash } from './utils'
+import { fetchWithTimeout, trimLastForwardSlash } from './utils'
 
 const OLDEST_INDEXED_BLOCK = 20463272
 
@@ -75,7 +75,7 @@ export class VestingsSubgraph {
     }
     `
     const variables = { address: address.toLowerCase() }
-    const response = await fetch(this.queryEndpoint, {
+    const response = await fetchWithTimeout(this.queryEndpoint, {
       method: 'post',
       headers: { 'Content-Type': 'application/json' },
       body: JSON.stringify({
@@ -104,7 +104,7 @@ export class VestingsSubgraph {
     const variables = queryAddresses
       ? { addresses: addresses.map((address) => address.toLowerCase()) }
       : { blockNumber: OLDEST_INDEXED_BLOCK }
-    const response = await fetch(this.queryEndpoint, {
+    const response = await fetchWithTimeout(this.queryEndpoint, {
       method: 'post',
       headers: { 'Content-Type': 'application/json' },
       body: JSON.stringify({
@@ -130,7 +130,7 @@ export class VestingsSubgraph {
     `
 
     const variables = { currentTimestamp, aDayAgoTimestamp }
-    const response = await fetch(this.queryEndpoint, {
+    const response = await fetchWithTimeout(this.queryEndpoint, {
       method: 'post',
       headers: { 'Content-Type': 'application/json' },
       body: JSON.stringify({

--- a/src/clients/utils.test.ts
+++ b/src/clients/utils.test.ts
@@ -1,4 +1,11 @@
-import { trimLastForwardSlash } from './utils'
+import { ErrorClient } from './ErrorClient'
+import { inBatches, redactSecrets, trimLastForwardSlash } from './utils'
+
+jest.mock('./ErrorClient', () => ({
+  ErrorClient: {
+    report: jest.fn(),
+  },
+}))
 
 describe('trimLastForwardSlash', () => {
   it('should return the string without the last forward slash', () => {
@@ -6,5 +13,65 @@ describe('trimLastForwardSlash', () => {
     expect(trimLastForwardSlash('https://hub.snapshot.org/')).toStrictEqual('https://hub.snapshot.org')
     expect(trimLastForwardSlash('https://testnet.snapshot.org/')).toStrictEqual('https://testnet.snapshot.org')
     expect(trimLastForwardSlash('https://testnet.snapshot.org')).toStrictEqual('https://testnet.snapshot.org')
+  })
+})
+
+describe('redactSecrets', () => {
+  describe('when the text contains a The Graph gateway url with an api key in the path', () => {
+    it('should redact the key segment', () => {
+      const input = 'https://gateway-arbitrum.network.thegraph.com/api/SECRETKEY123/subgraphs/id/abc'
+      expect(redactSecrets(input)).toBe('https://gateway-arbitrum.network.thegraph.com/api/<redacted>/subgraphs/id/abc')
+    })
+  })
+
+  describe('when the text contains an apiKey query parameter', () => {
+    it('should redact the parameter value', () => {
+      expect(redactSecrets('https://score.snapshot.org/?apiKey=abc123&foo=bar')).toBe(
+        'https://score.snapshot.org/?apiKey=<redacted>&foo=bar'
+      )
+    })
+  })
+
+  describe('when the text contains no secrets', () => {
+    it('should return it unchanged', () => {
+      expect(redactSecrets('some error without a url')).toBe('some error without a url')
+    })
+  })
+})
+
+describe('inBatches', () => {
+  afterEach(() => {
+    jest.clearAllMocks()
+  })
+
+  describe('when every batch resolves', () => {
+    let fetchFunction: jest.Mock
+
+    beforeEach(() => {
+      fetchFunction = jest.fn().mockResolvedValueOnce([1, 2]).mockResolvedValueOnce([3])
+    })
+
+    it('should accumulate results across batches until a short batch ends pagination', async () => {
+      const result = await inBatches(fetchFunction, {}, 2)
+      expect(result).toEqual([1, 2, 3])
+    })
+  })
+
+  describe('when a batch rejects after earlier batches succeeded', () => {
+    let fetchFunction: jest.Mock
+
+    beforeEach(() => {
+      fetchFunction = jest.fn().mockResolvedValueOnce([1, 2]).mockRejectedValueOnce(new Error('gateway 500'))
+    })
+
+    it('should return the partial results collected before the failure', async () => {
+      const result = await inBatches(fetchFunction, {}, 2)
+      expect(result).toEqual([1, 2])
+    })
+
+    it('should report the failure', async () => {
+      await inBatches(fetchFunction, {}, 2)
+      expect(ErrorClient.report).toHaveBeenCalled()
+    })
   })
 })

--- a/src/clients/utils.ts
+++ b/src/clients/utils.ts
@@ -1,6 +1,55 @@
 import { ErrorClient } from './ErrorClient'
 
 const SUBGRAPH_SKIP_LIMIT = 5000
+const DEFAULT_FETCH_TIMEOUT_MS = 30000
+
+/**
+ * Strips API keys that are embedded in URLs (The Graph gateway path segment and `apiKey`
+ * query params) so they are not leaked into logs or error reports.
+ */
+export function redactSecrets(text: string): string {
+  return text
+    .replace(/(\/api\/)[^/\s]+(\/subgraphs)/g, '$1<redacted>$2')
+    .replace(/([?&]apiKey=)[^&\s]+/gi, '$1<redacted>')
+}
+
+/**
+ * fetch wrapper that aborts after `timeoutMs` so a hung upstream cannot keep the
+ * request (and its socket) open indefinitely.
+ */
+export async function fetchWithTimeout(url: string, init?: RequestInit, timeoutMs = DEFAULT_FETCH_TIMEOUT_MS) {
+  const controller = new AbortController()
+  const timeoutId = setTimeout(() => controller.abort(), timeoutMs)
+  try {
+    return await fetch(url, { ...init, signal: controller.signal })
+  } finally {
+    clearTimeout(timeoutId)
+  }
+}
+
+/**
+ * POSTs a GraphQL query with a timeout and validates the response, so an HTTP error
+ * (429/500/HTML gateway page) or a GraphQL `errors` payload throws instead of being
+ * silently interpreted as "no data".
+ */
+export async function queryGraphql<T>(url: string, body: unknown): Promise<T> {
+  const response = await fetchWithTimeout(url, {
+    method: 'post',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify(body),
+  })
+
+  if (!response.ok) {
+    throw new Error(`GraphQL request to ${redactSecrets(url)} failed with status ${response.status}`)
+  }
+
+  const json = await response.json()
+  if (json?.errors) {
+    throw new Error(`GraphQL request to ${redactSecrets(url)} returned errors: ${JSON.stringify(json.errors)}`)
+  }
+
+  return json as T
+}
 
 export async function inBatches<T, K>(
   fetchFunction: (params: T, skip: number, batchSize: number) => Promise<K[]>,
@@ -25,8 +74,12 @@ export async function inBatches<T, K>(
     }
     return allResults
   } catch (error) {
-    ErrorClient.report(`Error while executing ${fetchFunction.name} in batches: `, { error: `${error}` })
-    return []
+    // Report the failure (so an upstream outage is visible, not silent) and return
+    // whatever was collected so far instead of discarding partial results.
+    ErrorClient.report(`Error while executing ${fetchFunction.name} in batches: `, {
+      error: redactSecrets(`${error}`),
+    })
+    return allResults
   }
 }
 

--- a/src/entities/Committee/isDAOCommittee.ts
+++ b/src/entities/Committee/isDAOCommittee.ts
@@ -17,5 +17,5 @@ export default function isDAOCommittee(user?: string | null | undefined) {
     return false
   }
 
-  return committeeAddresses.has(user)
+  return committeeAddresses.has(user.toLowerCase())
 }

--- a/src/entities/Proposal/model.ts
+++ b/src/entities/Proposal/model.ts
@@ -144,7 +144,7 @@ export default class ProposalModel extends Model<ProposalAttributes> {
         )}
         WHERE ${join(
           conditionsKeys.map((key) => SQL`"${SQL.raw(key)}" = ${conditions[key]}`),
-          SQL`,`
+          SQL` AND `
         )}
     `
 

--- a/src/entities/Snapshot/utils.ts
+++ b/src/entities/Snapshot/utils.ts
@@ -187,12 +187,15 @@ export function getChecksumAddress(address: string) {
 
 // TODO: Move to non-snapshot-related file
 export function isSameAddress(userAddress?: string | null, address?: string | null) {
+  // Compare case-insensitively rather than checksumming: ethereum address equality
+  // only differs by casing, and getChecksumAddress throws on malformed input (which
+  // can arrive from external sources), so this stays robust and never throws.
   return (
     !!userAddress &&
     userAddress.length > 0 &&
     !!address &&
     address.length > 0 &&
-    getChecksumAddress(userAddress) === getChecksumAddress(address)
+    userAddress.toLowerCase() === address.toLowerCase()
   )
 }
 

--- a/src/jobs/BadgeAirdrop.ts
+++ b/src/jobs/BadgeAirdrop.ts
@@ -13,27 +13,39 @@ export async function runQueuedAirdropJobs() {
     return
   }
   logger.log(`Running ${pendingJobs.length} airdrop jobs`)
-  pendingJobs.map(async (pendingJob) => {
-    const { id, badge_spec, recipients } = pendingJob
-    const airdropOutcome = await BadgesService.giveBadgeToUsers(badge_spec, recipients)
-    logger.log('Airdrop Outcome', airdropOutcome)
-    if (airdropOutcome.status === AirdropJobStatus.FAILED) {
-      ErrorService.report('Airdrop job failed', {
-        category: ErrorCategory.Badges,
-        id,
-        badge_spec,
-        recipients,
-        error: airdropOutcome.error,
-      })
-    }
-    await AirdropJobModel.update<AirdropJobAttributes>(
-      {
-        ...airdropOutcome,
-        updated_at: new Date(),
-      },
-      { id }
-    )
-  })
+  await Promise.all(
+    pendingJobs.map(async (pendingJob) => {
+      const { id, badge_spec, recipients } = pendingJob
+      try {
+        const airdropOutcome = await BadgesService.giveBadgeToUsers(badge_spec, recipients)
+        logger.log('Airdrop Outcome', airdropOutcome)
+        if (airdropOutcome.status === AirdropJobStatus.FAILED) {
+          ErrorService.report('Airdrop job failed', {
+            category: ErrorCategory.Badges,
+            id,
+            badge_spec,
+            recipients,
+            error: airdropOutcome.error,
+          })
+        }
+        await AirdropJobModel.update<AirdropJobAttributes>(
+          {
+            ...airdropOutcome,
+            updated_at: new Date(),
+          },
+          { id }
+        )
+      } catch (error) {
+        ErrorService.report('Unexpected error running airdrop job', {
+          category: ErrorCategory.Badges,
+          id,
+          badge_spec,
+          recipients,
+          error: `${error}`,
+        })
+      }
+    })
+  )
 }
 
 export async function giveAndRevokeLandOwnerBadges() {

--- a/src/models/Event.ts
+++ b/src/models/Event.ts
@@ -43,11 +43,13 @@ export default class EventModel extends Model<Event> {
   }
 
   static async isDiscourseEventRegistered(discourseEventId: string) {
+    // Match any comment event type (proposal_commented and project_update_commented)
+    // so replays of update-topic comments are also deduped, not just proposal comments.
     const query = SQL`
       SELECT count(*)
       FROM ${table(EventModel)}
       WHERE
-          event_type = ${EventType.ProposalCommented} AND 
+          event_type IN (${EventType.ProposalCommented}, ${EventType.ProjectUpdateCommented}) AND
           (event_data ->>'discourse_event_id') = ${discourseEventId}
     `
     const count = (await this.namedQuery<{ count: string }>('find_discourse_event_id', query))[0].count

--- a/src/routes/budget.ts
+++ b/src/routes/budget.ts
@@ -1,4 +1,4 @@
-import { auth } from 'decentraland-gatsby/dist/entities/Auth/middleware'
+import { WithAuth, auth } from 'decentraland-gatsby/dist/entities/Auth/middleware'
 import handleAPI from 'decentraland-gatsby/dist/entities/Route/handle'
 import routes from 'decentraland-gatsby/dist/entities/Route/routes'
 import { Request } from 'express'
@@ -8,7 +8,7 @@ import { Budget, BudgetWithContestants, CategoryBudget } from '../entities/Budge
 import { QuarterBudgetAttributes } from '../entities/QuarterBudget/types'
 import { toNewGrantCategory } from '../entities/QuarterCategoryBudget/utils'
 import { BudgetService } from '../services/BudgetService'
-import { validateId } from '../utils/validations'
+import { validateDebugAddress, validateId } from '../utils/validations'
 
 export default routes((route) => {
   const withAuth = auth()
@@ -27,7 +27,8 @@ async function getCategoryBudget(req: Request): Promise<CategoryBudget> {
   return await BudgetService.getCategoryBudget(grantCategory)
 }
 
-async function updateBudgets(): Promise<QuarterBudgetAttributes[]> {
+async function updateBudgets(req: WithAuth): Promise<QuarterBudgetAttributes[]> {
+  validateDebugAddress(req.auth!)
   return await BudgetService.updateGovernanceBudgets()
 }
 

--- a/src/routes/common.test.ts
+++ b/src/routes/common.test.ts
@@ -45,6 +45,16 @@ describe('isPrivateIp', () => {
     })
   })
 
+  describe('when given deprecated IPv4-compatible IPv6 addresses (::a.b.c.d)', () => {
+    it('should classify an embedded loopback address as private', () => {
+      expect(isPrivateIp('::127.0.0.1')).toBe(true)
+    })
+
+    it('should classify an embedded private address as private', () => {
+      expect(isPrivateIp('::10.0.0.1')).toBe(true)
+    })
+  })
+
   describe('when given public IPv6 addresses', () => {
     const publicV6 = ['2001:4860:4860::8888', '2606:4700:4700::1111']
 

--- a/src/routes/common.test.ts
+++ b/src/routes/common.test.ts
@@ -1,0 +1,110 @@
+import dns from 'dns'
+
+import { assertPublicUrl, isPrivateIp } from './common'
+
+describe('isPrivateIp', () => {
+  describe('when given IPv4 addresses in a private, loopback, link-local or CGNAT range', () => {
+    const privateV4 = ['0.0.0.1', '10.1.2.3', '127.0.0.1', '169.254.169.254', '172.16.0.1', '192.168.1.1', '100.64.0.1']
+
+    it('should classify every one of them as private', () => {
+      expect(privateV4.map(isPrivateIp)).toEqual(privateV4.map(() => true))
+    })
+  })
+
+  describe('when given public IPv4 addresses', () => {
+    const publicV4 = ['8.8.8.8', '1.1.1.1', '172.32.0.1', '93.184.216.34']
+
+    it('should classify every one of them as public', () => {
+      expect(publicV4.map(isPrivateIp)).toEqual(publicV4.map(() => false))
+    })
+  })
+
+  describe('when given the IPv6 loopback address written in different valid forms', () => {
+    const loopbackForms = ['::1', '0::1', '::0:1', '0:0:0:0:0:0:0:1']
+
+    it('should classify every spelling as private', () => {
+      expect(loopbackForms.map(isPrivateIp)).toEqual(loopbackForms.map(() => true))
+    })
+  })
+
+  describe('when given IPv6 link-local, unique-local or unspecified addresses', () => {
+    const privateV6 = ['fe80::1', 'fe80:0:0:0:0:0:0:1', 'fc00::1', 'fd12:3456::1', '::']
+
+    it('should classify every one of them as private', () => {
+      expect(privateV6.map(isPrivateIp)).toEqual(privateV6.map(() => true))
+    })
+  })
+
+  describe('when given IPv4-mapped IPv6 addresses', () => {
+    it('should classify a mapped private address as private', () => {
+      expect(isPrivateIp('::ffff:127.0.0.1')).toBe(true)
+    })
+
+    it('should classify a mapped public address as public', () => {
+      expect(isPrivateIp('::ffff:8.8.8.8')).toBe(false)
+    })
+  })
+
+  describe('when given public IPv6 addresses', () => {
+    const publicV6 = ['2001:4860:4860::8888', '2606:4700:4700::1111']
+
+    it('should classify every one of them as public', () => {
+      expect(publicV6.map(isPrivateIp)).toEqual(publicV6.map(() => false))
+    })
+  })
+})
+
+describe('assertPublicUrl', () => {
+  afterEach(() => {
+    jest.restoreAllMocks()
+  })
+
+  describe('when the host is an IP literal in a private range', () => {
+    it('should reject an IPv4 loopback literal', async () => {
+      await expect(assertPublicUrl('https://127.0.0.1/admin')).rejects.toThrow('private')
+    })
+
+    it('should reject an IPv6 loopback literal written in expanded form', async () => {
+      await expect(assertPublicUrl('https://[0:0:0:0:0:0:0:1]/')).rejects.toThrow('private')
+    })
+  })
+
+  describe('when the host is a public IP literal', () => {
+    it('should resolve without throwing', async () => {
+      await expect(assertPublicUrl('https://1.1.1.1/')).resolves.toBeUndefined()
+    })
+  })
+
+  describe('when the host is a domain that resolves to a private address', () => {
+    beforeEach(() => {
+      jest.spyOn(dns.promises, 'lookup').mockResolvedValue([{ address: '10.0.0.5', family: 4 }] as never)
+    })
+
+    it('should reject because the resolved address is private', async () => {
+      await expect(assertPublicUrl('https://internal.example/')).rejects.toThrow('private address')
+    })
+  })
+
+  describe('when the host is a domain that resolves only to public addresses', () => {
+    beforeEach(() => {
+      jest.spyOn(dns.promises, 'lookup').mockResolvedValue([{ address: '93.184.216.34', family: 4 }] as never)
+    })
+
+    it('should resolve without throwing', async () => {
+      await expect(assertPublicUrl('https://example.com/')).resolves.toBeUndefined()
+    })
+  })
+
+  describe('when the host is a domain that resolves to a mix of public and private addresses', () => {
+    beforeEach(() => {
+      jest.spyOn(dns.promises, 'lookup').mockResolvedValue([
+        { address: '93.184.216.34', family: 4 },
+        { address: '169.254.169.254', family: 4 },
+      ] as never)
+    })
+
+    it('should reject because at least one resolved address is private', async () => {
+      await expect(assertPublicUrl('https://rebind.example/')).rejects.toThrow('private address')
+    })
+  })
+})

--- a/src/routes/common.ts
+++ b/src/routes/common.ts
@@ -11,23 +11,6 @@ export default routes((router) => {
   return router.post('/url-title', withAuth, handleAPI(checkUrlTitle))
 })
 
-const fetchWithTimeout = async (url: string, timeout = 10000, options?: RequestInit) => {
-  const controller = new AbortController()
-  const timeoutId = setTimeout(() => {
-    controller.abort()
-  }, timeout)
-
-  try {
-    const response = await fetch(url, {
-      ...options,
-      signal: controller.signal,
-    })
-    return response
-  } finally {
-    clearTimeout(timeoutId)
-  }
-}
-
 const isHttpsURL = (url: string) => isURL(url, { protocols: ['https'], require_protocol: true })
 
 // Parses any valid IPv6 textual form (compact, expanded, or with an embedded IPv4 suffix)
@@ -107,6 +90,12 @@ export async function assertPublicUrl(url: string) {
     return
   }
 
+  // Known limitation: this resolves the hostname and vets the IPs, but the subsequent
+  // fetch() resolves DNS again independently, so a DNS-rebinding attacker (very low TTL)
+  // could pass here with a public IP and have the fetch hit a private IP. Fully closing it
+  // would require pinning this IP into the request (connect-to-IP + Host header), which
+  // native fetch doesn't support without breaking TLS SNI. Accepted for the current threat
+  // model (endpoint is authenticated); redirect: 'manual' in getTitle blocks the redirect variant.
   const resolved = await dns.promises.lookup(hostname, { all: true })
   if (resolved.length === 0) {
     throw new Error('Invalid url: could not resolve host')
@@ -117,12 +106,17 @@ export async function assertPublicUrl(url: string) {
 }
 
 async function getTitle(url: string) {
-  // redirect: 'manual' prevents a public URL from 3xx-redirecting to an internal host
-  // after the address check has passed.
-  const response = await fetchWithTimeout(url, 6000, { redirect: 'manual' })
-  const text = await response.text()
-  const title = text.match(/<title>([^<]+)<\/title>/)?.[1]
-  return title
+  const controller = new AbortController()
+  const timeoutId = setTimeout(() => controller.abort(), 6000)
+  try {
+    // redirect: 'manual' prevents a public URL from 3xx-redirecting to an internal host
+    // after the address check has passed.
+    const response = await fetch(url, { redirect: 'manual', signal: controller.signal })
+    const text = await response.text()
+    return text.match(/<title>([^<]+)<\/title>/)?.[1]
+  } finally {
+    clearTimeout(timeoutId)
+  }
 }
 
 // eslint-disable-next-line @typescript-eslint/no-explicit-any

--- a/src/routes/common.ts
+++ b/src/routes/common.ts
@@ -1,10 +1,14 @@
+import { auth } from 'decentraland-gatsby/dist/entities/Auth/middleware'
 import handleAPI from 'decentraland-gatsby/dist/entities/Route/handle'
 import routes from 'decentraland-gatsby/dist/entities/Route/routes'
+import dns from 'dns'
 import { Request } from 'express'
+import net from 'net'
 import isURL from 'validator/lib/isURL'
 
 export default routes((router) => {
-  return router.post('/url-title', handleAPI(checkUrlTitle))
+  const withAuth = auth()
+  return router.post('/url-title', withAuth, handleAPI(checkUrlTitle))
 })
 
 const fetchWithTimeout = async (url: string, timeout = 10000, options?: RequestInit) => {
@@ -26,8 +30,96 @@ const fetchWithTimeout = async (url: string, timeout = 10000, options?: RequestI
 
 const isHttpsURL = (url: string) => isURL(url, { protocols: ['https'], require_protocol: true })
 
+// Parses any valid IPv6 textual form (compact, expanded, or with an embedded IPv4 suffix)
+// into its 16 bytes, so range checks below cannot be bypassed by an alternate spelling
+// (e.g. "0::1" vs "::1"). Returns null for anything it cannot parse.
+function parseIPv6ToBytes(ip: string): number[] | null {
+  const halves = ip.split('%')[0].split('::') // strip zone id, split on the compressor
+  if (halves.length > 2) return null
+
+  const groupsToBytes = (groups: string[]): number[] | null => {
+    const bytes: number[] = []
+    for (let i = 0; i < groups.length; i++) {
+      const group = groups[i]
+      if (group === '') return null
+      if (group.includes('.')) {
+        // Embedded IPv4 is only valid as the final group.
+        if (i !== groups.length - 1 || !net.isIPv4(group)) return null
+        for (const part of group.split('.')) bytes.push(Number(part))
+        continue
+      }
+      if (!/^[0-9a-f]{1,4}$/.test(group)) return null
+      const value = parseInt(group, 16)
+      bytes.push((value >> 8) & 0xff, value & 0xff)
+    }
+    return bytes
+  }
+
+  const leftBytes = groupsToBytes(halves[0] ? halves[0].split(':') : [])
+  const rightBytes = groupsToBytes(halves.length === 2 && halves[1] ? halves[1].split(':') : [])
+  if (leftBytes === null || rightBytes === null) return null
+
+  const missing = 16 - leftBytes.length - rightBytes.length
+  if (halves.length === 1) {
+    return missing === 0 ? leftBytes : null // no "::" means the address must be full
+  }
+  if (missing < 1) return null // "::" must stand for at least one zero group
+  return [...leftBytes, ...Array(missing).fill(0), ...rightBytes]
+}
+
+// Blocks loopback, private, link-local (incl. cloud metadata 169.254.169.254), CGNAT and
+// unique-local addresses so this endpoint cannot be used to reach internal services.
+export function isPrivateIp(ip: string): boolean {
+  if (net.isIPv4(ip)) {
+    const [a, b] = ip.split('.').map(Number)
+    if (a === 0 || a === 10 || a === 127) return true
+    if (a === 169 && b === 254) return true
+    if (a === 172 && b >= 16 && b <= 31) return true
+    if (a === 192 && b === 168) return true
+    if (a === 100 && b >= 64 && b <= 127) return true
+    return false
+  }
+
+  if (net.isIPv6(ip)) {
+    const bytes = parseIPv6ToBytes(ip.toLowerCase())
+    if (!bytes || bytes.length !== 16) return true // fail closed on anything unparseable
+    // IPv4-mapped ::ffff:a.b.c.d — reuse the IPv4 ranges above.
+    if (bytes.slice(0, 10).every((x) => x === 0) && bytes[10] === 0xff && bytes[11] === 0xff) {
+      return isPrivateIp(bytes.slice(12).join('.'))
+    }
+    if (bytes.slice(0, 15).every((x) => x === 0) && bytes[15] === 1) return true // ::1 loopback
+    if (bytes.every((x) => x === 0)) return true // :: unspecified
+    if (bytes[0] === 0xfe && (bytes[1] & 0xc0) === 0x80) return true // fe80::/10 link-local
+    if ((bytes[0] & 0xfe) === 0xfc) return true // fc00::/7 unique local
+    return false
+  }
+
+  return true // unknown format, fail closed
+}
+
+export async function assertPublicUrl(url: string) {
+  const hostname = new URL(url).hostname.replace(/^\[|\]$/g, '')
+
+  if (net.isIP(hostname)) {
+    if (isPrivateIp(hostname)) {
+      throw new Error('Invalid url: private addresses are not allowed')
+    }
+    return
+  }
+
+  const resolved = await dns.promises.lookup(hostname, { all: true })
+  if (resolved.length === 0) {
+    throw new Error('Invalid url: could not resolve host')
+  }
+  if (resolved.some(({ address }) => isPrivateIp(address))) {
+    throw new Error('Invalid url: host resolves to a private address')
+  }
+}
+
 async function getTitle(url: string) {
-  const response = await fetchWithTimeout(url, 6000)
+  // redirect: 'manual' prevents a public URL from 3xx-redirecting to an internal host
+  // after the address check has passed.
+  const response = await fetchWithTimeout(url, 6000, { redirect: 'manual' })
   const text = await response.text()
   const title = text.match(/<title>([^<]+)<\/title>/)?.[1]
   return title
@@ -43,6 +135,8 @@ async function checkUrlTitle(req: Request<any, any, { url: string }>) {
   if (!isHttpsURL(url)) {
     throw new Error('Invalid url: ' + url)
   }
+
+  await assertPublicUrl(url)
 
   const title = await getTitle(url)
   return { title }

--- a/src/routes/common.ts
+++ b/src/routes/common.ts
@@ -70,8 +70,12 @@ export function isPrivateIp(ip: string): boolean {
     if (bytes.slice(0, 10).every((x) => x === 0) && bytes[10] === 0xff && bytes[11] === 0xff) {
       return isPrivateIp(bytes.slice(12).join('.'))
     }
-    if (bytes.slice(0, 15).every((x) => x === 0) && bytes[15] === 1) return true // ::1 loopback
-    if (bytes.every((x) => x === 0)) return true // :: unspecified
+    // Deprecated IPv4-compatible ::a.b.c.d, plus ::1 and ::, all have the first 12 bytes zero.
+    // Apply the IPv4 rules to the embedded address so forms like ::127.0.0.1 or ::10.0.0.1
+    // can't slip through (::1 -> 0.0.0.1 and :: -> 0.0.0.0 both match the 0.x private rule).
+    if (bytes.slice(0, 12).every((x) => x === 0)) {
+      return isPrivateIp(bytes.slice(12).join('.'))
+    }
     if (bytes[0] === 0xfe && (bytes[1] & 0xc0) === 0x80) return true // fe80::/10 link-local
     if ((bytes[0] & 0xfe) === 0xfc) return true // fc00::/7 unique local
     return false

--- a/src/routes/debug.ts
+++ b/src/routes/debug.ts
@@ -20,6 +20,7 @@ export default routes((router) => {
   const withAuth = auth()
   router.get(
     '/debug',
+    withAuth,
     handleAPI(async () => DEBUG_ADDRESSES)
   )
   router.post('/debug/report-error', auth({ optional: true }), handleAPI(reportClientError))
@@ -27,8 +28,19 @@ export default routes((router) => {
   router.delete('/debug/invalidate-cache', withAuth, handleAPI(invalidateCache))
 })
 
+const MAX_CLIENT_ERROR_MESSAGE_LENGTH = 1000
+
 function reportClientError(req: WithAuth): void {
-  ErrorService.report(req.body.message, { frontend: true, ...req.body.extraInfo })
+  const message =
+    typeof req.body?.message === 'string'
+      ? req.body.message.slice(0, MAX_CLIENT_ERROR_MESSAGE_LENGTH)
+      : 'Unknown client error'
+  const extraInfo =
+    req.body?.extraInfo && typeof req.body.extraInfo === 'object' && !Array.isArray(req.body.extraInfo)
+      ? req.body.extraInfo
+      : {}
+  // Spread first so client-provided keys can never override the trusted `frontend` marker.
+  ErrorService.report(message, { ...extraInfo, frontend: true })
 }
 
 async function triggerFunction(req: WithAuth) {

--- a/src/routes/events.ts
+++ b/src/routes/events.ts
@@ -22,9 +22,8 @@ async function voted(req: WithAuth) {
   const user = req.auth!
 
   validateId(req.body.proposalId)
-  validateRequiredString('proposalTitle', req.body.proposalTitle)
   validateRequiredString('choice', req.body.choice)
-  return await EventsService.voted(req.body.proposalId, req.body.proposalTitle, req.body.choice, user)
+  return await EventsService.voted(req.body.proposalId, req.body.choice, user)
 }
 
 async function getAllEvents(req: WithAuth) {

--- a/src/routes/newsletter.ts
+++ b/src/routes/newsletter.ts
@@ -26,7 +26,7 @@ async function handleSubscription(req: Request): Promise<NewsletterSubscriptionR
       Accept: 'application/json',
       Authorization: `Bearer ${process.env.BEEHIIV_API_KEY}`,
     },
-    body: `{ "email": "${email}" }`,
+    body: JSON.stringify({ email }),
   })
   const data = await response.json()
 

--- a/src/routes/webhooks.ts
+++ b/src/routes/webhooks.ts
@@ -15,15 +15,20 @@ export default routes((route) => {
 })
 
 async function delegationUpdate(req: Request) {
+  // Signature validation runs outside the try/catch so an invalid signature surfaces
+  // as a 403 instead of being masked with a 200.
+  validateAlchemyWebhookSignature(req)
+  const block = req.body.event.data.block as AlchemyBlock
+  if (block.transactions.length === 0) {
+    return
+  }
   try {
-    validateAlchemyWebhookSignature(req)
-    const block = req.body.event.data.block as AlchemyBlock
-    if (block.transactions.length === 0) {
-      return
-    }
     return await EventsService.delegationUpdate(block)
   } catch (error) {
+    // Report, then re-throw so Alchemy sees a non-2xx and retries delivery instead of
+    // silently dropping the event. delegationUpdate is idempotent (isDelegationTxRegistered).
     ErrorService.report('Something failed on delegation update webhook', { error, category: ErrorCategory.Webhook })
+    throw error
   }
 }
 

--- a/src/server.ts
+++ b/src/server.ts
@@ -63,6 +63,17 @@ swaggerDocument['servers'] = [{ url: process.env.GATSBY_GOVERNANCE_API }]
 const app = express()
 app.set('x-powered-by', false)
 app.use(withLogs())
+// Capture the raw request body for webhook routes so signature HMACs are verified against
+// the exact bytes the sender signed, not a re-serialization. Registered before the main
+// chain; body-parser in withBody() skips re-parsing because req._body is already set.
+app.use(
+  '/api/webhooks',
+  express.json({
+    verify: (req, _res, buf) => {
+      ;(req as unknown as { rawBody?: string }).rawBody = buf.toString('utf8')
+    },
+  })
+)
 app.use('/api', [
   status(),
   withDDosProtection({ limit: 1000, checkinterval: 4 }),

--- a/src/services/BidService.ts
+++ b/src/services/BidService.ts
@@ -52,6 +52,12 @@ export default class BidService {
         status: UnpublishedBidStatus.Pending,
       })
     } catch (error) {
+      // The DB enforces UNIQUE(linked_proposal_id, author_address), so a bid that races
+      // past the check above still fails here with a unique violation (Postgres code 23505).
+      // Surface it as the same "already exists" error rather than a generic failure.
+      if ((error as { code?: string })?.code === '23505') {
+        throw new Error('Bid already exists')
+      }
       const msg = 'Error creating bid'
       ErrorService.report(msg, { error, author_address, linked_proposal_id, category: ErrorCategory.Bid })
       throw new Error(msg)

--- a/src/services/FinancialService.ts
+++ b/src/services/FinancialService.ts
@@ -33,7 +33,7 @@ export class FinancialService {
 
   public static async createRecords(update_id: string, records: FinancialRecord[]): Promise<FinancialAttributes[]> {
     try {
-      this.deleteRecordsByUpdateId(update_id)
+      await this.deleteRecordsByUpdateId(update_id)
       return await FinancialModel.createRecords(update_id, records)
     } catch (error) {
       const msg = 'Error inserting financial records'

--- a/src/services/ProposalService.test.ts
+++ b/src/services/ProposalService.test.ts
@@ -1,8 +1,10 @@
 import ProposalModel from '../entities/Proposal/model'
 import { createTestProposal } from '../entities/Proposal/testHelpers'
 import { ProposalStatus, ProposalType, ProposalWithProject } from '../entities/Proposal/types'
+import { UpdateService } from '../services/update'
 
 import { DiscourseService } from './DiscourseService'
+import { ProjectService } from './ProjectService'
 import { ProposalService } from './ProposalService'
 
 jest.mock('../services/discord', () => ({
@@ -26,6 +28,12 @@ jest.mock('../services/notification', () => ({
 jest.mock('../services/update', () => ({
   UpdateService: {
     createPendingUpdatesForVesting: jest.fn(),
+  },
+}))
+
+jest.mock('./ProjectService', () => ({
+  ProjectService: {
+    getUpdatedProject: jest.fn(),
   },
 }))
 
@@ -82,6 +90,80 @@ describe('ProposalService', () => {
         passed_by: passedBy,
       })
       expect(DiscourseService.commentUpdatedProposal).toHaveBeenCalledWith(updatedProposal)
+    })
+
+    describe('when enacting a passed project proposal for the first time', () => {
+      const user = '0x2AC89522CB415AC333E64F52a1a5693218cEBD58'
+      const projectId = '11111111-1111-1111-1111-111111111111'
+      const vestingAddresses = ['0x1111111111111111111111111111111111111111']
+      let proposal: ProposalWithProject
+
+      beforeEach(() => {
+        jest.clearAllMocks()
+        jest.spyOn(ProposalModel, 'update').mockResolvedValue({} as never)
+        ;(ProjectService.getUpdatedProject as jest.Mock).mockResolvedValue({ status: 'in_progress' } as never)
+        proposal = {
+          ...createTestProposal(ProposalType.Grant, ProposalStatus.Passed, 10000),
+          project_id: projectId,
+          personnel: [],
+        }
+      })
+
+      it('should regenerate the pending vesting updates with the requested addresses', async () => {
+        await ProposalService.updateProposalStatus(
+          proposal,
+          { status: ProposalStatus.Enacted, vesting_addresses: vestingAddresses },
+          user
+        )
+
+        expect(UpdateService.createPendingUpdatesForVesting).toHaveBeenCalledWith(projectId, vestingAddresses)
+      })
+    })
+
+    describe('when re-enacting an already-enacted project proposal', () => {
+      const user = '0x2AC89522CB415AC333E64F52a1a5693218cEBD58'
+      const projectId = '11111111-1111-1111-1111-111111111111'
+      const existingAddresses = ['0x1111111111111111111111111111111111111111']
+      let proposal: ProposalWithProject
+
+      beforeEach(() => {
+        jest.clearAllMocks()
+        jest.spyOn(ProposalModel, 'update').mockResolvedValue({} as never)
+        ;(ProjectService.getUpdatedProject as jest.Mock).mockResolvedValue({ status: 'in_progress' } as never)
+        proposal = {
+          ...createTestProposal(ProposalType.Grant, ProposalStatus.Enacted, 10000),
+          project_id: projectId,
+          enacted: true,
+          vesting_addresses: existingAddresses,
+          personnel: [],
+        }
+      })
+
+      describe('and the vesting addresses are unchanged', () => {
+        it('should not regenerate the pending vesting updates', async () => {
+          await ProposalService.updateProposalStatus(
+            proposal,
+            { status: ProposalStatus.Enacted, vesting_addresses: existingAddresses },
+            user
+          )
+
+          expect(UpdateService.createPendingUpdatesForVesting).not.toHaveBeenCalled()
+        })
+      })
+
+      describe('and a new vesting address is added', () => {
+        it('should regenerate the pending vesting updates', async () => {
+          const newAddresses = [...existingAddresses, '0x2222222222222222222222222222222222222222']
+
+          await ProposalService.updateProposalStatus(
+            proposal,
+            { status: ProposalStatus.Enacted, vesting_addresses: newAddresses },
+            user
+          )
+
+          expect(UpdateService.createPendingUpdatesForVesting).toHaveBeenCalledWith(projectId, newAddresses)
+        })
+      })
     })
   })
 })

--- a/src/services/ProposalService.ts
+++ b/src/services/ProposalService.ts
@@ -19,6 +19,7 @@ import {
 } from '../entities/Proposal/types'
 import { isGrantProposalSubmitEnabled, isProjectProposal } from '../entities/Proposal/utils'
 import { SNAPSHOT_SPACE } from '../entities/Snapshot/constants'
+import { isSameAddress } from '../entities/Snapshot/utils'
 import VotesModel from '../entities/Votes/model'
 import { getEnvironmentChainId } from '../helpers'
 import { DiscordService } from '../services/discord'
@@ -153,7 +154,7 @@ export class ProposalService {
   }
 
   private static validateRemoval(proposal: ProposalAttributes, user: string) {
-    const allowToRemove = proposal.user === user || isDAOCouncil(user)
+    const allowToRemove = isSameAddress(proposal.user, user) || isDAOCouncil(user)
     if (!allowToRemove) {
       throw new RequestError('Forbidden', RequestError.Forbidden)
     }
@@ -299,13 +300,26 @@ export class ProposalService {
     } else if (newStatus === ProposalStatus.Rejected) {
       update.rejected_by = user
     }
+
+    // Only (re)generate the vesting update schedule on a fresh enactment or when the vesting
+    // addresses actually change, so an accidental re-enact with the same addresses does not
+    // wipe and reset existing pending updates.
+    const wasAlreadyEnacted = proposal.status === ProposalStatus.Enacted
+    const vestingAddressesChanged = !this.haveSameVestingAddresses(proposal.vesting_addresses, vesting_addresses)
+    const shouldCreatePendingUpdates = isEnactedStatus && isProject && (!wasAlreadyEnacted || vestingAddressesChanged)
+
+    // Run the failure-prone vesting work before persisting the status so a failure leaves the
+    // proposal in its previous state (consistent and retryable) rather than half-enacted.
+    if (shouldCreatePendingUpdates) {
+      const validatedProjectId = validateId(proposal.project_id)
+      await UpdateService.createPendingUpdatesForVesting(validatedProjectId, vesting_addresses)
+    }
+
     await ProposalModel.update<ProposalAttributes>(update, { id })
 
     const updatedProposal = { ...proposal, ...update }
 
     if (isEnactedStatus && isProject) {
-      const validatedProjectId = validateId(proposal.project_id)
-      await UpdateService.createPendingUpdatesForVesting(validatedProjectId, vesting_addresses)
       const project = await ProjectService.getUpdatedProject(proposal.project_id!)
       updatedProposal.project_status = project.status
       NotificationService.projectProposalEnacted(proposal)
@@ -315,6 +329,20 @@ export class ProposalService {
     DiscourseService.commentUpdatedProposal(updatedProposal)
 
     return updatedProposal
+  }
+
+  private static haveSameVestingAddresses(a: string[] | null | undefined, b: string[] | null | undefined): boolean {
+    const setA = new Set((a || []).map((address) => address.toLowerCase()))
+    const setB = new Set((b || []).map((address) => address.toLowerCase()))
+    if (setA.size !== setB.size) {
+      return false
+    }
+    for (const address of setA) {
+      if (!setB.has(address)) {
+        return false
+      }
+    }
+    return true
   }
 
   private static getEnactedStatusData(

--- a/src/services/events.ts
+++ b/src/services/events.ts
@@ -6,6 +6,7 @@ import ProposalModel from '../entities/Proposal/model'
 import { ProposalWithOutcome } from '../entities/Proposal/outcome'
 import { ProposalAttributes } from '../entities/Proposal/types'
 import { SNAPSHOT_SPACE } from '../entities/Snapshot/constants'
+import { isSameAddress } from '../entities/Snapshot/utils'
 import UpdateModel from '../entities/Updates/model'
 import { UpdateAttributes } from '../entities/Updates/types'
 import UserModel from '../entities/User/model'
@@ -39,6 +40,7 @@ import { DclProfile } from '../utils/Catalyst/types'
 import Time from '../utils/date/Time'
 import { ErrorCategory } from '../utils/errorCategories'
 
+import { SnapshotService } from './SnapshotService'
 import { NotificationService } from './notification'
 
 const CLEAR_DELEGATE_SIGNATURE_HASH = '0x9c4f00c4291262731946e308dc2979a56bd22cce8f95906b975065e96cd5a064'
@@ -131,19 +133,39 @@ export class EventsService {
     }
   }
 
-  static async voted(proposal_id: string, proposal_title: string, choice: string, address: string) {
+  static async voted(proposal_id: string, choice: string, address: string) {
     try {
+      const proposalRow = await ProposalModel.findOne<ProposalAttributes>({ id: proposal_id, deleted: false })
+      if (!proposalRow) {
+        throw new Error(`Proposal not found: "${proposal_id}"`)
+      }
+      const proposal = ProposalModel.parse(proposalRow)
+
+      // Confirm on Snapshot that this address actually voted on the proposal before
+      // recording the activity event, so "voted" entries cannot be fabricated.
+      const votes = await SnapshotService.getVotesByProposal(proposal.snapshot_id)
+      const userVote = votes.find((vote) => isSameAddress(vote.voter, address))
+      if (!userVote) {
+        throw new Error(`No Snapshot vote found for ${address} on proposal "${proposal_id}"`)
+      }
+
+      // Derive the choice label from the proposal's own choices via the vote's choice index
+      // so no client-supplied free text is stored (prevents feed spoofing / stored XSS).
+      const choices: string[] = proposal.snapshot_proposal?.choices || []
+      const derivedChoice = typeof userVote.choice === 'number' ? choices[userVote.choice - 1] : undefined
+      const safeChoice = derivedChoice ?? (choices.includes(choice) ? choice : 'unknown')
+
       const votedEvent: VotedEvent = {
         id: crypto.randomUUID(),
         address,
         event_type: EventType.Voted,
-        event_data: { proposal_id, proposal_title, choice },
+        event_data: { proposal_id, proposal_title: proposal.title, choice: safeChoice },
         created_at: new Date(),
       }
       await EventModel.create(votedEvent)
       NotificationService.newVote(proposal_id, address)
     } catch (error) {
-      this.reportEventError(error as Error, EventType.Voted, { address, proposal_id, proposal_title, choice })
+      this.reportEventError(error as Error, EventType.Voted, { address, proposal_id, choice })
     }
   }
 

--- a/src/services/vote.test.ts
+++ b/src/services/vote.test.ts
@@ -1,3 +1,5 @@
+import { SnapshotVote } from '../clients/SnapshotTypes'
+import { VOTES_VP_THRESHOLD } from '../constants'
 import CacheService from '../services/CacheService'
 import { SnapshotService } from '../services/SnapshotService'
 import { SNAPSHOT_VOTES_30_DAYS } from '../utils/votes/Votes-30days'
@@ -249,6 +251,31 @@ describe('getSortedCountPerUser', () => {
     expect(sortedVotes[3].lastVoted).toBeLessThan(sortedVotes[4].lastVoted)
     expect(sortedVotes[4].votes).toEqual(sortedVotes[5].votes)
     expect(sortedVotes[4].lastVoted).toBeLessThan(sortedVotes[5].lastVoted)
+  })
+
+  describe('when votes include voting power below, at and above the threshold', () => {
+    const belowThreshold = '0xaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa'
+    const atThreshold = '0xbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb'
+    const aboveThreshold = '0xcccccccccccccccccccccccccccccccccccccccc'
+    let votes: SnapshotVote[]
+
+    beforeEach(() => {
+      votes = [
+        { voter: belowThreshold, created: 100, vp: VOTES_VP_THRESHOLD - 1, choice: 1 },
+        { voter: atThreshold, created: 200, vp: VOTES_VP_THRESHOLD, choice: 1 },
+        { voter: aboveThreshold, created: 300, vp: VOTES_VP_THRESHOLD + 1, choice: 1 },
+      ]
+    })
+
+    it('should count the voter whose voting power equals the threshold', () => {
+      const result = VoteService.getSortedVoteCountPerUser(votes)
+      expect(result.map((voter) => voter.address)).toEqual([atThreshold, aboveThreshold])
+    })
+
+    it('should exclude the voter whose voting power is below the threshold', () => {
+      const result = VoteService.getSortedVoteCountPerUser(votes)
+      expect(result.map((voter) => voter.address)).not.toContain(belowThreshold)
+    })
   })
 })
 

--- a/src/services/vote.ts
+++ b/src/services/vote.ts
@@ -88,7 +88,7 @@ export class VoteService {
 
   public static getSortedVoteCountPerUser(votes: SnapshotVote[]) {
     const votesByUser = votes
-      .filter((vote) => vote.vp && vote.vp > VOTES_VP_THRESHOLD)
+      .filter((vote) => vote.vp && vote.vp >= VOTES_VP_THRESHOLD)
       .reduce((acc, vote) => {
         const address = vote.voter.toLowerCase()
         if (!acc[address]) {

--- a/src/utils/validations.test.ts
+++ b/src/utils/validations.test.ts
@@ -4,7 +4,14 @@ import { createTestProposal } from '../entities/Proposal/testHelpers'
 import { ProposalStatus, ProposalType } from '../entities/Proposal/types'
 import { EventType } from '../shared/types/events'
 
-import { validateEventFilters, validateId, validateStatusUpdate } from './validations'
+import {
+  extractImageUrls,
+  isValidImage,
+  validateBlockNumber,
+  validateEventFilters,
+  validateId,
+  validateStatusUpdate,
+} from './validations'
 
 describe('validateProposalId', () => {
   const UUID = '00000000-0000-0000-0000-000000000000'
@@ -101,5 +108,93 @@ describe('validateEventTypesFilters', () => {
     const req = { query: { event_type: 'single_event' } } as never
 
     expect(() => validateEventFilters(req)).toThrow()
+  })
+})
+
+describe('extractImageUrls', () => {
+  describe('when the markdown contains an inline image', () => {
+    it('should extract the url', () => {
+      expect(extractImageUrls('text ![alt](https://cdn.decentraland.org/a.png) more')).toEqual([
+        'https://cdn.decentraland.org/a.png',
+      ])
+    })
+  })
+
+  describe('when the inline image has a title after the url', () => {
+    it('should extract only the url and drop the title', () => {
+      expect(extractImageUrls('![alt](https://cdn.decentraland.org/a.png "a title")')).toEqual([
+        'https://cdn.decentraland.org/a.png',
+      ])
+    })
+  })
+
+  describe('when the markdown uses a reference-style image definition', () => {
+    it('should extract the referenced url', () => {
+      expect(extractImageUrls('[ref]: https://cdn.decentraland.org/a.png')).toEqual([
+        'https://cdn.decentraland.org/a.png',
+      ])
+    })
+  })
+
+  describe('when the markdown embeds a raw HTML img tag', () => {
+    it('should extract the src of a double-quoted img tag', () => {
+      expect(extractImageUrls('<img src="https://evil.example/track.png">')).toEqual(['https://evil.example/track.png'])
+    })
+
+    it('should extract the src of a single-quoted img tag that has other attributes first', () => {
+      expect(extractImageUrls("<img class='x' src='https://evil.example/track.png' />")).toEqual([
+        'https://evil.example/track.png',
+      ])
+    })
+
+    it('should extract the src of an unquoted img tag', () => {
+      expect(extractImageUrls('<img src=https://evil.example/track.png width=10>')).toEqual([
+        'https://evil.example/track.png',
+      ])
+    })
+  })
+
+  describe('when the markdown contains no images', () => {
+    it('should return an empty array', () => {
+      expect(extractImageUrls('just some text with a [link](https://decentraland.org)')).toEqual([])
+    })
+  })
+})
+
+describe('isValidImage', () => {
+  describe('when the url is not on a trusted domain', () => {
+    it('should return false without performing a request', async () => {
+      await expect(isValidImage('https://evil.example/track.png')).resolves.toBe(false)
+    })
+  })
+})
+
+describe('validateBlockNumber', () => {
+  describe('when the block number is a finite number', () => {
+    it('should not throw', () => {
+      expect(() => validateBlockNumber(12345)).not.toThrow()
+    })
+  })
+
+  describe('when the block number is null or undefined', () => {
+    it('should not throw for null', () => {
+      expect(() => validateBlockNumber(null)).not.toThrow()
+    })
+
+    it('should not throw for undefined', () => {
+      expect(() => validateBlockNumber(undefined)).not.toThrow()
+    })
+  })
+
+  describe('when the block number is NaN', () => {
+    it('should throw an invalid block number error', () => {
+      expect(() => validateBlockNumber(NaN)).toThrow('Invalid blockNumber')
+    })
+  })
+
+  describe('when the block number is a string', () => {
+    it('should throw an invalid block number error', () => {
+      expect(() => validateBlockNumber('12345')).toThrow('Invalid blockNumber')
+    })
   })
 })

--- a/src/utils/validations.ts
+++ b/src/utils/validations.ts
@@ -137,6 +137,10 @@ function timingSafeStringEqual(a: string, b: string): boolean {
 
 // Prefer the exact raw bytes captured before parsing (see server.ts) so the HMAC matches
 // what the sender signed; fall back to re-serialization if the raw body is unavailable.
+// IMPORTANT: rawBody is only captured for routes under the /api/webhooks prefix (see the
+// express.json verify hook in server.ts). Any new signature-verified webhook MUST be mounted
+// under that prefix — otherwise this falls back to JSON.stringify(req.body), whose key order
+// and whitespace may differ from the sender's payload and cause valid signatures to be rejected.
 function getWebhookPayload(req: Request): string {
   const rawBody = (req as unknown as { rawBody?: string }).rawBody
   return typeof rawBody === 'string' && rawBody.length > 0 ? rawBody : JSON.stringify(req.body)

--- a/src/utils/validations.ts
+++ b/src/utils/validations.ts
@@ -135,14 +135,21 @@ function timingSafeStringEqual(a: string, b: string): boolean {
   return bufA.length === bufB.length && crypto.timingSafeEqual(bufA, bufB)
 }
 
+// Prefer the exact raw bytes captured before parsing (see server.ts) so the HMAC matches
+// what the sender signed; fall back to re-serialization if the raw body is unavailable.
+function getWebhookPayload(req: Request): string {
+  const rawBody = (req as unknown as { rawBody?: string }).rawBody
+  return typeof rawBody === 'string' && rawBody.length > 0 ? rawBody : JSON.stringify(req.body)
+}
+
 export function validateDiscourseWebhookSignature(req: Request) {
   const providedSignature = req.get('X-Discourse-Event-Signature') || ''
   if (!DISCOURSE_WEBHOOK_SECRET || DISCOURSE_WEBHOOK_SECRET.length === 0) {
     throw new RequestError('Endpoint disabled', RequestError.NotImplemented)
   }
-  const payload = req.body
+  const payload = getWebhookPayload(req)
   const calculatedSignature = 'sha256='.concat(
-    crypto.createHmac('sha256', DISCOURSE_WEBHOOK_SECRET).update(JSON.stringify(payload)).digest('hex')
+    crypto.createHmac('sha256', DISCOURSE_WEBHOOK_SECRET).update(payload).digest('hex')
   )
 
   if (!timingSafeStringEqual(providedSignature, calculatedSignature)) {
@@ -156,7 +163,7 @@ export function validateAlchemyWebhookSignature(req: Request) {
   if (!ALCHEMY_DELEGATIONS_WEBHOOK_SECRET || ALCHEMY_DELEGATIONS_WEBHOOK_SECRET.length === 0) {
     throw new RequestError('Endpoint disabled', RequestError.NotImplemented)
   }
-  const body = JSON.stringify(req.body)
+  const body = getWebhookPayload(req)
   const hmac = crypto.createHmac('sha256', ALCHEMY_DELEGATIONS_WEBHOOK_SECRET)
   hmac.update(body, 'utf8')
   const digest = hmac.digest('hex')
@@ -230,7 +237,10 @@ export async function validateCanEditProject(user: string, projectId: string) {
 }
 
 export function validateBlockNumber(blockNumber?: unknown | null) {
-  if (blockNumber !== null && blockNumber !== undefined && typeof blockNumber !== 'number') {
+  if (blockNumber === null || blockNumber === undefined) {
+    return
+  }
+  if (typeof blockNumber !== 'number' || Number.isNaN(blockNumber)) {
     throw new Error('Invalid blockNumber: must be null, undefined, or a number')
   }
 }
@@ -272,13 +282,10 @@ const TRUSTED_IMAGE_DOMAINS = new Set([
   'i.postimg.cc',
   's3.amazonaws.com', // AWS S3
   'storage.googleapis.com', // Google Cloud Storage
-  'drive.google.com', // Google Drive
   'dropboxusercontent.com', // Dropbox
   'www.dropbox.com',
-  'media.discordapp.net', // Discord
+  'media.discordapp.net', // Discord CDN
   'cdn.discordapp.com',
-  'discord.com',
-  'discord.gg',
 ])
 
 function isFromTrustedDomain(url: string): boolean {
@@ -322,12 +329,23 @@ export async function isValidImage(imageUrl: string) {
 }
 
 export function extractImageUrls(markdown: string): string[] {
-  const imageRegex = /!\[.*?\]\((.*?)\)|\[.*?\]:\s*(.*?)(?:\s|$)/g
   const urls: string[] = []
   let match
 
-  while ((match = imageRegex.exec(markdown)) !== null) {
-    const url = match[1] || match[2]
+  // Markdown images ![alt](url) and reference-style [ref]: url
+  const markdownRegex = /!\[.*?\]\((.*?)\)|\[.*?\]:\s*(.*?)(?:\s|$)/g
+  while ((match = markdownRegex.exec(markdown)) !== null) {
+    // Take the first whitespace-delimited token so a trailing "title" (e.g. ![a](url "t"))
+    // does not smuggle an unvalidated URL past the trusted-domain check.
+    const url = (match[1] || match[2] || '').trim().split(/\s+/)[0]
+    if (url) urls.push(url)
+  }
+
+  // Raw HTML <img src=...> embeds (quoted or unquoted), which markdown renderers may honor
+  // and which would otherwise bypass the trusted-domain check entirely.
+  const htmlImgRegex = /<img\b[^>]*?\ssrc\s*=\s*(?:"([^"]*)"|'([^']*)'|([^\s"'>]+))/gi
+  while ((match = htmlImgRegex.exec(markdown)) !== null) {
+    const url = (match[1] || match[2] || match[3] || '').trim()
     if (url) urls.push(url)
   }
 


### PR DESCRIPTION
## What

Security and correctness hardening from a full backend audit. Grouped by severity.

### High
- **SSRF in `POST /url-title`** — now requires auth, resolves the host and rejects loopback/private/link-local/CGNAT/unique-local addresses (including alternate IPv6 spellings like `[0::1]`), and fetches with `redirect: 'manual'`.
- **Financial record delete/insert race** — `FinancialService.createRecords` now `await`s the delete before the insert so it can't wipe the just-inserted rows.

### Medium
- **`POST /budget/update`** gated behind a debug-address role.
- **Discourse update-comment dedup** — `isDiscourseEventRegistered` matches both `proposal_commented` and `project_update_commented`, so replays don't duplicate notifications.
- **Airdrop job** now `await`s all jobs with per-job error isolation (no unhandled rejection / premature "success").
- **Voted-event spoofing** — the event is only recorded after verifying the vote exists on Snapshot; title and choice are derived server-side (prevents activity-feed spoofing and stored XSS).
- **Subgraph errors** — new `queryGraphql` throws on non-2xx / GraphQL `errors`; `inBatches` reports failures and returns partial results instead of silently returning `[]`.
- **`updateProposalStatus`** runs the vesting work before persisting status, so a failure no longer leaves a half-enacted proposal.
- **Trusted-image bypass** — `extractImageUrls` now catches raw `<img>` (quoted and unquoted) and strips markdown title suffixes; non-image hosts removed from the allowlist.
- **API-key leakage** — base client no longer follows redirects, so secret headers aren't re-sent to a redirect target.

### Low
- Request timeouts on all external client fetches.
- Re-enactment guard so an identical re-enact doesn't wipe/regenerate pending updates.
- Address casing/equality fixes (`isDAOCommittee`, proposal owner check, non-throwing `isSameAddress`).
- Consistent VP threshold in vote counting.
- `ProposalModel.update` WHERE clause joins with `AND` instead of `,`.
- `GET /debug` requires auth; `report-error` input validated/capped.
- Alchemy webhook propagates errors and rejects bad signatures.
- `validateBlockNumber` rejects `NaN`; newsletter body uses `JSON.stringify`; API keys redacted in error reports; webhook HMAC verified over the raw request body.

## Tests
Added unit tests for the SSRF IP checks (`routes/common.test.ts`), image-URL extraction and `validateBlockNumber` (`utils/validations.test.ts`), `redactSecrets` and `inBatches` (`clients/utils.test.ts`), the vote VP threshold boundary (`services/vote.test.ts`), and the re-enactment guard (`services/ProposalService.test.ts`).

## Test plan
- `npx tsc -p . --noEmit` — clean
- `npx jest` — 35 suites, 395 passed, 1 skipped

## Notes
- No endpoints were removed in this PR (that analysis is being tracked separately).
- A couple of behavior changes are deliberate: subgraph failures now surface/report instead of returning `[]` (partial results preserved), and API clients no longer follow redirects.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
