### PR TITLE
fix: surface the real cause of discourse post failures

### DIFF
--- a/src/services/DiscourseService.ts
+++ b/src/services/DiscourseService.ts
@@ -51,12 +51,13 @@ export class DiscourseService {
       /* eslint-disable @typescript-eslint/no-explicit-any */
     } catch (error: any) {
       SnapshotService.dropSnapshotProposal(snapshotId)
+      const cause = error?.cause ? ` | cause: ${error.cause}` : ''
       ErrorService.report('Error creating discourse post', {
         proposalId,
-        error: `${error}`,
+        error: `${error}${cause}`,
         category: ErrorCategory.Discourse,
       })
-      throw new Error(`Forum error: ${error.body?.errors.join(', ')}`, error)
+      throw new Error(`Forum error: ${error?.message ?? error}`, { cause: error })
     }
   }
 
@@ -72,13 +73,14 @@ export class DiscourseService {
       this.logPostCreation(discourseUpdate)
       return discourseUpdate
     } catch (error: any) {
+      const cause = error?.cause ? ` | cause: ${error.cause}` : ''
       ErrorService.report('Error creating discourse post for update', {
         update_id: newUpdate.id,
         proposal_id: newUpdate.proposal_id,
-        error: `${error}`,
+        error: `${error}${cause}`,
         category: ErrorCategory.Discourse,
       })
-      throw new Error(`Forum error: ${error.body?.errors.join(', ')}`, error)
+      throw new Error(`Forum error: ${error?.message ?? error}`, { cause: error })
     }
   }
 


### PR DESCRIPTION
## what

when a discourse post fails, log `error.cause` and throw the error's `.message` (attaching the original via `{ cause }`), instead of reading a non-existent `error.body?.errors`.

## why

`api.fetch` was migrated to native fetch (#1935) and now throws plain `Error`s whose detail lives in `.message` (`HTTP error! status: …`) and, for transport failures, `.cause` (undici's `TypeError: fetch failed` wraps the real reason there). but `discourseservice` still read `error.body?.errors.join(', ')` — a leftover from the old gatsby api client that attached parsed bodies as `.body`.

result: `error.body` is always undefined, the optional chain short-circuits, and **every** forum failure surfaces as `Forum error: undefined` with the real cause discarded. this actively hid a real staging failure where creating a proposal returns:

```
Error creating discourse post — error: "TypeError: fetch failed"
```

whose `.cause` (not logged) is a dns failure against the dev forum host.

## fix

- log `${error}${cause}` so undici's `.cause` (e.g. `getaddrinfo ENOTFOUND forum.dcldaodev.xyz`) is captured
- throw `Forum error: ${error?.message ?? error}` — legible instead of `undefined`
- attach the original error via `{ cause }` (the previous `new Error(msg, error)` passed a non-options 2nd arg, so the cause was dropped)

applied to both `createProposal` and `createUpdate`.

## note

this is a logging/observability fix — it does not change the failure itself. the underlying staging failure is a separate infra issue (the dev forum host `forum.dcldaodev.xyz`, configured via `GATSBY_DISCOURSE_API` in definitions, does not resolve). full test suite passes (397 passed, 1 skipped).