### PR TITLE
chore: bump node 24 base image to 24.18.0-alpine

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM node:24-alpine@sha256:5fa278c599dbba0c8f873d8717d50ecbb57c5ae6a53b7ab240c25135e0b65995 as compiler
+FROM node:24-alpine@sha256:a0b9bf06e4e6193cf7a0f58816cc935ff8c2a908f81e6f1a95432d679c54fbfd as compiler
 ARG version_number
 ARG heroku_app_name
 ARG FRONT_BUILD_NODE_OPTIONS="--max-old-space-size=4096"
@@ -36,7 +36,7 @@ COPY ./.babelrc.json                          /app/.babelrc.json
 RUN NODE_OPTIONS="--max-old-space-size=4096" npm run build
 RUN npm prune --production --ignore-scripts
 
-FROM node:24-alpine@sha256:5fa278c599dbba0c8f873d8717d50ecbb57c5ae6a53b7ab240c25135e0b65995
+FROM node:24-alpine@sha256:a0b9bf06e4e6193cf7a0f58816cc935ff8c2a908f81e6f1a95432d679c54fbfd
 WORKDIR /app
 
 RUN rm -rf \


### PR DESCRIPTION
## what

bump both dockerfile build stages from the previously pinned early-24.x digest to the latest `node:24-alpine` (24.18.0) digest `sha256:a0b9bf06e4e6193cf7a0f58816cc935ff8c2a908f81e6f1a95432d679c54fbfd`.

## why

creating a proposal in zone fails at snapshot submission with a 500:

```
Invalid response body while trying to fetch https://testnet.seq.snapshot.org/: Premature close
code: ERR_STREAM_PREMATURE_CLOSE
```

the error comes from node-fetch (via cross-fetch@3, bundled inside `@snapshot-labs/snapshot.js@0.10.1`) failing to read the sequencer's response body — this path is untouched by the recent node-fetch→native migration. the failure correlates with the recent node 24 upgrade, and the pinned image is an early 24.x (already off docker hub's recent-tags list). bumping to 24.18.0 picks up http/stream fixes and is a low-risk, reversible first step.

## caveats

this is not a guaranteed fix — the failing fetch lives inside node-fetch, so a runtime patch only helps if the old 24.x carried the relevant regression. the sequencer itself is healthy (repeated GETs return 200). if this doesn't resolve it, the robust follow-up is a retry around the snapshot.js sequencer calls (`createProposal`/`castVote`/`cancelProposal`), since premature-close is a transient transport error.

## verification

needs a zone rebuild/redeploy from this dockerfile, then retry creating a proposal. full test suite passes locally (397 passed, 1 skipped).