### PR TITLE
test: cover the project routes and the ownership query behind them

### DIFF
--- a/.github/workflows/pull_request_build.yml
+++ b/.github/workflows/pull_request_build.yml
@@ -67,6 +67,9 @@ jobs:
     env:
       NODE_ENV: test
       CONNECTION_STRING: postgres://postgres:postgres@localhost:5432/governance_test
+      # Not a secret: the bid payload column is encrypted at rest, and the round trip only runs if
+      # both halves use the same key.
+      DB_ENCRYPTION_KEY: integration-test-key
 
     steps:
       - uses: actions/checkout@v4

--- a/package.json
+++ b/package.json
@@ -31,7 +31,10 @@
       "^.+\\.(t|j)s$": "ts-jest"
     },
     "testEnvironment": "node",
-    "resolver": "<rootDir>/export-maps-resolver.js"
+    "resolver": "<rootDir>/export-maps-resolver.js",
+    "setupFilesAfterEnv": [
+      "<rootDir>/test/setup/closeTestApps.ts"
+    ]
   },
   "repository": {
     "type": "git",

--- a/src/routes/badges.test.ts
+++ b/src/routes/badges.test.ts
@@ -143,8 +143,10 @@ describe('the badge routes', () => {
       })
 
       it('should fail rather than airdrop to nobody', () => {
-        // Recorded, not endorsed: the handler maps over recipients before checking it is a list.
-        expect(response.status).toBe(500)
+        // Refused rather than served. The status itself is known-wrong — a plain Error becomes a
+        // 500 where this should be a client error — and is fixed in the follow-up, so asserting
+        // refusal here means that fix will not have to rewrite this.
+        expect(response.body.ok).toBe(false)
       })
 
       it('should not hand out any badge', () => {

--- a/src/routes/badges.test.ts
+++ b/src/routes/badges.test.ts
@@ -1,0 +1,415 @@
+import { Server } from 'http'
+import supertest from 'supertest'
+
+import { storeBadgeSpec } from '../entities/Badges/storeBadgeSpec'
+import { ActionStatus } from '../entities/Badges/types'
+import { BadgesService } from '../services/BadgesService'
+import { createSpec } from '../utils/contractInteractions'
+
+import badges from './badges'
+import { createTestApp } from './testApp'
+
+const DEBUG_ADDRESS = '0x2AC89522CB415AC333E64F52a1a5693218cEBD58'
+const REGULAR_ADDRESS = '0x56d0B5eD3D525332F00C9BC938f93598ab16AAA7'
+const RECIPIENT = '0x49E4DbfF86a2E5DA27c540c9A9E8D2C3726E278F'
+const BADGE_CID = 'bafybeib-badge-spec-cid'
+
+jest.mock('decentraland-gatsby/dist/entities/Auth/middleware', () => ({
+  auth:
+    (options?: { optional?: boolean }) =>
+    (
+      req: { get: (name: string) => string | undefined; auth?: string },
+      res: { status: (code: number) => { json: (body: unknown) => void } },
+      next: () => void
+    ) => {
+      const address = req.get('x-test-auth')
+      if (address) {
+        req.auth = address
+        return next()
+      }
+      if (options?.optional) {
+        return next()
+      }
+      res.status(401).json({ ok: false, error: 'Unauthorized' })
+    },
+}))
+
+jest.mock('../entities/Debug/isDebugAddress', () => ({
+  __esModule: true,
+  default: (address?: string) => address === '0x2AC89522CB415AC333E64F52a1a5693218cEBD58',
+}))
+
+jest.mock('../entities/Badges/storeBadgeSpec', () => ({ storeBadgeSpec: jest.fn() }))
+jest.mock('../utils/contractInteractions', () => ({ createSpec: jest.fn() }))
+
+// Airdropping and revoking badges are privileged actions, so every write here is gated on the
+// caller being a debug address rather than merely signed in.
+describe('the badge routes', () => {
+  let app: Server
+
+  beforeEach(() => {
+    app = createTestApp(badges)
+  })
+
+  afterEach(() => {
+    jest.restoreAllMocks()
+    jest.clearAllMocks()
+  })
+
+  describe('POST /api/badges/airdrop', () => {
+    let giveBadgeToUsers: jest.SpyInstance
+    let response: supertest.Response
+
+    beforeEach(() => {
+      giveBadgeToUsers = jest.spyOn(BadgesService, 'giveBadgeToUsers').mockResolvedValue({} as never)
+    })
+
+    describe('when the caller is unauthenticated', () => {
+      beforeEach(async () => {
+        response = await supertest(app)
+          .post('/api/badges/airdrop/')
+          .send({ badgeSpecCid: BADGE_CID, recipients: [RECIPIENT] })
+      })
+
+      it('should respond with a 401', () => {
+        expect(response.status).toBe(401)
+      })
+
+      it('should not hand out any badge', () => {
+        expect(giveBadgeToUsers).not.toHaveBeenCalled()
+      })
+    })
+
+    describe('when the caller is signed in but not a debug address', () => {
+      beforeEach(async () => {
+        response = await supertest(app)
+          .post('/api/badges/airdrop/')
+          .set('x-test-auth', REGULAR_ADDRESS)
+          .send({ badgeSpecCid: BADGE_CID, recipients: [RECIPIENT] })
+      })
+
+      it('should refuse the airdrop', () => {
+        expect(response.status).toBe(401)
+      })
+
+      it('should not hand out any badge', () => {
+        expect(giveBadgeToUsers).not.toHaveBeenCalled()
+      })
+    })
+
+    describe('when a recipient is not an ethereum address', () => {
+      beforeEach(async () => {
+        response = await supertest(app)
+          .post('/api/badges/airdrop/')
+          .set('x-test-auth', DEBUG_ADDRESS)
+          .send({ badgeSpecCid: BADGE_CID, recipients: [RECIPIENT, 'not-an-address'] })
+      })
+
+      it('should reject the whole request', () => {
+        expect(response.status).toBe(400)
+      })
+
+      it('should not hand out a badge to the valid recipients either', () => {
+        expect(giveBadgeToUsers).not.toHaveBeenCalled()
+      })
+    })
+
+    describe('when the badge spec cid is missing', () => {
+      beforeEach(async () => {
+        response = await supertest(app)
+          .post('/api/badges/airdrop/')
+          .set('x-test-auth', DEBUG_ADDRESS)
+          .send({ recipients: [RECIPIENT] })
+      })
+
+      it('should reject the request', () => {
+        expect(response.status).toBe(400)
+      })
+
+      it('should not hand out any badge', () => {
+        expect(giveBadgeToUsers).not.toHaveBeenCalled()
+      })
+    })
+
+    // Recorded, not endorsed: the handler maps over recipients before checking it is a list, so a
+    // debug address that omits the field gets a 500 rather than a 400. Only a debug address can
+    // reach it, which is why it is a note rather than a fix.
+    describe('when a debug address omits the recipient list entirely', () => {
+      beforeEach(async () => {
+        response = await supertest(app)
+          .post('/api/badges/airdrop/')
+          .set('x-test-auth', DEBUG_ADDRESS)
+          .send({ badgeSpecCid: BADGE_CID })
+      })
+
+      it('should fail rather than airdrop to nobody', () => {
+        expect(response.status).toBeGreaterThanOrEqual(400)
+      })
+
+      it('should not hand out any badge', () => {
+        expect(giveBadgeToUsers).not.toHaveBeenCalled()
+      })
+    })
+
+    describe('when a debug address airdrops to valid recipients', () => {
+      beforeEach(async () => {
+        response = await supertest(app)
+          .post('/api/badges/airdrop/')
+          .set('x-test-auth', DEBUG_ADDRESS)
+          .send({ badgeSpecCid: BADGE_CID, recipients: [RECIPIENT] })
+      })
+
+      it('should hand out the badge to exactly those recipients', () => {
+        expect(giveBadgeToUsers).toHaveBeenCalledWith(BADGE_CID, [RECIPIENT])
+      })
+
+      it('should respond successfully', () => {
+        expect(response.status).toBe(201)
+      })
+    })
+  })
+
+  describe('POST /api/badges/revoke', () => {
+    let revokeBadge: jest.SpyInstance
+    let response: supertest.Response
+
+    beforeEach(() => {
+      revokeBadge = jest.spyOn(BadgesService, 'revokeBadge').mockResolvedValue([] as never)
+    })
+
+    describe('when the caller is signed in but not a debug address', () => {
+      beforeEach(async () => {
+        response = await supertest(app)
+          .post('/api/badges/revoke/')
+          .set('x-test-auth', REGULAR_ADDRESS)
+          .send({ badgeSpecCid: BADGE_CID, recipients: [RECIPIENT] })
+      })
+
+      it('should refuse the revocation', () => {
+        expect(response.status).toBe(401)
+      })
+
+      it('should not revoke anything', () => {
+        expect(revokeBadge).not.toHaveBeenCalled()
+      })
+    })
+
+    describe('when the reason is not one the contract accepts', () => {
+      beforeEach(async () => {
+        response = await supertest(app)
+          .post('/api/badges/revoke/')
+          .set('x-test-auth', DEBUG_ADDRESS)
+          .send({ badgeSpecCid: BADGE_CID, recipients: [RECIPIENT], reason: 'because I said so' })
+      })
+
+      it('should reject the request', () => {
+        expect(response.status).toBe(400)
+      })
+
+      it('should not revoke anything', () => {
+        expect(revokeBadge).not.toHaveBeenCalled()
+      })
+    })
+
+    describe('when no reason is given', () => {
+      beforeEach(async () => {
+        response = await supertest(app)
+          .post('/api/badges/revoke/')
+          .set('x-test-auth', DEBUG_ADDRESS)
+          .send({ badgeSpecCid: BADGE_CID, recipients: [RECIPIENT] })
+      })
+
+      it('should revoke without one rather than inventing a default', () => {
+        expect(revokeBadge).toHaveBeenCalledWith(BADGE_CID, [RECIPIENT], undefined)
+      })
+    })
+
+    describe('when a recipient is not an ethereum address', () => {
+      beforeEach(async () => {
+        response = await supertest(app)
+          .post('/api/badges/revoke/')
+          .set('x-test-auth', DEBUG_ADDRESS)
+          .send({ badgeSpecCid: BADGE_CID, recipients: ['not-an-address'] })
+      })
+
+      it('should reject the request', () => {
+        expect(response.status).toBe(400)
+      })
+    })
+  })
+
+  describe('POST /api/badges/upload-badge-spec', () => {
+    let response: supertest.Response
+    const spec = { title: 'A badge', description: 'What it is for', imgUrl: 'https://example.com/badge.png' }
+
+    describe('when the caller is signed in but not a debug address', () => {
+      beforeEach(async () => {
+        response = await supertest(app)
+          .post('/api/badges/upload-badge-spec/')
+          .set('x-test-auth', REGULAR_ADDRESS)
+          .send(spec)
+      })
+
+      it('should refuse the upload', () => {
+        expect(response.status).toBe(401)
+      })
+
+      it('should not store a spec', () => {
+        expect(storeBadgeSpec).not.toHaveBeenCalled()
+      })
+    })
+
+    describe('when a required field is missing', () => {
+      beforeEach(async () => {
+        response = await supertest(app)
+          .post('/api/badges/upload-badge-spec/')
+          .set('x-test-auth', DEBUG_ADDRESS)
+          .send({ title: 'A badge', description: 'What it is for' })
+      })
+
+      it('should reject the request', () => {
+        expect(response.status).toBe(400)
+      })
+
+      it('should not store a spec', () => {
+        expect(storeBadgeSpec).not.toHaveBeenCalled()
+      })
+    })
+
+    describe('when the expiry is not a date', () => {
+      beforeEach(async () => {
+        response = await supertest(app)
+          .post('/api/badges/upload-badge-spec/')
+          .set('x-test-auth', DEBUG_ADDRESS)
+          .send({ ...spec, expiresAt: 'whenever' })
+      })
+
+      it('should reject the request', () => {
+        expect(response.status).toBe(400)
+      })
+    })
+
+    describe('when a debug address uploads a valid spec', () => {
+      beforeEach(async () => {
+        ;(storeBadgeSpec as jest.Mock).mockResolvedValue({ badgeCid: BADGE_CID })
+        response = await supertest(app)
+          .post('/api/badges/upload-badge-spec/')
+          .set('x-test-auth', DEBUG_ADDRESS)
+          .send(spec)
+      })
+
+      it('should report success with the stored cid', () => {
+        expect(response.body.data).toEqual({ status: ActionStatus.Success, badgeCid: BADGE_CID })
+      })
+    })
+
+    // Storage failures are reported in the body rather than as an error status, so the client sees
+    // a structured outcome instead of a 500.
+    describe('when storing the spec fails', () => {
+      beforeEach(async () => {
+        ;(storeBadgeSpec as jest.Mock).mockRejectedValue(new Error('ipfs unavailable'))
+        response = await supertest(app)
+          .post('/api/badges/upload-badge-spec/')
+          .set('x-test-auth', DEBUG_ADDRESS)
+          .send(spec)
+      })
+
+      it('should still respond successfully', () => {
+        expect(response.status).toBe(201)
+      })
+
+      it('should report the failure in the body', () => {
+        expect(response.body.data.status).toBe(ActionStatus.Failed)
+      })
+    })
+  })
+
+  describe('POST /api/badges/create-badge-spec', () => {
+    let response: supertest.Response
+
+    describe('when the caller is signed in but not a debug address', () => {
+      beforeEach(async () => {
+        response = await supertest(app)
+          .post('/api/badges/create-badge-spec/')
+          .set('x-test-auth', REGULAR_ADDRESS)
+          .send({ badgeCid: BADGE_CID })
+      })
+
+      it('should refuse the request', () => {
+        expect(response.status).toBe(401)
+      })
+
+      it('should not create a spec on chain', () => {
+        expect(createSpec).not.toHaveBeenCalled()
+      })
+    })
+
+    describe('when the badge cid is missing', () => {
+      beforeEach(async () => {
+        response = await supertest(app)
+          .post('/api/badges/create-badge-spec/')
+          .set('x-test-auth', DEBUG_ADDRESS)
+          .send({})
+      })
+
+      it('should reject the request', () => {
+        expect(response.status).toBe(400)
+      })
+
+      it('should not create a spec on chain', () => {
+        expect(createSpec).not.toHaveBeenCalled()
+      })
+    })
+
+    describe('when a debug address creates a spec', () => {
+      beforeEach(async () => {
+        ;(createSpec as jest.Mock).mockResolvedValue({ hash: '0xabc' })
+        response = await supertest(app)
+          .post('/api/badges/create-badge-spec/')
+          .set('x-test-auth', DEBUG_ADDRESS)
+          .send({ badgeCid: BADGE_CID })
+      })
+
+      it('should create it with the given cid', () => {
+        expect(createSpec).toHaveBeenCalledWith(BADGE_CID)
+      })
+
+      it('should report success', () => {
+        expect(response.body.data.status).toBe(ActionStatus.Success)
+      })
+    })
+  })
+
+  describe('GET /api/badges/:address', () => {
+    let getBadges: jest.SpyInstance
+    let response: supertest.Response
+
+    beforeEach(() => {
+      getBadges = jest.spyOn(BadgesService, 'getBadges').mockResolvedValue({} as never)
+    })
+
+    describe('when the address is not an ethereum address', () => {
+      beforeEach(async () => {
+        response = await supertest(app).get('/api/badges/not-an-address/')
+      })
+
+      it('should respond with a 400', () => {
+        expect(response.status).toBe(400)
+      })
+
+      it('should not run the lookup', () => {
+        expect(getBadges).not.toHaveBeenCalled()
+      })
+    })
+
+    describe('when the address is valid', () => {
+      beforeEach(async () => {
+        response = await supertest(app).get(`/api/badges/${RECIPIENT}/`)
+      })
+
+      it('should look up that address without requiring authentication', () => {
+        expect(getBadges).toHaveBeenCalledWith(RECIPIENT)
+      })
+    })
+  })
+})

--- a/src/routes/badges.test.ts
+++ b/src/routes/badges.test.ts
@@ -146,7 +146,9 @@ describe('the badge routes', () => {
         // Refused rather than served. The status itself is known-wrong — a plain Error becomes a
         // 500 where this should be a client error — and is fixed in the follow-up, so asserting
         // refusal here means that fix will not have to rewrite this.
-        expect(response.body.ok).toBe(false)
+        // response.ok is superagent's 2xx flag, so this also rules out a 200 that merely says
+        // ok:false in its body. still no exact status, which is the point.
+        expect({ http: response.ok, body: response.body.ok }).toEqual({ http: false, body: false })
       })
 
       it('should not hand out any badge', () => {

--- a/src/routes/badges.test.ts
+++ b/src/routes/badges.test.ts
@@ -143,7 +143,8 @@ describe('the badge routes', () => {
       })
 
       it('should fail rather than airdrop to nobody', () => {
-        expect(response.status).toBeGreaterThanOrEqual(400)
+        // Recorded, not endorsed: the handler maps over recipients before checking it is a list.
+        expect(response.status).toBe(500)
       })
 
       it('should not hand out any badge', () => {

--- a/src/routes/budget.test.ts
+++ b/src/routes/budget.test.ts
@@ -120,8 +120,10 @@ describe('the budget routes', () => {
       })
 
       it('should reject the request', () => {
-        // Recorded, not endorsed: toNewGrantCategory raises a plain Error.
-        expect(response.status).toBe(500)
+        // Refused rather than served. The status itself is known-wrong — a plain Error becomes a
+        // 500 where this should be a client error — and is fixed in the follow-up, so asserting
+        // refusal here means that fix will not have to rewrite this.
+        expect(response.body.ok).toBe(false)
       })
 
       it('should not run the lookup', () => {

--- a/src/routes/budget.test.ts
+++ b/src/routes/budget.test.ts
@@ -120,7 +120,8 @@ describe('the budget routes', () => {
       })
 
       it('should reject the request', () => {
-        expect(response.status).toBeGreaterThanOrEqual(400)
+        // Recorded, not endorsed: toNewGrantCategory raises a plain Error.
+        expect(response.status).toBe(500)
       })
 
       it('should not run the lookup', () => {

--- a/src/routes/budget.test.ts
+++ b/src/routes/budget.test.ts
@@ -123,7 +123,9 @@ describe('the budget routes', () => {
         // Refused rather than served. The status itself is known-wrong — a plain Error becomes a
         // 500 where this should be a client error — and is fixed in the follow-up, so asserting
         // refusal here means that fix will not have to rewrite this.
-        expect(response.body.ok).toBe(false)
+        // response.ok is superagent's 2xx flag, so this also rules out a 200 that merely says
+        // ok:false in its body. still no exact status, which is the point.
+        expect({ http: response.ok, body: response.body.ok }).toEqual({ http: false, body: false })
       })
 
       it('should not run the lookup', () => {

--- a/src/routes/budget.test.ts
+++ b/src/routes/budget.test.ts
@@ -1,0 +1,188 @@
+import { Server } from 'http'
+import supertest from 'supertest'
+
+import { NewGrantCategory } from '../entities/Grant/types'
+import { BudgetService } from '../services/BudgetService'
+
+import budget from './budget'
+import { createTestApp } from './testApp'
+
+const DEBUG_ADDRESS = '0x2AC89522CB415AC333E64F52a1a5693218cEBD58'
+const REGULAR_ADDRESS = '0x56d0B5eD3D525332F00C9BC938f93598ab16AAA7'
+const PROPOSAL_ID = '00000000-0000-0000-0000-000000000001'
+
+jest.mock('decentraland-gatsby/dist/entities/Auth/middleware', () => ({
+  auth:
+    (options?: { optional?: boolean }) =>
+    (
+      req: { get: (name: string) => string | undefined; auth?: string },
+      res: { status: (code: number) => { json: (body: unknown) => void } },
+      next: () => void
+    ) => {
+      const address = req.get('x-test-auth')
+      if (address) {
+        req.auth = address
+        return next()
+      }
+      if (options?.optional) {
+        return next()
+      }
+      res.status(401).json({ ok: false, error: 'Unauthorized' })
+    },
+}))
+
+jest.mock('../entities/Debug/isDebugAddress', () => ({
+  __esModule: true,
+  default: (address?: string) => address === '0x2AC89522CB415AC333E64F52a1a5693218cEBD58',
+}))
+
+describe('the budget routes', () => {
+  let app: Server
+
+  beforeEach(() => {
+    app = createTestApp(budget)
+  })
+
+  afterEach(() => {
+    jest.restoreAllMocks()
+  })
+
+  // Rebuilding the quarter budgets rewrites what every grant is charged against, so it is not
+  // something any signed wallet may trigger.
+  describe('POST /api/budget/update', () => {
+    let updateGovernanceBudgets: jest.SpyInstance
+    let response: supertest.Response
+
+    beforeEach(() => {
+      updateGovernanceBudgets = jest.spyOn(BudgetService, 'updateGovernanceBudgets').mockResolvedValue([] as never)
+    })
+
+    describe('when the caller is unauthenticated', () => {
+      beforeEach(async () => {
+        response = await supertest(app).post('/api/budget/update/')
+      })
+
+      it('should respond with a 401', () => {
+        expect(response.status).toBe(401)
+      })
+
+      it('should not rebuild the budgets', () => {
+        expect(updateGovernanceBudgets).not.toHaveBeenCalled()
+      })
+    })
+
+    describe('when the caller is signed in but not a debug address', () => {
+      beforeEach(async () => {
+        response = await supertest(app).post('/api/budget/update/').set('x-test-auth', REGULAR_ADDRESS)
+      })
+
+      it('should refuse the request', () => {
+        expect(response.status).toBe(401)
+      })
+
+      it('should not rebuild the budgets', () => {
+        expect(updateGovernanceBudgets).not.toHaveBeenCalled()
+      })
+    })
+
+    describe('when a debug address triggers it', () => {
+      beforeEach(async () => {
+        await supertest(app).post('/api/budget/update/').set('x-test-auth', DEBUG_ADDRESS)
+      })
+
+      it('should rebuild the budgets', () => {
+        expect(updateGovernanceBudgets).toHaveBeenCalled()
+      })
+    })
+  })
+
+  describe('GET /api/budget/:category', () => {
+    let getCategoryBudget: jest.SpyInstance
+    let response: supertest.Response
+
+    beforeEach(() => {
+      getCategoryBudget = jest.spyOn(BudgetService, 'getCategoryBudget').mockResolvedValue({} as never)
+    })
+
+    describe('when the category is a known grant category', () => {
+      beforeEach(async () => {
+        await supertest(app).get('/api/budget/platform')
+      })
+
+      it('should look up that category', () => {
+        expect(getCategoryBudget).toHaveBeenCalledWith(NewGrantCategory.Platform)
+      })
+    })
+
+    describe('when the category is not a known one', () => {
+      beforeEach(async () => {
+        response = await supertest(app).get('/api/budget/not-a-category')
+      })
+
+      it('should reject the request', () => {
+        expect(response.status).toBeGreaterThanOrEqual(400)
+      })
+
+      it('should not run the lookup', () => {
+        expect(getCategoryBudget).not.toHaveBeenCalled()
+      })
+    })
+  })
+
+  describe('GET /api/budget/contested/:proposal', () => {
+    let getBudgetWithContestants: jest.SpyInstance
+    let response: supertest.Response
+
+    beforeEach(() => {
+      getBudgetWithContestants = jest.spyOn(BudgetService, 'getBudgetWithContestants').mockResolvedValue({} as never)
+    })
+
+    describe('when the proposal id is not a uuid', () => {
+      beforeEach(async () => {
+        response = await supertest(app).get('/api/budget/contested/not-a-uuid')
+      })
+
+      it('should respond with a 400', () => {
+        expect(response.status).toBe(400)
+      })
+
+      it('should not run the lookup', () => {
+        expect(getBudgetWithContestants).not.toHaveBeenCalled()
+      })
+    })
+
+    describe('when the proposal id is a uuid', () => {
+      beforeEach(async () => {
+        await supertest(app).get(`/api/budget/contested/${PROPOSAL_ID}`)
+      })
+
+      it('should look up that proposal', () => {
+        expect(getBudgetWithContestants).toHaveBeenCalledWith(PROPOSAL_ID)
+      })
+    })
+  })
+
+  describe('the public budget reads', () => {
+    const cases = [
+      { path: '/api/budget/all', method: 'getAllBudgets' as const },
+      { path: '/api/budget/current', method: 'getCurrentBudget' as const },
+      { path: '/api/budget/current-contested', method: 'getCurrentContestedBudget' as const },
+      { path: '/api/budget/fetch/', method: 'getTransparencyBudgets' as const },
+    ]
+
+    cases.forEach(({ path, method }) => {
+      describe(`when ${path} is requested`, () => {
+        let service: jest.SpyInstance
+
+        beforeEach(async () => {
+          service = jest.spyOn(BudgetService, method).mockResolvedValue([] as never)
+          await supertest(app).get(path)
+        })
+
+        it('should be served without requiring authentication', () => {
+          expect(service).toHaveBeenCalled()
+        })
+      })
+    })
+  })
+})

--- a/src/routes/coauthor.test.ts
+++ b/src/routes/coauthor.test.ts
@@ -136,7 +136,8 @@ describe('PUT /api/coauthors/:proposal', () => {
     })
 
     it('should fail rather than report success for a row it never changed', () => {
-      expect(response.status).toBeGreaterThanOrEqual(400)
+      // Recorded, not endorsed: the handler raises a plain Error.
+      expect(response.status).toBe(500)
     })
   })
 
@@ -150,7 +151,8 @@ describe('PUT /api/coauthors/:proposal', () => {
     })
 
     it('should refuse the change', () => {
-      expect(response.status).toBeGreaterThanOrEqual(400)
+      // Recorded, not endorsed: the handler raises a plain Error.
+      expect(response.status).toBe(500)
     })
 
     it('should not touch the invitation', () => {

--- a/src/routes/coauthor.test.ts
+++ b/src/routes/coauthor.test.ts
@@ -136,8 +136,10 @@ describe('PUT /api/coauthors/:proposal', () => {
     })
 
     it('should fail rather than report success for a row it never changed', () => {
-      // Recorded, not endorsed: the handler raises a plain Error.
-      expect(response.status).toBe(500)
+      // Refused rather than served. The status itself is known-wrong — a plain Error becomes a
+      // 500 where this should be a client error — and is fixed in the follow-up, so asserting
+      // refusal here means that fix will not have to rewrite this.
+      expect(response.body.ok).toBe(false)
     })
   })
 
@@ -151,8 +153,10 @@ describe('PUT /api/coauthors/:proposal', () => {
     })
 
     it('should refuse the change', () => {
-      // Recorded, not endorsed: the handler raises a plain Error.
-      expect(response.status).toBe(500)
+      // Refused rather than served. The status itself is known-wrong — a plain Error becomes a
+      // 500 where this should be a client error — and is fixed in the follow-up, so asserting
+      // refusal here means that fix will not have to rewrite this.
+      expect(response.body.ok).toBe(false)
     })
 
     it('should not touch the invitation', () => {

--- a/src/routes/coauthor.test.ts
+++ b/src/routes/coauthor.test.ts
@@ -139,7 +139,9 @@ describe('PUT /api/coauthors/:proposal', () => {
       // Refused rather than served. The status itself is known-wrong — a plain Error becomes a
       // 500 where this should be a client error — and is fixed in the follow-up, so asserting
       // refusal here means that fix will not have to rewrite this.
-      expect(response.body.ok).toBe(false)
+      // response.ok is superagent's 2xx flag, so this also rules out a 200 that merely says
+      // ok:false in its body. still no exact status, which is the point.
+      expect({ http: response.ok, body: response.body.ok }).toEqual({ http: false, body: false })
     })
   })
 
@@ -156,7 +158,9 @@ describe('PUT /api/coauthors/:proposal', () => {
       // Refused rather than served. The status itself is known-wrong — a plain Error becomes a
       // 500 where this should be a client error — and is fixed in the follow-up, so asserting
       // refusal here means that fix will not have to rewrite this.
-      expect(response.body.ok).toBe(false)
+      // response.ok is superagent's 2xx flag, so this also rules out a 200 that merely says
+      // ok:false in its body. still no exact status, which is the point.
+      expect({ http: response.ok, body: response.body.ok }).toEqual({ http: false, body: false })
     })
 
     it('should not touch the invitation', () => {

--- a/src/routes/coauthor.test.ts
+++ b/src/routes/coauthor.test.ts
@@ -1,4 +1,4 @@
-import { Express } from 'express'
+import { Server } from 'http'
 import supertest from 'supertest'
 
 import CoauthorModel from '../entities/Coauthor/model'
@@ -49,7 +49,7 @@ function finishedProposal() {
 }
 
 describe('PUT /api/coauthors/:proposal', () => {
-  let app: Express
+  let app: Server
   let update: jest.SpyInstance
   let response: supertest.Response
 
@@ -195,7 +195,7 @@ describe('PUT /api/coauthors/:proposal', () => {
 })
 
 describe('GET /api/coauthors/proposals/:address/:status?', () => {
-  let app: Express
+  let app: Server
   let findProposals: jest.SpyInstance
   let response: supertest.Response
 

--- a/src/routes/debug.test.ts
+++ b/src/routes/debug.test.ts
@@ -124,7 +124,8 @@ describe('POST /api/debug/trigger', () => {
     })
 
     it('should not treat the name as callable', () => {
-      expect(response.status).toBeGreaterThanOrEqual(400)
+      // Recorded, not endorsed: the handler raises a plain Error for an unknown name.
+      expect(response.status).toBe(500)
     })
   })
 })
@@ -155,7 +156,8 @@ describe('DELETE /api/debug/invalidate-cache', () => {
     })
 
     it('should reject the request', () => {
-      expect(response.status).toBeGreaterThanOrEqual(400)
+      // Recorded, not endorsed: the handler raises a plain Error for a missing cache key.
+      expect(response.status).toBe(500)
     })
   })
 })

--- a/src/routes/debug.test.ts
+++ b/src/routes/debug.test.ts
@@ -127,7 +127,9 @@ describe('POST /api/debug/trigger', () => {
       // Refused rather than served. The status itself is known-wrong — a plain Error becomes a
       // 500 where this should be a client error — and is fixed in the follow-up, so asserting
       // refusal here means that fix will not have to rewrite this.
-      expect(response.body.ok).toBe(false)
+      // response.ok is superagent's 2xx flag, so this also rules out a 200 that merely says
+      // ok:false in its body. still no exact status, which is the point.
+      expect({ http: response.ok, body: response.body.ok }).toEqual({ http: false, body: false })
     })
   })
 })
@@ -161,7 +163,9 @@ describe('DELETE /api/debug/invalidate-cache', () => {
       // Refused rather than served. The status itself is known-wrong — a plain Error becomes a
       // 500 where this should be a client error — and is fixed in the follow-up, so asserting
       // refusal here means that fix will not have to rewrite this.
-      expect(response.body.ok).toBe(false)
+      // response.ok is superagent's 2xx flag, so this also rules out a 200 that merely says
+      // ok:false in its body. still no exact status, which is the point.
+      expect({ http: response.ok, body: response.body.ok }).toEqual({ http: false, body: false })
     })
   })
 })

--- a/src/routes/debug.test.ts
+++ b/src/routes/debug.test.ts
@@ -1,4 +1,4 @@
-import { Express } from 'express'
+import { Server } from 'http'
 import supertest from 'supertest'
 
 import { ErrorService } from '../services/ErrorService'
@@ -42,7 +42,7 @@ jest.mock('../constants', () => ({
 }))
 
 describe('GET /api/debug', () => {
-  let app: Express
+  let app: Server
   let response: supertest.Response
 
   beforeEach(() => {
@@ -95,7 +95,7 @@ describe('GET /api/debug', () => {
 })
 
 describe('POST /api/debug/trigger', () => {
-  let app: Express
+  let app: Server
   let response: supertest.Response
 
   beforeEach(() => {
@@ -130,7 +130,7 @@ describe('POST /api/debug/trigger', () => {
 })
 
 describe('DELETE /api/debug/invalidate-cache', () => {
-  let app: Express
+  let app: Server
   let response: supertest.Response
 
   beforeEach(() => {
@@ -161,7 +161,7 @@ describe('DELETE /api/debug/invalidate-cache', () => {
 })
 
 describe('POST /api/debug/report-error', () => {
-  let app: Express
+  let app: Server
   let report: jest.SpyInstance
 
   beforeEach(() => {

--- a/src/routes/debug.test.ts
+++ b/src/routes/debug.test.ts
@@ -124,8 +124,10 @@ describe('POST /api/debug/trigger', () => {
     })
 
     it('should not treat the name as callable', () => {
-      // Recorded, not endorsed: the handler raises a plain Error for an unknown name.
-      expect(response.status).toBe(500)
+      // Refused rather than served. The status itself is known-wrong — a plain Error becomes a
+      // 500 where this should be a client error — and is fixed in the follow-up, so asserting
+      // refusal here means that fix will not have to rewrite this.
+      expect(response.body.ok).toBe(false)
     })
   })
 })
@@ -156,8 +158,10 @@ describe('DELETE /api/debug/invalidate-cache', () => {
     })
 
     it('should reject the request', () => {
-      // Recorded, not endorsed: the handler raises a plain Error for a missing cache key.
-      expect(response.status).toBe(500)
+      // Refused rather than served. The status itself is known-wrong — a plain Error becomes a
+      // 500 where this should be a client error — and is fixed in the follow-up, so asserting
+      // refusal here means that fix will not have to rewrite this.
+      expect(response.body.ok).toBe(false)
     })
   })
 })

--- a/src/routes/events.test.ts
+++ b/src/routes/events.test.ts
@@ -1,0 +1,204 @@
+import { Server } from 'http'
+import supertest from 'supertest'
+
+import { EventsService } from '../services/events'
+
+import events from './events'
+import { createTestApp } from './testApp'
+
+const DEBUG_ADDRESS = '0x2AC89522CB415AC333E64F52a1a5693218cEBD58'
+const REGULAR_ADDRESS = '0x56d0B5eD3D525332F00C9BC938f93598ab16AAA7'
+const PROPOSAL_ID = '00000000-0000-0000-0000-000000000001'
+
+jest.mock('decentraland-gatsby/dist/entities/Auth/middleware', () => ({
+  auth:
+    (options?: { optional?: boolean }) =>
+    (
+      req: { get: (name: string) => string | undefined; auth?: string },
+      res: { status: (code: number) => { json: (body: unknown) => void } },
+      next: () => void
+    ) => {
+      const address = req.get('x-test-auth')
+      if (address) {
+        req.auth = address
+        return next()
+      }
+      if (options?.optional) {
+        return next()
+      }
+      res.status(401).json({ ok: false, error: 'Unauthorized' })
+    },
+}))
+
+jest.mock('../entities/Debug/isDebugAddress', () => ({
+  __esModule: true,
+  default: (address?: string) => address === '0x2AC89522CB415AC333E64F52a1a5693218cEBD58',
+}))
+
+describe('the event routes', () => {
+  let app: Server
+
+  beforeEach(() => {
+    app = createTestApp(events)
+  })
+
+  afterEach(() => {
+    jest.restoreAllMocks()
+  })
+
+  // The unfiltered feed is not the same as the public activity ticker, so it is debug-only.
+  describe('GET /api/events/all', () => {
+    let getAll: jest.SpyInstance
+    let response: supertest.Response
+
+    beforeEach(() => {
+      getAll = jest.spyOn(EventsService, 'getAll').mockResolvedValue([] as never)
+    })
+
+    describe('when the caller is unauthenticated', () => {
+      beforeEach(async () => {
+        response = await supertest(app).get('/api/events/all')
+      })
+
+      it('should respond with a 401', () => {
+        expect(response.status).toBe(401)
+      })
+
+      it('should not read the events', () => {
+        expect(getAll).not.toHaveBeenCalled()
+      })
+    })
+
+    describe('when the caller is signed in but not a debug address', () => {
+      beforeEach(async () => {
+        response = await supertest(app).get('/api/events/all').set('x-test-auth', REGULAR_ADDRESS)
+      })
+
+      it('should refuse the request', () => {
+        expect(response.status).toBe(401)
+      })
+
+      it('should not read the events', () => {
+        expect(getAll).not.toHaveBeenCalled()
+      })
+    })
+
+    describe('when the caller is a debug address', () => {
+      beforeEach(async () => {
+        await supertest(app).get('/api/events/all').set('x-test-auth', DEBUG_ADDRESS)
+      })
+
+      it('should read the events', () => {
+        expect(getAll).toHaveBeenCalled()
+      })
+    })
+  })
+
+  describe('POST /api/events/voted', () => {
+    let voted: jest.SpyInstance
+    let response: supertest.Response
+
+    beforeEach(() => {
+      voted = jest.spyOn(EventsService, 'voted').mockResolvedValue({} as never)
+    })
+
+    describe('when the caller is unauthenticated', () => {
+      beforeEach(async () => {
+        response = await supertest(app).post('/api/events/voted').send({ proposalId: PROPOSAL_ID, choice: 'yes' })
+      })
+
+      it('should respond with a 401', () => {
+        expect(response.status).toBe(401)
+      })
+
+      it('should not record a vote event', () => {
+        expect(voted).not.toHaveBeenCalled()
+      })
+    })
+
+    describe('when the proposal id is not a uuid', () => {
+      beforeEach(async () => {
+        response = await supertest(app)
+          .post('/api/events/voted')
+          .set('x-test-auth', REGULAR_ADDRESS)
+          .send({ proposalId: 'not-a-uuid', choice: 'yes' })
+      })
+
+      it('should respond with a 400', () => {
+        expect(response.status).toBe(400)
+      })
+
+      it('should not record a vote event', () => {
+        expect(voted).not.toHaveBeenCalled()
+      })
+    })
+
+    describe('when the choice is missing', () => {
+      beforeEach(async () => {
+        response = await supertest(app)
+          .post('/api/events/voted')
+          .set('x-test-auth', REGULAR_ADDRESS)
+          .send({ proposalId: PROPOSAL_ID })
+      })
+
+      it('should reject the request', () => {
+        expect(response.status).toBeGreaterThanOrEqual(400)
+      })
+
+      it('should not record a vote event', () => {
+        expect(voted).not.toHaveBeenCalled()
+      })
+    })
+
+    // The event is attributed to the authenticated address, not to one the client names.
+    describe('when the caller names a different address in the body', () => {
+      beforeEach(async () => {
+        await supertest(app)
+          .post('/api/events/voted')
+          .set('x-test-auth', REGULAR_ADDRESS)
+          .send({ proposalId: PROPOSAL_ID, choice: 'yes', address: DEBUG_ADDRESS })
+      })
+
+      it('should attribute the vote to the authenticated address', () => {
+        expect(voted).toHaveBeenCalledWith(PROPOSAL_ID, 'yes', REGULAR_ADDRESS)
+      })
+    })
+  })
+
+  describe('GET /api/events', () => {
+    let getLatest: jest.SpyInstance
+    let response: supertest.Response
+
+    beforeEach(() => {
+      getLatest = jest.spyOn(EventsService, 'getLatest').mockResolvedValue([] as never)
+    })
+
+    describe('when no filters are given', () => {
+      beforeEach(async () => {
+        response = await supertest(app).get('/api/events')
+      })
+
+      it('should serve the ticker without requiring authentication', () => {
+        expect(response.status).toBe(200)
+      })
+
+      it('should read the latest events', () => {
+        expect(getLatest).toHaveBeenCalled()
+      })
+    })
+
+    describe('when the event type filter is not a known one', () => {
+      beforeEach(async () => {
+        response = await supertest(app).get('/api/events?event_type=not-an-event')
+      })
+
+      it('should reject the request', () => {
+        expect(response.status).toBeGreaterThanOrEqual(400)
+      })
+
+      it('should not read any events', () => {
+        expect(getLatest).not.toHaveBeenCalled()
+      })
+    })
+  })
+})

--- a/src/routes/events.test.ts
+++ b/src/routes/events.test.ts
@@ -193,8 +193,10 @@ describe('the event routes', () => {
       })
 
       it('should reject the request', () => {
-        // Recorded, not endorsed: the event filter raises a plain Error.
-        expect(response.status).toBe(500)
+        // Refused rather than served. The status itself is known-wrong — a plain Error becomes a
+        // 500 where this should be a client error — and is fixed in the follow-up, so asserting
+        // refusal here means that fix will not have to rewrite this.
+        expect(response.body.ok).toBe(false)
       })
 
       it('should not read any events', () => {

--- a/src/routes/events.test.ts
+++ b/src/routes/events.test.ts
@@ -142,7 +142,7 @@ describe('the event routes', () => {
       })
 
       it('should reject the request', () => {
-        expect(response.status).toBeGreaterThanOrEqual(400)
+        expect(response.status).toBe(400)
       })
 
       it('should not record a vote event', () => {
@@ -193,7 +193,8 @@ describe('the event routes', () => {
       })
 
       it('should reject the request', () => {
-        expect(response.status).toBeGreaterThanOrEqual(400)
+        // Recorded, not endorsed: the event filter raises a plain Error.
+        expect(response.status).toBe(500)
       })
 
       it('should not read any events', () => {

--- a/src/routes/events.test.ts
+++ b/src/routes/events.test.ts
@@ -196,7 +196,9 @@ describe('the event routes', () => {
         // Refused rather than served. The status itself is known-wrong — a plain Error becomes a
         // 500 where this should be a client error — and is fixed in the follow-up, so asserting
         // refusal here means that fix will not have to rewrite this.
-        expect(response.body.ok).toBe(false)
+        // response.ok is superagent's 2xx flag, so this also rules out a 200 that merely says
+        // ok:false in its body. still no exact status, which is the point.
+        expect({ http: response.ok, body: response.body.ok }).toEqual({ http: false, body: false })
       })
 
       it('should not read any events', () => {

--- a/src/routes/misc.test.ts
+++ b/src/routes/misc.test.ts
@@ -243,8 +243,10 @@ describe('POST /api/newsletter-subscribe', () => {
     })
 
     it('should fail rather than subscribe nobody', () => {
-      // Recorded, not endorsed: isEmail throws on a non-string instead of returning false.
-      expect(response.status).toBe(500)
+      // Refused rather than served. The status itself is known-wrong — a plain Error becomes a
+      // 500 where this should be a client error — and is fixed in the follow-up, so asserting
+      // refusal here means that fix will not have to rewrite this.
+      expect(response.body.ok).toBe(false)
     })
 
     it('should not call the newsletter provider', () => {

--- a/src/routes/misc.test.ts
+++ b/src/routes/misc.test.ts
@@ -130,8 +130,8 @@ describe('the bid routes', () => {
         response = await supertest(app).get(`/api/bids/${PROPOSAL_ID}/get-user-bid`)
       })
 
-      it('should not be refused outright', () => {
-        expect(response.status).not.toBe(401)
+      it('should respond with a 200', () => {
+        expect(response.status).toBe(200)
       })
 
       it('should look up a bid for no address rather than for somebody else', () => {
@@ -243,7 +243,8 @@ describe('POST /api/newsletter-subscribe', () => {
     })
 
     it('should fail rather than subscribe nobody', () => {
-      expect(response.status).toBeGreaterThanOrEqual(400)
+      // Recorded, not endorsed: isEmail throws on a non-string instead of returning false.
+      expect(response.status).toBe(500)
     })
 
     it('should not call the newsletter provider', () => {

--- a/src/routes/misc.test.ts
+++ b/src/routes/misc.test.ts
@@ -1,0 +1,284 @@
+import { Server } from 'http'
+import supertest from 'supertest'
+
+import AirdropJobModel from '../models/AirdropJob'
+import BidService from '../services/BidService'
+import { ErrorService } from '../services/ErrorService'
+import { SurveyTopicsService } from '../services/SurveyTopicsService'
+
+import airdrop from './airdrop'
+import bid from './bid'
+import committee from './committee'
+import council from './council'
+import newsletter from './newsletter'
+import surveyTopics from './surveyTopics'
+import { createTestApp } from './testApp'
+
+const DEBUG_ADDRESS = '0x2AC89522CB415AC333E64F52a1a5693218cEBD58'
+const REGULAR_ADDRESS = '0x56d0B5eD3D525332F00C9BC938f93598ab16AAA7'
+const PROPOSAL_ID = '00000000-0000-0000-0000-000000000001'
+
+jest.mock('decentraland-gatsby/dist/entities/Auth/middleware', () => ({
+  auth:
+    (options?: { optional?: boolean }) =>
+    (
+      req: { get: (name: string) => string | undefined; auth?: string },
+      res: { status: (code: number) => { json: (body: unknown) => void } },
+      next: () => void
+    ) => {
+      const address = req.get('x-test-auth')
+      if (address) {
+        req.auth = address
+        return next()
+      }
+      if (options?.optional) {
+        return next()
+      }
+      res.status(401).json({ ok: false, error: 'Unauthorized' })
+    },
+}))
+
+jest.mock('../entities/Debug/isDebugAddress', () => ({
+  __esModule: true,
+  default: (address?: string) => address === '0x2AC89522CB415AC333E64F52a1a5693218cEBD58',
+}))
+
+describe('GET /api/airdrops/all', () => {
+  let app: Server
+  let getAll: jest.SpyInstance
+  let response: supertest.Response
+
+  beforeEach(() => {
+    app = createTestApp(airdrop)
+    getAll = jest.spyOn(AirdropJobModel, 'getAll').mockResolvedValue([] as never)
+  })
+
+  afterEach(() => {
+    jest.restoreAllMocks()
+  })
+
+  // The airdrop queue names every pending badge recipient, so it is debug-only.
+  describe('when the caller is unauthenticated', () => {
+    beforeEach(async () => {
+      response = await supertest(app).get('/api/airdrops/all')
+    })
+
+    it('should respond with a 401', () => {
+      expect(response.status).toBe(401)
+    })
+
+    it('should not read the queue', () => {
+      expect(getAll).not.toHaveBeenCalled()
+    })
+  })
+
+  describe('when the caller is signed in but not a debug address', () => {
+    beforeEach(async () => {
+      response = await supertest(app).get('/api/airdrops/all').set('x-test-auth', REGULAR_ADDRESS)
+    })
+
+    it('should refuse the request', () => {
+      expect(response.status).toBe(401)
+    })
+
+    it('should not read the queue', () => {
+      expect(getAll).not.toHaveBeenCalled()
+    })
+  })
+
+  describe('when the caller is a debug address', () => {
+    beforeEach(async () => {
+      await supertest(app).get('/api/airdrops/all').set('x-test-auth', DEBUG_ADDRESS)
+    })
+
+    it('should read the queue', () => {
+      expect(getAll).toHaveBeenCalled()
+    })
+  })
+})
+
+describe('the bid routes', () => {
+  let app: Server
+  let getUserBidOnTender: jest.SpyInstance
+
+  beforeEach(() => {
+    app = createTestApp(bid)
+    getUserBidOnTender = jest.spyOn(BidService, 'getUserBidOnTender').mockResolvedValue(null as never)
+    jest.spyOn(BidService, 'getBidsInfoByTender').mockResolvedValue({} as never)
+  })
+
+  afterEach(() => {
+    jest.restoreAllMocks()
+  })
+
+  describe('GET /api/bids/:tenderId/get-user-bid', () => {
+    describe('when the caller is authenticated', () => {
+      beforeEach(async () => {
+        await supertest(app).get(`/api/bids/${PROPOSAL_ID}/get-user-bid`).set('x-test-auth', REGULAR_ADDRESS)
+      })
+
+      it('should look up the bid for that caller', () => {
+        expect(getUserBidOnTender).toHaveBeenCalledWith(REGULAR_ADDRESS, PROPOSAL_ID)
+      })
+    })
+
+    // Auth is optional, so an anonymous caller reaches the handler with no address.
+    describe('when the caller is anonymous', () => {
+      let response: supertest.Response
+
+      beforeEach(async () => {
+        response = await supertest(app).get(`/api/bids/${PROPOSAL_ID}/get-user-bid`)
+      })
+
+      it('should not be refused outright', () => {
+        expect(response.status).not.toBe(401)
+      })
+
+      it('should look up a bid for no address rather than for somebody else', () => {
+        expect(getUserBidOnTender).toHaveBeenCalledWith(undefined, PROPOSAL_ID)
+      })
+    })
+  })
+})
+
+describe('the public address lists', () => {
+  describe('GET /api/committee', () => {
+    let response: supertest.Response
+
+    beforeEach(async () => {
+      response = await supertest(createTestApp(committee)).get('/api/committee')
+    })
+
+    // Deliberately public, unlike the debug address list which is gated.
+    it('should be served without authentication', () => {
+      expect(response.status).toBe(200)
+    })
+
+    it('should return a list', () => {
+      expect(Array.isArray(response.body.data)).toBe(true)
+    })
+  })
+
+  describe('GET /api/dao-council', () => {
+    let response: supertest.Response
+
+    beforeEach(async () => {
+      response = await supertest(createTestApp(council)).get('/api/dao-council')
+    })
+
+    it('should be served without authentication', () => {
+      expect(response.status).toBe(200)
+    })
+
+    it('should return a list', () => {
+      expect(Array.isArray(response.body.data)).toBe(true)
+    })
+  })
+})
+
+describe('GET /api/proposals/:proposal/survey-topics', () => {
+  let app: Server
+  let getProposalSurveyTopics: jest.SpyInstance
+  let response: supertest.Response
+
+  beforeEach(() => {
+    app = createTestApp(surveyTopics)
+    getProposalSurveyTopics = jest.spyOn(SurveyTopicsService, 'getProposalSurveyTopics').mockResolvedValue([] as never)
+  })
+
+  afterEach(() => {
+    jest.restoreAllMocks()
+  })
+
+  describe('when a proposal id is given', () => {
+    beforeEach(async () => {
+      response = await supertest(app).get(`/api/proposals/${PROPOSAL_ID}/survey-topics`)
+    })
+
+    it('should look up its topics', () => {
+      expect(getProposalSurveyTopics).toHaveBeenCalledWith(PROPOSAL_ID)
+    })
+
+    it('should be served without authentication', () => {
+      expect(response.status).toBe(200)
+    })
+  })
+})
+
+describe('POST /api/newsletter-subscribe', () => {
+  let app: Server
+  let response: supertest.Response
+  let report: jest.SpyInstance
+
+  beforeEach(() => {
+    app = createTestApp(newsletter)
+    report = jest.spyOn(ErrorService, 'report').mockImplementation(() => undefined)
+  })
+
+  afterEach(() => {
+    jest.restoreAllMocks()
+  })
+
+  describe('when the email is not an email', () => {
+    beforeEach(async () => {
+      global.fetch = jest.fn() as never
+      response = await supertest(app).post('/api/newsletter-subscribe').send({ email: 'not-an-email' })
+    })
+
+    it('should respond with a 400', () => {
+      expect(response.status).toBe(400)
+    })
+
+    it('should not call the newsletter provider', () => {
+      expect(global.fetch).not.toHaveBeenCalled()
+    })
+  })
+
+  // Recorded, not endorsed: isEmail throws on a non-string rather than returning false, so an
+  // omitted email surfaces as a 500 on a public endpoint instead of the 400 the branch intends.
+  describe('when the email is missing', () => {
+    beforeEach(async () => {
+      global.fetch = jest.fn() as never
+      response = await supertest(app).post('/api/newsletter-subscribe').send({})
+    })
+
+    it('should fail rather than subscribe nobody', () => {
+      expect(response.status).toBeGreaterThanOrEqual(400)
+    })
+
+    it('should not call the newsletter provider', () => {
+      expect(global.fetch).not.toHaveBeenCalled()
+    })
+  })
+
+  describe('when the provider accepts the subscription', () => {
+    beforeEach(async () => {
+      global.fetch = jest.fn().mockResolvedValue({ json: async () => ({ data: { id: 'sub_1' } }) }) as never
+      response = await supertest(app).post('/api/newsletter-subscribe').send({ email: 'someone@example.com' })
+    })
+
+    it('should report no error', () => {
+      expect(response.body.data).toEqual({ email: 'someone@example.com', error: false, details: '' })
+    })
+  })
+
+  // The provider's rejection is surfaced in the body rather than as a failed request.
+  describe('when the provider rejects the subscription', () => {
+    beforeEach(async () => {
+      global.fetch = jest.fn().mockResolvedValue({ json: async () => ({ errors: ['nope'] }) }) as never
+      response = await supertest(app).post('/api/newsletter-subscribe').send({ email: 'someone@example.com' })
+    })
+
+    it('should still respond successfully', () => {
+      expect(response.status).toBe(201)
+    })
+
+    it('should mark the result as failed', () => {
+      expect(response.body.data.error).toBe(true)
+    })
+
+    it('should report it server-side', () => {
+      expect(report).toHaveBeenCalled()
+    })
+  })
+})

--- a/src/routes/misc.test.ts
+++ b/src/routes/misc.test.ts
@@ -246,7 +246,9 @@ describe('POST /api/newsletter-subscribe', () => {
       // Refused rather than served. The status itself is known-wrong — a plain Error becomes a
       // 500 where this should be a client error — and is fixed in the follow-up, so asserting
       // refusal here means that fix will not have to rewrite this.
-      expect(response.body.ok).toBe(false)
+      // response.ok is superagent's 2xx flag, so this also rules out a 200 that merely says
+      // ok:false in its body. still no exact status, which is the point.
+      expect({ http: response.ok, body: response.body.ok }).toEqual({ http: false, body: false })
     })
 
     it('should not call the newsletter provider', () => {

--- a/src/routes/notification.test.ts
+++ b/src/routes/notification.test.ts
@@ -1,4 +1,4 @@
-import { Express } from 'express'
+import { Server } from 'http'
 import supertest from 'supertest'
 
 import { NotificationService } from '../services/notification'
@@ -29,7 +29,7 @@ jest.mock('decentraland-gatsby/dist/entities/Auth/middleware', () => ({
 }))
 
 describe('GET /api/notifications/user/:address', () => {
-  let app: Express
+  let app: Server
   let getUserFeed: jest.SpyInstance
   let response: supertest.Response
 
@@ -98,7 +98,7 @@ describe('GET /api/notifications/user/:address', () => {
 })
 
 describe('the authenticated notification routes', () => {
-  let app: Express
+  let app: Server
 
   beforeEach(() => {
     app = createTestApp(notification)

--- a/src/routes/project.test.ts
+++ b/src/routes/project.test.ts
@@ -375,8 +375,10 @@ describe('the project routes', () => {
       })
 
       it('should refuse the request', () => {
-        // Recorded, not endorsed: the handler's own bad request is swallowed by its catch.
-        expect(response.status).toBe(500)
+        // Refused rather than served. The status itself is known-wrong — a plain Error becomes a
+        // 500 where this should be a client error — and is fixed in the follow-up, so asserting
+        // refusal here means that fix will not have to rewrite this.
+        expect(response.body.ok).toBe(false)
       })
     })
   })

--- a/src/routes/project.test.ts
+++ b/src/routes/project.test.ts
@@ -239,7 +239,7 @@ describe('the project routes', () => {
           })
 
           it('should refuse the request', () => {
-            expect(response.status).toBeGreaterThanOrEqual(400)
+            expect(response.status).toBe(401)
           })
 
           it('should not delete it', () => {
@@ -375,7 +375,8 @@ describe('the project routes', () => {
       })
 
       it('should refuse the request', () => {
-        expect(response.status).toBeGreaterThanOrEqual(400)
+        // Recorded, not endorsed: the handler's own bad request is swallowed by its catch.
+        expect(response.status).toBe(500)
       })
     })
   })

--- a/src/routes/project.test.ts
+++ b/src/routes/project.test.ts
@@ -1,0 +1,382 @@
+import { Express } from 'express'
+import supertest from 'supertest'
+
+import { ProjectStatus } from '../entities/Grant/types'
+import PersonnelModel from '../models/Personnel'
+import ProjectLinkModel from '../models/ProjectLink'
+import ProjectMilestoneModel from '../models/ProjectMilestone'
+import { ProjectService } from '../services/ProjectService'
+
+import project from './project'
+import { createTestApp } from './testApp'
+
+const OWNER = '0x2AC89522CB415AC333E64F52a1a5693218cEBD58'
+const STRANGER = '0x56d0B5eD3D525332F00C9BC938f93598ab16AAA7'
+const PROJECT_ID = '00000000-0000-0000-0000-000000000001'
+const ENTITY_ID = '00000000-0000-0000-0000-000000000002'
+
+jest.mock('decentraland-gatsby/dist/entities/Auth/middleware', () => ({
+  auth:
+    (options?: { optional?: boolean }) =>
+    (
+      req: { get: (name: string) => string | undefined; auth?: string },
+      res: { status: (code: number) => { json: (body: unknown) => void } },
+      next: () => void
+    ) => {
+      const address = req.get('x-test-auth')
+      if (address) {
+        req.auth = address
+        return next()
+      }
+      if (options?.optional) {
+        return next()
+      }
+      res.status(401).json({ ok: false, error: 'Unauthorized' })
+    },
+}))
+
+const PERSONNEL = { project_id: PROJECT_ID, name: 'A member', role: 'Engineer', about: 'About them' }
+const LINK = { project_id: PROJECT_ID, label: 'Repository', url: 'https://example.com' }
+const MILESTONE = {
+  project_id: PROJECT_ID,
+  title: 'A milestone',
+  description: 'What it delivers',
+  delivery_date: '2030-01-01T00:00:00.000Z',
+}
+
+// Every write below goes through validateCanEditProject, which is ownership plus a check that the
+// project is still editable. Both halves are exercised here; the ownership query itself is covered
+// against the database in test/integration/projectAuthorization.test.ts.
+describe('the project routes', () => {
+  let app: Express
+  let isAuthorOrCoauthor: jest.SpyInstance
+
+  beforeEach(() => {
+    app = createTestApp(project)
+    isAuthorOrCoauthor = jest.spyOn(ProjectService, 'isAuthorOrCoauthor').mockResolvedValue(true)
+    jest
+      .spyOn(ProjectService, 'getUpdatedProject')
+      .mockResolvedValue({ id: PROJECT_ID, status: ProjectStatus.InProgress } as never)
+  })
+
+  afterEach(() => {
+    jest.restoreAllMocks()
+  })
+
+  describe('the routes that add to a project', () => {
+    const cases = [
+      { path: '/api/projects/personnel/', body: { personnel: PERSONNEL }, method: 'addPersonnel' as const },
+      { path: '/api/projects/links/', body: { project_link: LINK }, method: 'addLink' as const },
+      { path: '/api/projects/milestones/', body: { milestone: MILESTONE }, method: 'addMilestone' as const },
+    ]
+
+    describe('when the caller is unauthenticated', () => {
+      let statuses: number[]
+
+      beforeEach(async () => {
+        const responses = await Promise.all(cases.map(({ path, body }) => supertest(app).post(path).send(body)))
+        statuses = responses.map((response) => response.status)
+      })
+
+      it('should refuse every one with a 401', () => {
+        expect(statuses).toEqual(cases.map(() => 401))
+      })
+    })
+
+    describe('when the caller may not edit the project', () => {
+      let statuses: number[]
+
+      beforeEach(async () => {
+        isAuthorOrCoauthor.mockResolvedValue(false)
+        const responses = await Promise.all(
+          cases.map(({ path, body }) => supertest(app).post(path).set('x-test-auth', STRANGER).send(body))
+        )
+        statuses = responses.map((response) => response.status)
+      })
+
+      it('should refuse every one', () => {
+        expect(statuses.every((status) => status >= 400)).toBe(true)
+      })
+    })
+
+    // A finished or revoked project is closed to edits even for its own author.
+    describe('when the project is already finished', () => {
+      let response: supertest.Response
+      let addPersonnel: jest.SpyInstance
+
+      beforeEach(async () => {
+        ;(ProjectService.getUpdatedProject as jest.Mock).mockResolvedValue({
+          id: PROJECT_ID,
+          status: ProjectStatus.Finished,
+        })
+        addPersonnel = jest.spyOn(ProjectService, 'addPersonnel').mockResolvedValue({} as never)
+        response = await supertest(app)
+          .post('/api/projects/personnel/')
+          .set('x-test-auth', OWNER)
+          .send({ personnel: PERSONNEL })
+      })
+
+      it('should refuse the edit even though the caller owns it', () => {
+        expect(response.status).toBe(400)
+      })
+
+      it('should not add anything', () => {
+        expect(addPersonnel).not.toHaveBeenCalled()
+      })
+    })
+
+    describe('when the project has been revoked', () => {
+      let response: supertest.Response
+
+      beforeEach(async () => {
+        ;(ProjectService.getUpdatedProject as jest.Mock).mockResolvedValue({
+          id: PROJECT_ID,
+          status: ProjectStatus.Revoked,
+        })
+        response = await supertest(app)
+          .post('/api/projects/personnel/')
+          .set('x-test-auth', OWNER)
+          .send({ personnel: PERSONNEL })
+      })
+
+      it('should refuse the edit', () => {
+        expect(response.status).toBe(400)
+      })
+    })
+
+    describe('when the owner adds personnel to an editable project', () => {
+      let addPersonnel: jest.SpyInstance
+
+      beforeEach(async () => {
+        addPersonnel = jest.spyOn(ProjectService, 'addPersonnel').mockResolvedValue({} as never)
+        await supertest(app).post('/api/projects/personnel/').set('x-test-auth', OWNER).send({ personnel: PERSONNEL })
+      })
+
+      it('should check ownership against the authenticated address', () => {
+        expect(isAuthorOrCoauthor).toHaveBeenCalledWith(OWNER, PROJECT_ID)
+      })
+
+      it('should record the addition against that address', () => {
+        expect(addPersonnel).toHaveBeenCalledWith(expect.anything(), OWNER)
+      })
+    })
+
+    describe('when the body does not match the schema', () => {
+      let response: supertest.Response
+      let addLink: jest.SpyInstance
+
+      beforeEach(async () => {
+        addLink = jest.spyOn(ProjectService, 'addLink').mockResolvedValue({} as never)
+        response = await supertest(app)
+          .post('/api/projects/links/')
+          .set('x-test-auth', OWNER)
+          .send({ project_link: { project_id: PROJECT_ID, label: 'Repository' } })
+      })
+
+      it('should reject it', () => {
+        expect(response.status).toBe(400)
+      })
+
+      it('should not store anything', () => {
+        expect(addLink).not.toHaveBeenCalled()
+      })
+    })
+  })
+
+  describe('the routes that delete from a project', () => {
+    // Ownership is checked against the project the entity belongs to, which is read from the stored
+    // row rather than taken from the request.
+    const cases = [
+      {
+        name: 'personnel',
+        path: `/api/projects/personnel/${ENTITY_ID}`,
+        model: PersonnelModel,
+        service: 'deletePersonnel' as const,
+      },
+      {
+        name: 'link',
+        path: `/api/projects/links/${ENTITY_ID}`,
+        model: ProjectLinkModel,
+        service: 'deleteLink' as const,
+      },
+      {
+        name: 'milestone',
+        path: `/api/projects/milestones/${ENTITY_ID}`,
+        model: ProjectMilestoneModel,
+        service: 'deleteMilestone' as const,
+      },
+    ]
+
+    cases.forEach(({ name, path, model, service }) => {
+      describe(`when deleting a ${name}`, () => {
+        let remove: jest.SpyInstance
+        let findOne: jest.SpyInstance
+        let response: supertest.Response
+
+        beforeEach(() => {
+          findOne = jest.spyOn(model, 'findOne').mockResolvedValue({ id: ENTITY_ID, project_id: PROJECT_ID } as never)
+          remove = jest.spyOn(ProjectService, service).mockResolvedValue(ENTITY_ID as never)
+        })
+
+        describe('and the caller is unauthenticated', () => {
+          beforeEach(async () => {
+            response = await supertest(app).delete(path)
+          })
+
+          it('should respond with a 401', () => {
+            expect(response.status).toBe(401)
+          })
+
+          it('should not delete it', () => {
+            expect(remove).not.toHaveBeenCalled()
+          })
+        })
+
+        describe('and the caller may not edit the project it belongs to', () => {
+          beforeEach(async () => {
+            isAuthorOrCoauthor.mockResolvedValue(false)
+            response = await supertest(app).delete(path).set('x-test-auth', STRANGER)
+          })
+
+          it('should refuse the request', () => {
+            expect(response.status).toBeGreaterThanOrEqual(400)
+          })
+
+          it('should not delete it', () => {
+            expect(remove).not.toHaveBeenCalled()
+          })
+        })
+
+        describe('and it does not exist', () => {
+          beforeEach(async () => {
+            findOne.mockResolvedValue(undefined)
+            response = await supertest(app).delete(path).set('x-test-auth', OWNER)
+          })
+
+          it('should respond with a 404', () => {
+            expect(response.status).toBe(404)
+          })
+
+          it('should not check ownership against a project it never found', () => {
+            expect(isAuthorOrCoauthor).not.toHaveBeenCalled()
+          })
+        })
+
+        describe('and the id is not a uuid', () => {
+          beforeEach(async () => {
+            response = await supertest(app).delete(path.replace(ENTITY_ID, 'not-a-uuid')).set('x-test-auth', OWNER)
+          })
+
+          it('should respond with a 400', () => {
+            expect(response.status).toBe(400)
+          })
+
+          it('should not look it up', () => {
+            expect(findOne).not.toHaveBeenCalled()
+          })
+        })
+
+        describe('and the owner deletes it', () => {
+          beforeEach(async () => {
+            response = await supertest(app).delete(path).set('x-test-auth', OWNER)
+          })
+
+          it('should check ownership against the project the row belongs to', () => {
+            expect(isAuthorOrCoauthor).toHaveBeenCalledWith(OWNER, PROJECT_ID)
+          })
+
+          it('should delete it', () => {
+            expect(remove).toHaveBeenCalled()
+          })
+        })
+      })
+    })
+  })
+
+  describe('GET /api/projects/:project', () => {
+    let response: supertest.Response
+
+    describe('when the id is not a uuid', () => {
+      beforeEach(async () => {
+        response = await supertest(app).get('/api/projects/not-a-uuid')
+      })
+
+      it('should respond with a 400', () => {
+        expect(response.status).toBe(400)
+      })
+    })
+
+    describe('when the project does not exist', () => {
+      beforeEach(async () => {
+        ;(ProjectService.getUpdatedProject as jest.Mock).mockRejectedValue(new Error('missing'))
+        response = await supertest(app).get(`/api/projects/${PROJECT_ID}`)
+      })
+
+      it('should respond with a 404', () => {
+        expect(response.status).toBe(404)
+      })
+    })
+
+    describe('when the project exists', () => {
+      beforeEach(async () => {
+        response = await supertest(app).get(`/api/projects/${PROJECT_ID}`)
+      })
+
+      it('should return it without requiring authentication', () => {
+        expect(response.status).toBe(200)
+      })
+    })
+  })
+
+  describe('GET /api/projects/user/:address', () => {
+    let getUserProjects: jest.SpyInstance
+    let response: supertest.Response
+
+    beforeEach(() => {
+      getUserProjects = jest.spyOn(ProjectService, 'getUserProjects').mockResolvedValue([] as never)
+    })
+
+    describe('when the address is not an ethereum address', () => {
+      beforeEach(async () => {
+        response = await supertest(app).get('/api/projects/user/not-an-address')
+      })
+
+      it('should respond with a 400', () => {
+        expect(response.status).toBe(400)
+      })
+
+      it('should not run the query', () => {
+        expect(getUserProjects).not.toHaveBeenCalled()
+      })
+    })
+
+    describe('when the address is valid', () => {
+      beforeEach(async () => {
+        response = await supertest(app).get(`/api/projects/user/${OWNER}`)
+      })
+
+      it('should query for that address', () => {
+        expect(getUserProjects).toHaveBeenCalledWith(OWNER)
+      })
+
+      it('should report how many came back', () => {
+        expect(response.body.data).toEqual({ data: [], total: 0 })
+      })
+    })
+  })
+
+  describe('GET /api/projects', () => {
+    describe('when the range starts after it ends', () => {
+      let response: supertest.Response
+
+      beforeEach(async () => {
+        jest.spyOn(ProjectService, 'getProjects').mockResolvedValue([] as never)
+        response = await supertest(app).get('/api/projects?from=2024-02-01&to=2024-01-01')
+      })
+
+      it('should refuse the request', () => {
+        expect(response.status).toBeGreaterThanOrEqual(400)
+      })
+    })
+  })
+})

--- a/src/routes/project.test.ts
+++ b/src/routes/project.test.ts
@@ -1,4 +1,4 @@
-import { Express } from 'express'
+import { Server } from 'http'
 import supertest from 'supertest'
 
 import { ProjectStatus } from '../entities/Grant/types'
@@ -48,7 +48,7 @@ const MILESTONE = {
 // project is still editable. Both halves are exercised here; the ownership query itself is covered
 // against the database in test/integration/projectAuthorization.test.ts.
 describe('the project routes', () => {
-  let app: Express
+  let app: Server
   let isAuthorOrCoauthor: jest.SpyInstance
 
   beforeEach(() => {

--- a/src/routes/project.test.ts
+++ b/src/routes/project.test.ts
@@ -378,7 +378,9 @@ describe('the project routes', () => {
         // Refused rather than served. The status itself is known-wrong — a plain Error becomes a
         // 500 where this should be a client error — and is fixed in the follow-up, so asserting
         // refusal here means that fix will not have to rewrite this.
-        expect(response.body.ok).toBe(false)
+        // response.ok is superagent's 2xx flag, so this also rules out a 200 that merely says
+        // ok:false in its body. still no exact status, which is the point.
+        expect({ http: response.ok, body: response.body.ok }).toEqual({ http: false, body: false })
       })
     })
   })

--- a/src/routes/proposal.test.ts
+++ b/src/routes/proposal.test.ts
@@ -134,7 +134,7 @@ describe('the proposal routes', () => {
       })
 
       it('should reject the transition', () => {
-        expect(response.status).toBeGreaterThanOrEqual(400)
+        expect(response.status).toBe(400)
       })
 
       it('should not change the proposal status', () => {
@@ -286,7 +286,7 @@ describe('the proposal routes', () => {
       })
 
       it('should reject the request', () => {
-        expect(response.status).toBeGreaterThanOrEqual(400)
+        expect(response.status).toBe(400)
       })
     })
   })

--- a/src/routes/proposal.test.ts
+++ b/src/routes/proposal.test.ts
@@ -1,4 +1,4 @@
-import { Express } from 'express'
+import { Server } from 'http'
 import supertest from 'supertest'
 
 import { SnapshotGraphql } from '../clients/SnapshotGraphql'
@@ -52,7 +52,7 @@ jest.mock('../entities/Council/IsDAOCouncil', () => ({
 }))
 
 describe('the proposal routes', () => {
-  let app: Express
+  let app: Server
 
   beforeEach(() => {
     app = createTestApp(proposal)

--- a/src/routes/snapshot.test.ts
+++ b/src/routes/snapshot.test.ts
@@ -1,4 +1,4 @@
-import { Express } from 'express'
+import { Server } from 'http'
 import supertest from 'supertest'
 
 import { SnapshotService } from '../services/SnapshotService'
@@ -12,7 +12,7 @@ const START = '2024-01-01T00:00:00.000Z'
 const END = '2024-02-01T00:00:00.000Z'
 
 describe('the snapshot proxy routes', () => {
-  let app: Express
+  let app: Server
 
   beforeEach(() => {
     app = createTestApp(snapshot)

--- a/src/routes/subscription.test.ts
+++ b/src/routes/subscription.test.ts
@@ -1,0 +1,207 @@
+import { Server } from 'http'
+import supertest from 'supertest'
+
+import SubscriptionModel from '../entities/Subscription/model'
+
+import subscription from './subscription'
+import { createTestApp } from './testApp'
+
+const CALLER = '0x2AC89522CB415AC333E64F52a1a5693218cEBD58'
+const SOMEONE_ELSE = '0x56d0B5eD3D525332F00C9BC938f93598ab16AAA7'
+const PROPOSAL_ID = '00000000-0000-0000-0000-000000000001'
+
+jest.mock('decentraland-gatsby/dist/entities/Auth/middleware', () => ({
+  auth:
+    (options?: { optional?: boolean }) =>
+    (
+      req: { get: (name: string) => string | undefined; auth?: string },
+      res: { status: (code: number) => { json: (body: unknown) => void } },
+      next: () => void
+    ) => {
+      const address = req.get('x-test-auth')
+      if (address) {
+        req.auth = address
+        return next()
+      }
+      if (options?.optional) {
+        return next()
+      }
+      res.status(401).json({ ok: false, error: 'Unauthorized' })
+    },
+}))
+
+// Stubbed rather than imported: routes/proposal drags in the whole service graph, and all this
+// route needs from it is the resolved proposal.
+jest.mock('./proposal', () => ({ getProposal: jest.fn() }))
+
+// eslint-disable-next-line @typescript-eslint/no-var-requires
+const { getProposal } = require('./proposal')
+
+describe('the subscription routes', () => {
+  let app: Server
+
+  beforeEach(() => {
+    app = createTestApp(subscription)
+    ;(getProposal as jest.Mock).mockResolvedValue({ id: PROPOSAL_ID })
+  })
+
+  afterEach(() => {
+    jest.restoreAllMocks()
+    jest.clearAllMocks()
+  })
+
+  describe('GET /api/subscriptions', () => {
+    let find: jest.SpyInstance
+    let response: supertest.Response
+
+    beforeEach(() => {
+      find = jest.spyOn(SubscriptionModel, 'find').mockResolvedValue([] as never)
+    })
+
+    // Auth is optional here, so an anonymous caller gets an empty list rather than a 401 or, worse,
+    // a query for every subscription in the table.
+    describe('when the caller is anonymous', () => {
+      beforeEach(async () => {
+        response = await supertest(app).get('/api/subscriptions')
+      })
+
+      it('should return an empty list', () => {
+        expect(response.body.data).toEqual([])
+      })
+
+      it('should not query for anyone’s subscriptions', () => {
+        expect(find).not.toHaveBeenCalled()
+      })
+    })
+
+    describe('when the caller is authenticated', () => {
+      beforeEach(async () => {
+        await supertest(app).get('/api/subscriptions').set('x-test-auth', CALLER)
+      })
+
+      it('should query only their own subscriptions', () => {
+        expect(find).toHaveBeenCalledWith({ user: CALLER })
+      })
+    })
+  })
+
+  describe('POST /api/proposals/:proposal/subscriptions', () => {
+    let create: jest.SpyInstance
+    let findOne: jest.SpyInstance
+    let response: supertest.Response
+
+    beforeEach(() => {
+      create = jest.spyOn(SubscriptionModel, 'create').mockResolvedValue({} as never)
+      findOne = jest.spyOn(SubscriptionModel, 'findOne').mockResolvedValue(undefined as never)
+    })
+
+    describe('when the caller is unauthenticated', () => {
+      beforeEach(async () => {
+        response = await supertest(app).post(`/api/proposals/${PROPOSAL_ID}/subscriptions`)
+      })
+
+      it('should respond with a 401', () => {
+        expect(response.status).toBe(401)
+      })
+
+      it('should not subscribe anyone', () => {
+        expect(create).not.toHaveBeenCalled()
+      })
+    })
+
+    describe('when the caller is not yet subscribed', () => {
+      beforeEach(async () => {
+        await supertest(app).post(`/api/proposals/${PROPOSAL_ID}/subscriptions`).set('x-test-auth', CALLER)
+      })
+
+      it('should subscribe the authenticated address to that proposal', () => {
+        expect(create).toHaveBeenCalledWith(expect.objectContaining({ proposal_id: PROPOSAL_ID, user: CALLER }))
+      })
+    })
+
+    // Subscribing twice is a no-op rather than a duplicate row, since nothing in the schema stops
+    // one being written.
+    describe('when the caller is already subscribed', () => {
+      beforeEach(async () => {
+        findOne.mockResolvedValue({ proposal_id: PROPOSAL_ID, user: CALLER, created_at: new Date() })
+        response = await supertest(app).post(`/api/proposals/${PROPOSAL_ID}/subscriptions`).set('x-test-auth', CALLER)
+      })
+
+      it('should not write a second row', () => {
+        expect(create).not.toHaveBeenCalled()
+      })
+
+      it('should return the existing subscription', () => {
+        expect(response.body.data).toEqual(expect.objectContaining({ user: CALLER }))
+      })
+    })
+
+    describe('when the caller supplies a different address in the body', () => {
+      beforeEach(async () => {
+        await supertest(app)
+          .post(`/api/proposals/${PROPOSAL_ID}/subscriptions`)
+          .set('x-test-auth', CALLER)
+          .send({ user: SOMEONE_ELSE })
+      })
+
+      it('should subscribe the authenticated address instead', () => {
+        expect(create).toHaveBeenCalledWith(expect.objectContaining({ user: CALLER }))
+      })
+    })
+  })
+
+  describe('DELETE /api/proposals/:proposal/subscriptions', () => {
+    let remove: jest.SpyInstance
+    let response: supertest.Response
+
+    beforeEach(() => {
+      remove = jest.spyOn(SubscriptionModel, 'delete').mockResolvedValue(1 as never)
+    })
+
+    describe('when the caller is unauthenticated', () => {
+      beforeEach(async () => {
+        response = await supertest(app).delete(`/api/proposals/${PROPOSAL_ID}/subscriptions`)
+      })
+
+      it('should respond with a 401', () => {
+        expect(response.status).toBe(401)
+      })
+
+      it('should not unsubscribe anyone', () => {
+        expect(remove).not.toHaveBeenCalled()
+      })
+    })
+
+    // Scoped to the caller, so unsubscribing cannot remove somebody else from a proposal.
+    describe('when the caller unsubscribes', () => {
+      beforeEach(async () => {
+        await supertest(app)
+          .delete(`/api/proposals/${PROPOSAL_ID}/subscriptions`)
+          .set('x-test-auth', CALLER)
+          .send({ user: SOMEONE_ELSE })
+      })
+
+      it('should delete only their own subscription to that proposal', () => {
+        expect(remove).toHaveBeenCalledWith({ proposal_id: PROPOSAL_ID, user: CALLER })
+      })
+    })
+  })
+
+  describe('GET /api/proposals/:proposal/subscriptions', () => {
+    let find: jest.SpyInstance
+
+    beforeEach(() => {
+      find = jest.spyOn(SubscriptionModel, 'find').mockResolvedValue([] as never)
+    })
+
+    describe('when it is requested', () => {
+      beforeEach(async () => {
+        await supertest(app).get(`/api/proposals/${PROPOSAL_ID}/subscriptions`)
+      })
+
+      it('should list them for that proposal without requiring authentication', () => {
+        expect(find).toHaveBeenCalledWith({ proposal_id: PROPOSAL_ID })
+      })
+    })
+  })
+})

--- a/src/routes/testApp.ts
+++ b/src/routes/testApp.ts
@@ -1,6 +1,21 @@
 import RequestError from 'decentraland-gatsby/dist/entities/Route/error'
 import handle from 'decentraland-gatsby/dist/entities/Route/handle'
 import express, { Express, Router } from 'express'
+import { Server } from 'http'
+
+/**
+ * Binds the app to an ephemeral port once and hands back the listening server.
+ *
+ * Passing the app itself to supertest makes it start and tear down a server per request, which is
+ * hundreds of short-lived listeners across a full run and produced occasional socket resets under
+ * load. One listener per test file avoids that. It is unref'd, so a suite that never closes it
+ * still lets the process exit.
+ */
+function listen(app: Express): Server {
+  const server = app.listen(0)
+  server.unref()
+  return server
+}
 
 /**
  * Mounts a single route module the way server.ts does — under /api, with the same
@@ -11,7 +26,7 @@ import express, { Express, Router } from 'express'
  * mock decentraland-gatsby's auth middleware, so what is covered is whether a route requires
  * auth and what it does with the resulting address, not the signature checking behind it.
  */
-export function createTestApp(router: Router): Express {
+export function createTestApp(router: Router): Server {
   const app = express()
   app.set('x-powered-by', false)
   app.use(express.json())
@@ -21,14 +36,14 @@ export function createTestApp(router: Router): Express {
       throw new RequestError('NotFound', RequestError.NotFound)
     }),
   ])
-  return app
+  return listen(app)
 }
 
 /**
  * Captures the raw request body under /api/webhooks exactly as server.ts does, so signature
  * tests cover the rawBody path rather than only the JSON.stringify fallback.
  */
-export function createWebhookTestApp(router: Router): Express {
+export function createWebhookTestApp(router: Router): Server {
   const app = express()
   app.set('x-powered-by', false)
   app.use(
@@ -46,5 +61,5 @@ export function createWebhookTestApp(router: Router): Express {
       throw new RequestError('NotFound', RequestError.NotFound)
     }),
   ])
-  return app
+  return listen(app)
 }

--- a/src/routes/testApp.ts
+++ b/src/routes/testApp.ts
@@ -4,17 +4,34 @@ import express, { Express, Router } from 'express'
 import { Server } from 'http'
 
 /**
- * Binds the app to an ephemeral port once and hands back the listening server.
+ * One listener per router, per test file.
  *
- * Passing the app itself to supertest makes it start and tear down a server per request, which is
- * hundreds of short-lived listeners across a full run and produced occasional socket resets under
- * load. One listener per test file avoids that. It is unref'd, so a suite that never closes it
- * still lets the process exit.
+ * Handing the app itself to supertest makes it bind and tear down a server for every request, which
+ * is thousands of short-lived listeners across a run and produced occasional socket resets. Binding
+ * one per call is not enough either, because suites build their app in `beforeEach` — that is a
+ * listener per test case, held open for the whole file.
+ *
+ * Jest gives each test file its own module registry, so this cache holds at most one server per
+ * router per file, and `closeTestApps` (registered globally in test/setup/closeTestApps.ts) shuts
+ * them down when the file finishes.
  */
-function listen(app: Express): Server {
-  const server = app.listen(0)
+const servers = new Map<Router, Server>()
+
+function listen(router: Router, build: () => Express): Server {
+  const existing = servers.get(router)
+  if (existing) {
+    return existing
+  }
+  const server = build().listen(0)
   server.unref()
+  servers.set(router, server)
   return server
+}
+
+export async function closeTestApps(): Promise<void> {
+  const open = [...servers.values()]
+  servers.clear()
+  await Promise.all(open.map((server) => new Promise<void>((resolve) => server.close(() => resolve()))))
 }
 
 /**
@@ -27,16 +44,18 @@ function listen(app: Express): Server {
  * auth and what it does with the resulting address, not the signature checking behind it.
  */
 export function createTestApp(router: Router): Server {
-  const app = express()
-  app.set('x-powered-by', false)
-  app.use(express.json())
-  app.use('/api', [
-    router,
-    handle(async () => {
-      throw new RequestError('NotFound', RequestError.NotFound)
-    }),
-  ])
-  return listen(app)
+  return listen(router, () => {
+    const app = express()
+    app.set('x-powered-by', false)
+    app.use(express.json())
+    app.use('/api', [
+      router,
+      handle(async () => {
+        throw new RequestError('NotFound', RequestError.NotFound)
+      }),
+    ])
+    return app
+  })
 }
 
 /**
@@ -44,22 +63,24 @@ export function createTestApp(router: Router): Server {
  * tests cover the rawBody path rather than only the JSON.stringify fallback.
  */
 export function createWebhookTestApp(router: Router): Server {
-  const app = express()
-  app.set('x-powered-by', false)
-  app.use(
-    '/api/webhooks',
-    express.json({
-      verify: (req, _res, buf) => {
-        ;(req as unknown as { rawBody?: string }).rawBody = buf.toString('utf8')
-      },
-    })
-  )
-  app.use(express.json())
-  app.use('/api', [
-    router,
-    handle(async () => {
-      throw new RequestError('NotFound', RequestError.NotFound)
-    }),
-  ])
-  return listen(app)
+  return listen(router, () => {
+    const app = express()
+    app.set('x-powered-by', false)
+    app.use(
+      '/api/webhooks',
+      express.json({
+        verify: (req, _res, buf) => {
+          ;(req as unknown as { rawBody?: string }).rawBody = buf.toString('utf8')
+        },
+      })
+    )
+    app.use(express.json())
+    app.use('/api', [
+      router,
+      handle(async () => {
+        throw new RequestError('NotFound', RequestError.NotFound)
+      }),
+    ])
+    return app
+  })
 }

--- a/src/routes/update.test.ts
+++ b/src/routes/update.test.ts
@@ -102,7 +102,9 @@ describe('the project update routes', () => {
         // Refused rather than served. The status itself is known-wrong — a plain Error becomes a
         // 500 where this should be a client error — and is fixed in the follow-up, so asserting
         // refusal here means that fix will not have to rewrite this.
-        expect(response.body.ok).toBe(false)
+        // response.ok is superagent's 2xx flag, so this also rules out a 200 that merely says
+        // ok:false in its body. still no exact status, which is the point.
+        expect({ http: response.ok, body: response.body.ok }).toEqual({ http: false, body: false })
       })
 
       it('should not create the update', () => {

--- a/src/routes/update.test.ts
+++ b/src/routes/update.test.ts
@@ -99,7 +99,8 @@ describe('the project update routes', () => {
       })
 
       it('should refuse the request', () => {
-        expect(response.status).toBeGreaterThanOrEqual(400)
+        // Recorded, not endorsed: the ownership error is swallowed by the handler's catch.
+        expect(response.status).toBe(500)
       })
 
       it('should not create the update', () => {
@@ -160,7 +161,7 @@ describe('the project update routes', () => {
       })
 
       it('should refuse the request', () => {
-        expect(response.status).toBeGreaterThanOrEqual(400)
+        expect(response.status).toBe(401)
       })
 
       it('should not edit the update', () => {
@@ -239,7 +240,7 @@ describe('the project update routes', () => {
       })
 
       it('should refuse the request', () => {
-        expect(response.status).toBeGreaterThanOrEqual(400)
+        expect(response.status).toBe(401)
       })
 
       it('should not delete the update', () => {

--- a/src/routes/update.test.ts
+++ b/src/routes/update.test.ts
@@ -99,8 +99,10 @@ describe('the project update routes', () => {
       })
 
       it('should refuse the request', () => {
-        // Recorded, not endorsed: the ownership error is swallowed by the handler's catch.
-        expect(response.status).toBe(500)
+        // Refused rather than served. The status itself is known-wrong — a plain Error becomes a
+        // 500 where this should be a client error — and is fixed in the follow-up, so asserting
+        // refusal here means that fix will not have to rewrite this.
+        expect(response.body.ok).toBe(false)
       })
 
       it('should not create the update', () => {

--- a/src/routes/update.test.ts
+++ b/src/routes/update.test.ts
@@ -1,4 +1,4 @@
-import { Express } from 'express'
+import { Server } from 'http'
 import supertest from 'supertest'
 
 import { ProjectService } from '../services/ProjectService'
@@ -47,7 +47,7 @@ const VALID_BODY = {
 const VALID_PATCH_BODY = { ...VALID_BODY, financial_records: null }
 
 describe('the project update routes', () => {
-  let app: Express
+  let app: Server
   let isAuthorOrCoauthor: jest.SpyInstance
 
   beforeEach(() => {

--- a/src/routes/user.test.ts
+++ b/src/routes/user.test.ts
@@ -1,0 +1,368 @@
+import { Server } from 'http'
+import supertest from 'supertest'
+
+import { AccountType } from '../entities/User/types'
+import { UserService } from '../services/user'
+
+import { createTestApp } from './testApp'
+import user from './user'
+
+const CALLER = '0x2AC89522CB415AC333E64F52a1a5693218cEBD58'
+const SOMEONE_ELSE = '0x56d0B5eD3D525332F00C9BC938f93598ab16AAA7'
+
+jest.mock('decentraland-gatsby/dist/entities/Auth/middleware', () => ({
+  auth:
+    (options?: { optional?: boolean }) =>
+    (
+      req: { get: (name: string) => string | undefined; auth?: string },
+      res: { status: (code: number) => { json: (body: unknown) => void } },
+      next: () => void
+    ) => {
+      const address = req.get('x-test-auth')
+      if (address) {
+        req.auth = address
+        return next()
+      }
+      if (options?.optional) {
+        return next()
+      }
+      res.status(401).json({ ok: false, error: 'Unauthorized' })
+    },
+}))
+
+describe('the user routes', () => {
+  let app: Server
+
+  beforeEach(() => {
+    app = createTestApp(user)
+  })
+
+  afterEach(() => {
+    jest.restoreAllMocks()
+  })
+
+  // Linking an account binds a wallet to a forum or discord identity, so every one of these must
+  // act on the authenticated address and never on one the caller supplied.
+  describe('the routes that act on the caller’s own account', () => {
+    const authGatedPaths = [
+      { method: 'get' as const, path: '/api/user/validate' },
+      { method: 'post' as const, path: '/api/user/validate/forum' },
+      { method: 'post' as const, path: '/api/user/validate/discord' },
+      { method: 'post' as const, path: '/api/user/discord-active' },
+      { method: 'get' as const, path: '/api/user/discord-active' },
+      { method: 'get' as const, path: '/api/user/discord-linked' },
+      { method: 'post' as const, path: '/api/user/unlink' },
+    ]
+
+    describe('when the caller is unauthenticated', () => {
+      let statuses: number[]
+
+      beforeEach(async () => {
+        const responses = await Promise.all(
+          authGatedPaths.map(({ method, path }) => supertest(app)[method](path).send({}))
+        )
+        statuses = responses.map((response) => response.status)
+      })
+
+      it('should refuse every one with a 401', () => {
+        expect(statuses).toEqual(authGatedPaths.map(() => 401))
+      })
+    })
+  })
+
+  describe('GET /api/user/validate', () => {
+    let getValidationMessage: jest.SpyInstance
+
+    beforeEach(() => {
+      getValidationMessage = jest.spyOn(UserService, 'getValidationMessage').mockResolvedValue({} as never)
+    })
+
+    describe('when an account is named in the query', () => {
+      beforeEach(async () => {
+        await supertest(app).get(`/api/user/validate?account=${AccountType.Forum}`).set('x-test-auth', CALLER)
+      })
+
+      it('should build the message for the authenticated address', () => {
+        expect(getValidationMessage).toHaveBeenCalledWith(CALLER, AccountType.Forum)
+      })
+    })
+
+    describe('when no account is named', () => {
+      beforeEach(async () => {
+        await supertest(app).get('/api/user/validate').set('x-test-auth', CALLER)
+      })
+
+      it('should ask without one', () => {
+        expect(getValidationMessage).toHaveBeenCalledWith(CALLER, undefined)
+      })
+    })
+
+    describe('when the account is repeated in the query', () => {
+      beforeEach(async () => {
+        await supertest(app).get('/api/user/validate?account=forum&account=discord').set('x-test-auth', CALLER)
+      })
+
+      it('should ignore the array rather than pass one through', () => {
+        expect(getValidationMessage).toHaveBeenCalledWith(CALLER, undefined)
+      })
+    })
+  })
+
+  describe('POST /api/user/validate/forum', () => {
+    let validateForumUser: jest.SpyInstance
+
+    beforeEach(() => {
+      validateForumUser = jest.spyOn(UserService, 'validateForumUser').mockResolvedValue({} as never)
+    })
+
+    describe('when the caller supplies a different address in the body', () => {
+      beforeEach(async () => {
+        await supertest(app)
+          .post('/api/user/validate/forum')
+          .set('x-test-auth', CALLER)
+          .send({ address: SOMEONE_ELSE, user: SOMEONE_ELSE })
+      })
+
+      it('should link the authenticated address, not the one supplied', () => {
+        expect(validateForumUser).toHaveBeenCalledWith(CALLER)
+      })
+    })
+  })
+
+  describe('POST /api/user/validate/discord', () => {
+    let validateDiscordUser: jest.SpyInstance
+
+    beforeEach(() => {
+      validateDiscordUser = jest.spyOn(UserService, 'validateDiscordUser').mockResolvedValue({} as never)
+    })
+
+    describe('when the caller supplies a different address in the body', () => {
+      beforeEach(async () => {
+        await supertest(app)
+          .post('/api/user/validate/discord')
+          .set('x-test-auth', CALLER)
+          .send({ address: SOMEONE_ELSE })
+      })
+
+      it('should link the authenticated address, not the one supplied', () => {
+        expect(validateDiscordUser).toHaveBeenCalledWith(CALLER)
+      })
+    })
+  })
+
+  describe('POST /api/user/discord-active', () => {
+    let updateDiscordStatus: jest.SpyInstance
+    let response: supertest.Response
+
+    beforeEach(() => {
+      updateDiscordStatus = jest.spyOn(UserService, 'updateDiscordStatus').mockResolvedValue(undefined as never)
+    })
+
+    describe('when the flag is a boolean', () => {
+      beforeEach(async () => {
+        await supertest(app)
+          .post('/api/user/discord-active')
+          .set('x-test-auth', CALLER)
+          .send({ is_discord_notifications_active: false })
+      })
+
+      it('should apply it to the authenticated address', () => {
+        expect(updateDiscordStatus).toHaveBeenCalledWith(CALLER, false)
+      })
+    })
+
+    // A truthy string would otherwise switch notifications on for a client that meant to send false.
+    describe('when the flag is a string rather than a boolean', () => {
+      beforeEach(async () => {
+        response = await supertest(app)
+          .post('/api/user/discord-active')
+          .set('x-test-auth', CALLER)
+          .send({ is_discord_notifications_active: 'false' })
+      })
+
+      it('should reject the request', () => {
+        expect(response.status).toBeGreaterThanOrEqual(400)
+      })
+
+      it('should not change the stored setting', () => {
+        expect(updateDiscordStatus).not.toHaveBeenCalled()
+      })
+    })
+
+    describe('when the flag is missing', () => {
+      beforeEach(async () => {
+        response = await supertest(app).post('/api/user/discord-active').set('x-test-auth', CALLER).send({})
+      })
+
+      it('should reject the request', () => {
+        expect(response.status).toBeGreaterThanOrEqual(400)
+      })
+
+      it('should not change the stored setting', () => {
+        expect(updateDiscordStatus).not.toHaveBeenCalled()
+      })
+    })
+  })
+
+  describe('POST /api/user/unlink', () => {
+    let unlinkAccount: jest.SpyInstance
+    let response: supertest.Response
+
+    beforeEach(() => {
+      unlinkAccount = jest.spyOn(UserService, 'unlinkAccount').mockResolvedValue(undefined as never)
+    })
+
+    describe('when a known account type is given', () => {
+      beforeEach(async () => {
+        await supertest(app)
+          .post('/api/user/unlink')
+          .set('x-test-auth', CALLER)
+          .send({ accountType: AccountType.Discord })
+      })
+
+      it('should unlink it from the authenticated address', () => {
+        expect(unlinkAccount).toHaveBeenCalledWith(CALLER, AccountType.Discord)
+      })
+    })
+
+    describe('when the caller names someone else’s address alongside it', () => {
+      beforeEach(async () => {
+        await supertest(app)
+          .post('/api/user/unlink')
+          .set('x-test-auth', CALLER)
+          .send({ accountType: AccountType.Forum, address: SOMEONE_ELSE })
+      })
+
+      it('should still unlink from the authenticated address', () => {
+        expect(unlinkAccount).toHaveBeenCalledWith(CALLER, AccountType.Forum)
+      })
+    })
+
+    describe('when the account type is not a known one', () => {
+      beforeEach(async () => {
+        response = await supertest(app)
+          .post('/api/user/unlink')
+          .set('x-test-auth', CALLER)
+          .send({ accountType: 'myspace' })
+      })
+
+      it('should reject the request', () => {
+        expect(response.status).toBeGreaterThanOrEqual(400)
+      })
+
+      it('should not unlink anything', () => {
+        expect(unlinkAccount).not.toHaveBeenCalled()
+      })
+    })
+
+    describe('when no account type is given', () => {
+      beforeEach(async () => {
+        response = await supertest(app).post('/api/user/unlink').set('x-test-auth', CALLER).send({})
+      })
+
+      it('should reject the request', () => {
+        expect(response.status).toBeGreaterThanOrEqual(400)
+      })
+
+      it('should not unlink anything', () => {
+        expect(unlinkAccount).not.toHaveBeenCalled()
+      })
+    })
+
+    // Recorded, not endorsed: only the first of several account types is acted on.
+    describe('when several account types are given at once', () => {
+      beforeEach(async () => {
+        await supertest(app)
+          .post('/api/user/unlink')
+          .set('x-test-auth', CALLER)
+          .send({ accountType: [AccountType.Forum, AccountType.Discord] })
+      })
+
+      it('should unlink only the first', () => {
+        expect(unlinkAccount).toHaveBeenCalledWith(CALLER, AccountType.Forum)
+      })
+    })
+  })
+
+  describe('GET /api/user/:address', () => {
+    let getProfile: jest.SpyInstance
+    let response: supertest.Response
+
+    beforeEach(() => {
+      getProfile = jest.spyOn(UserService, 'getProfile').mockResolvedValue({} as never)
+    })
+
+    describe('when the address is not an ethereum address', () => {
+      beforeEach(async () => {
+        response = await supertest(app).get('/api/user/not-an-address')
+      })
+
+      it('should respond with a 400', () => {
+        expect(response.status).toBe(400)
+      })
+
+      it('should not run the lookup', () => {
+        expect(getProfile).not.toHaveBeenCalled()
+      })
+    })
+
+    describe('when the address is valid', () => {
+      beforeEach(async () => {
+        response = await supertest(app).get(`/api/user/${SOMEONE_ELSE}`)
+      })
+
+      it('should serve the profile without requiring authentication', () => {
+        expect(getProfile).toHaveBeenCalledWith(SOMEONE_ELSE)
+      })
+    })
+  })
+
+  describe('GET /api/user/:address/is-validated', () => {
+    let isValidated: jest.SpyInstance
+    let response: supertest.Response
+
+    beforeEach(() => {
+      isValidated = jest.spyOn(UserService, 'isValidated').mockResolvedValue(true as never)
+    })
+
+    describe('when the address is not an ethereum address', () => {
+      beforeEach(async () => {
+        response = await supertest(app).get(`/api/user/not-an-address/is-validated?account=${AccountType.Forum}`)
+      })
+
+      it('should respond with a 400', () => {
+        expect(response.status).toBe(400)
+      })
+
+      it('should not run the lookup', () => {
+        expect(isValidated).not.toHaveBeenCalled()
+      })
+    })
+
+    describe('when the account type is not a known one', () => {
+      beforeEach(async () => {
+        response = await supertest(app).get(`/api/user/${SOMEONE_ELSE}/is-validated?account=myspace`)
+      })
+
+      it('should reject the request', () => {
+        expect(response.status).toBeGreaterThanOrEqual(400)
+      })
+
+      it('should not run the lookup', () => {
+        expect(isValidated).not.toHaveBeenCalled()
+      })
+    })
+
+    describe('when several account types are asked about', () => {
+      beforeEach(async () => {
+        response = await supertest(app).get(
+          `/api/user/${SOMEONE_ELSE}/is-validated?account=${AccountType.Forum}&account=${AccountType.Discord}`
+        )
+      })
+
+      it('should ask about all of them as a set', () => {
+        expect(isValidated).toHaveBeenCalledWith(SOMEONE_ELSE, new Set([AccountType.Forum, AccountType.Discord]))
+      })
+    })
+  })
+})

--- a/src/routes/user.test.ts
+++ b/src/routes/user.test.ts
@@ -181,7 +181,8 @@ describe('the user routes', () => {
       })
 
       it('should reject the request', () => {
-        expect(response.status).toBeGreaterThanOrEqual(400)
+        // Recorded, not endorsed: the flag check raises a plain Error.
+        expect(response.status).toBe(500)
       })
 
       it('should not change the stored setting', () => {
@@ -195,7 +196,8 @@ describe('the user routes', () => {
       })
 
       it('should reject the request', () => {
-        expect(response.status).toBeGreaterThanOrEqual(400)
+        // Recorded, not endorsed: the flag check raises a plain Error.
+        expect(response.status).toBe(500)
       })
 
       it('should not change the stored setting', () => {
@@ -247,7 +249,8 @@ describe('the user routes', () => {
       })
 
       it('should reject the request', () => {
-        expect(response.status).toBeGreaterThanOrEqual(400)
+        // Recorded, not endorsed: validateAccountTypes raises a plain Error.
+        expect(response.status).toBe(500)
       })
 
       it('should not unlink anything', () => {
@@ -261,7 +264,8 @@ describe('the user routes', () => {
       })
 
       it('should reject the request', () => {
-        expect(response.status).toBeGreaterThanOrEqual(400)
+        // Recorded, not endorsed: validateAccountTypes raises a plain Error.
+        expect(response.status).toBe(500)
       })
 
       it('should not unlink anything', () => {
@@ -345,7 +349,8 @@ describe('the user routes', () => {
       })
 
       it('should reject the request', () => {
-        expect(response.status).toBeGreaterThanOrEqual(400)
+        // Recorded, not endorsed: validateAccountTypes raises a plain Error.
+        expect(response.status).toBe(500)
       })
 
       it('should not run the lookup', () => {

--- a/src/routes/user.test.ts
+++ b/src/routes/user.test.ts
@@ -181,8 +181,10 @@ describe('the user routes', () => {
       })
 
       it('should reject the request', () => {
-        // Recorded, not endorsed: the flag check raises a plain Error.
-        expect(response.status).toBe(500)
+        // Refused rather than served. The status itself is known-wrong — a plain Error becomes a
+        // 500 where this should be a client error — and is fixed in the follow-up, so asserting
+        // refusal here means that fix will not have to rewrite this.
+        expect(response.body.ok).toBe(false)
       })
 
       it('should not change the stored setting', () => {
@@ -196,8 +198,10 @@ describe('the user routes', () => {
       })
 
       it('should reject the request', () => {
-        // Recorded, not endorsed: the flag check raises a plain Error.
-        expect(response.status).toBe(500)
+        // Refused rather than served. The status itself is known-wrong — a plain Error becomes a
+        // 500 where this should be a client error — and is fixed in the follow-up, so asserting
+        // refusal here means that fix will not have to rewrite this.
+        expect(response.body.ok).toBe(false)
       })
 
       it('should not change the stored setting', () => {
@@ -249,8 +253,10 @@ describe('the user routes', () => {
       })
 
       it('should reject the request', () => {
-        // Recorded, not endorsed: validateAccountTypes raises a plain Error.
-        expect(response.status).toBe(500)
+        // Refused rather than served. The status itself is known-wrong — a plain Error becomes a
+        // 500 where this should be a client error — and is fixed in the follow-up, so asserting
+        // refusal here means that fix will not have to rewrite this.
+        expect(response.body.ok).toBe(false)
       })
 
       it('should not unlink anything', () => {
@@ -264,8 +270,10 @@ describe('the user routes', () => {
       })
 
       it('should reject the request', () => {
-        // Recorded, not endorsed: validateAccountTypes raises a plain Error.
-        expect(response.status).toBe(500)
+        // Refused rather than served. The status itself is known-wrong — a plain Error becomes a
+        // 500 where this should be a client error — and is fixed in the follow-up, so asserting
+        // refusal here means that fix will not have to rewrite this.
+        expect(response.body.ok).toBe(false)
       })
 
       it('should not unlink anything', () => {
@@ -349,8 +357,10 @@ describe('the user routes', () => {
       })
 
       it('should reject the request', () => {
-        // Recorded, not endorsed: validateAccountTypes raises a plain Error.
-        expect(response.status).toBe(500)
+        // Refused rather than served. The status itself is known-wrong — a plain Error becomes a
+        // 500 where this should be a client error — and is fixed in the follow-up, so asserting
+        // refusal here means that fix will not have to rewrite this.
+        expect(response.body.ok).toBe(false)
       })
 
       it('should not run the lookup', () => {

--- a/src/routes/user.test.ts
+++ b/src/routes/user.test.ts
@@ -184,7 +184,9 @@ describe('the user routes', () => {
         // Refused rather than served. The status itself is known-wrong — a plain Error becomes a
         // 500 where this should be a client error — and is fixed in the follow-up, so asserting
         // refusal here means that fix will not have to rewrite this.
-        expect(response.body.ok).toBe(false)
+        // response.ok is superagent's 2xx flag, so this also rules out a 200 that merely says
+        // ok:false in its body. still no exact status, which is the point.
+        expect({ http: response.ok, body: response.body.ok }).toEqual({ http: false, body: false })
       })
 
       it('should not change the stored setting', () => {
@@ -201,7 +203,9 @@ describe('the user routes', () => {
         // Refused rather than served. The status itself is known-wrong — a plain Error becomes a
         // 500 where this should be a client error — and is fixed in the follow-up, so asserting
         // refusal here means that fix will not have to rewrite this.
-        expect(response.body.ok).toBe(false)
+        // response.ok is superagent's 2xx flag, so this also rules out a 200 that merely says
+        // ok:false in its body. still no exact status, which is the point.
+        expect({ http: response.ok, body: response.body.ok }).toEqual({ http: false, body: false })
       })
 
       it('should not change the stored setting', () => {
@@ -256,7 +260,9 @@ describe('the user routes', () => {
         // Refused rather than served. The status itself is known-wrong — a plain Error becomes a
         // 500 where this should be a client error — and is fixed in the follow-up, so asserting
         // refusal here means that fix will not have to rewrite this.
-        expect(response.body.ok).toBe(false)
+        // response.ok is superagent's 2xx flag, so this also rules out a 200 that merely says
+        // ok:false in its body. still no exact status, which is the point.
+        expect({ http: response.ok, body: response.body.ok }).toEqual({ http: false, body: false })
       })
 
       it('should not unlink anything', () => {
@@ -273,7 +279,9 @@ describe('the user routes', () => {
         // Refused rather than served. The status itself is known-wrong — a plain Error becomes a
         // 500 where this should be a client error — and is fixed in the follow-up, so asserting
         // refusal here means that fix will not have to rewrite this.
-        expect(response.body.ok).toBe(false)
+        // response.ok is superagent's 2xx flag, so this also rules out a 200 that merely says
+        // ok:false in its body. still no exact status, which is the point.
+        expect({ http: response.ok, body: response.body.ok }).toEqual({ http: false, body: false })
       })
 
       it('should not unlink anything', () => {
@@ -360,7 +368,9 @@ describe('the user routes', () => {
         // Refused rather than served. The status itself is known-wrong — a plain Error becomes a
         // 500 where this should be a client error — and is fixed in the follow-up, so asserting
         // refusal here means that fix will not have to rewrite this.
-        expect(response.body.ok).toBe(false)
+        // response.ok is superagent's 2xx flag, so this also rules out a 200 that merely says
+        // ok:false in its body. still no exact status, which is the point.
+        expect({ http: response.ok, body: response.body.ok }).toEqual({ http: false, body: false })
       })
 
       it('should not run the lookup', () => {

--- a/src/routes/vestings.test.ts
+++ b/src/routes/vestings.test.ts
@@ -1,0 +1,112 @@
+import { Server } from 'http'
+import supertest from 'supertest'
+
+import { VestingService } from '../services/VestingService'
+
+import { createTestApp } from './testApp'
+import vestings from './vestings'
+
+const ADDRESS = '0x2AC89522CB415AC333E64F52a1a5693218cEBD58'
+const OTHER_ADDRESS = '0x56d0B5eD3D525332F00C9BC938f93598ab16AAA7'
+
+describe('the vesting routes', () => {
+  let app: Server
+
+  beforeEach(() => {
+    app = createTestApp(vestings)
+  })
+
+  afterEach(() => {
+    jest.restoreAllMocks()
+  })
+
+  // These forward straight to the vesting subgraph, so an unvalidated address becomes an outbound
+  // query built from whatever the caller sent.
+  describe('POST /api/vesting', () => {
+    let getVestings: jest.SpyInstance
+    let response: supertest.Response
+
+    beforeEach(() => {
+      getVestings = jest.spyOn(VestingService, 'getVestings').mockResolvedValue([] as never)
+    })
+
+    describe('when every address is an ethereum address', () => {
+      beforeEach(async () => {
+        await supertest(app)
+          .post('/api/vesting')
+          .send({ addresses: [ADDRESS, OTHER_ADDRESS] })
+      })
+
+      it('should forward them', () => {
+        expect(getVestings).toHaveBeenCalledWith([ADDRESS, OTHER_ADDRESS])
+      })
+    })
+
+    describe('when one address is not an ethereum address', () => {
+      beforeEach(async () => {
+        response = await supertest(app)
+          .post('/api/vesting')
+          .send({ addresses: [ADDRESS, 'not-an-address'] })
+      })
+
+      it('should respond with a 400', () => {
+        expect(response.status).toBe(400)
+      })
+
+      it('should not query for the valid ones either', () => {
+        expect(getVestings).not.toHaveBeenCalled()
+      })
+    })
+  })
+
+  describe('GET /api/vesting/:address', () => {
+    let getVestingWithLogs: jest.SpyInstance
+    let response: supertest.Response
+
+    beforeEach(() => {
+      getVestingWithLogs = jest.spyOn(VestingService, 'getVestingWithLogs').mockResolvedValue({} as never)
+    })
+
+    describe('when the address is not an ethereum address', () => {
+      beforeEach(async () => {
+        response = await supertest(app).get('/api/vesting/not-an-address')
+      })
+
+      it('should respond with a 400', () => {
+        expect(response.status).toBe(400)
+      })
+
+      it('should not query for it', () => {
+        expect(getVestingWithLogs).not.toHaveBeenCalled()
+      })
+    })
+
+    describe('when the address is valid', () => {
+      beforeEach(async () => {
+        response = await supertest(app).get(`/api/vesting/${ADDRESS}`)
+      })
+
+      it('should query for it without requiring authentication', () => {
+        expect(getVestingWithLogs).toHaveBeenCalledWith(ADDRESS)
+      })
+    })
+  })
+
+  describe('GET /api/all-vestings', () => {
+    let getAllVestings: jest.SpyInstance
+
+    beforeEach(() => {
+      getAllVestings = jest.spyOn(VestingService, 'getAllVestings').mockResolvedValue([] as never)
+    })
+
+    describe('when it is requested', () => {
+      beforeEach(async () => {
+        await supertest(app).get('/api/all-vestings')
+      })
+
+      it('should be served without requiring authentication', () => {
+        expect(getAllVestings).toHaveBeenCalled()
+      })
+    })
+  })
+})

--- a/src/routes/votes.test.ts
+++ b/src/routes/votes.test.ts
@@ -1,0 +1,312 @@
+import { Server } from 'http'
+import supertest from 'supertest'
+
+import { SnapshotGraphql } from '../clients/SnapshotGraphql'
+import ProposalModel from '../entities/Proposal/model'
+import { createTestProposal } from '../entities/Proposal/testHelpers'
+import { ProposalStatus, ProposalType } from '../entities/Proposal/types'
+import VotesModel from '../entities/Votes/model'
+import { ProposalService } from '../services/ProposalService'
+import { SnapshotService } from '../services/SnapshotService'
+import { VoteService } from '../services/vote'
+
+import { createTestApp } from './testApp'
+import votes from './votes'
+
+const ADDRESS = '0x2AC89522CB415AC333E64F52a1a5693218cEBD58'
+const PROPOSAL_ID = '00000000-0000-0000-0000-000000000001'
+const SNAPSHOT_ID = 'snapshot-1'
+
+function storedProposal(finishAt: Date) {
+  return {
+    ...createTestProposal(ProposalType.Poll, ProposalStatus.Active),
+    id: PROPOSAL_ID,
+    snapshot_id: SNAPSHOT_ID,
+    finish_at: finishAt,
+  }
+}
+
+const STILL_OPEN = new Date(Date.now() + 24 * 60 * 60 * 1000)
+const LONG_FINISHED = new Date('2020-01-01T00:00:00.000Z')
+
+describe('the vote routes', () => {
+  let app: Server
+
+  beforeEach(() => {
+    app = createTestApp(votes)
+  })
+
+  afterEach(() => {
+    jest.restoreAllMocks()
+  })
+
+  describe('GET /api/proposals/:proposal/votes', () => {
+    let getVotesByProposal: jest.SpyInstance
+    let update: jest.SpyInstance
+    let response: supertest.Response
+
+    beforeEach(() => {
+      jest.spyOn(ProposalService, 'getProposal').mockResolvedValue(storedProposal(STILL_OPEN) as never)
+      jest.spyOn(VoteService, 'getVotes').mockResolvedValue({ hash: 'stored-hash', votes: { stored: true } } as never)
+      getVotesByProposal = jest.fn().mockResolvedValue([])
+      jest.spyOn(SnapshotGraphql, 'get').mockReturnValue({ getVotesByProposal } as never)
+      jest.spyOn(VotesModel, 'hashVotes').mockReturnValue('stored-hash')
+      update = jest.spyOn(VotesModel, 'update').mockResolvedValue({} as never)
+    })
+
+    describe('when the proposal id is not a uuid', () => {
+      beforeEach(async () => {
+        response = await supertest(app).get('/api/proposals/not-a-uuid/votes')
+      })
+
+      it('should respond with a 400', () => {
+        expect(response.status).toBe(400)
+      })
+    })
+
+    // Voting is closed and settled, so there is nothing new to fetch.
+    describe('when the proposal finished more than an hour ago', () => {
+      beforeEach(async () => {
+        ;(ProposalService.getProposal as jest.Mock).mockResolvedValue(storedProposal(LONG_FINISHED))
+        response = await supertest(app).get(`/api/proposals/${PROPOSAL_ID}/votes`)
+      })
+
+      it('should serve the stored votes', () => {
+        expect(response.body.data).toEqual({ stored: true })
+      })
+
+      it('should not ask snapshot at all', () => {
+        expect(getVotesByProposal).not.toHaveBeenCalled()
+      })
+    })
+
+    describe('when a finished proposal is asked to refresh', () => {
+      beforeEach(async () => {
+        ;(ProposalService.getProposal as jest.Mock).mockResolvedValue(storedProposal(LONG_FINISHED))
+        response = await supertest(app).get(`/api/proposals/${PROPOSAL_ID}/votes?refresh=true`)
+      })
+
+      it('should go back to snapshot anyway', () => {
+        expect(getVotesByProposal).toHaveBeenCalledWith(SNAPSHOT_ID)
+      })
+    })
+
+    describe('when snapshot returns the same votes already stored', () => {
+      beforeEach(async () => {
+        response = await supertest(app).get(`/api/proposals/${PROPOSAL_ID}/votes`)
+      })
+
+      it('should serve the stored votes', () => {
+        expect(response.body.data).toEqual({ stored: true })
+      })
+
+      it('should not rewrite an unchanged row', () => {
+        expect(update).not.toHaveBeenCalled()
+      })
+    })
+
+    describe('when snapshot returns votes that differ from the stored ones', () => {
+      beforeEach(async () => {
+        ;(VotesModel.hashVotes as jest.Mock).mockReturnValue('a-different-hash')
+        response = await supertest(app).get(`/api/proposals/${PROPOSAL_ID}/votes`)
+      })
+
+      it('should store the new votes against the proposal', () => {
+        expect(update).toHaveBeenCalledWith(expect.anything(), { proposal_id: PROPOSAL_ID })
+      })
+    })
+
+    // Snapshot being unreachable must not take the votes endpoint down with it.
+    describe('when snapshot is unreachable', () => {
+      beforeEach(async () => {
+        getVotesByProposal.mockRejectedValue(new Error('snapshot down'))
+        response = await supertest(app).get(`/api/proposals/${PROPOSAL_ID}/votes`)
+      })
+
+      it('should respond with a 200', () => {
+        expect(response.status).toBe(200)
+      })
+
+      it('should fall back to the stored votes', () => {
+        expect(response.body.data).toEqual({ stored: true })
+      })
+    })
+  })
+
+  describe('GET /api/votes', () => {
+    let findAny: jest.SpyInstance
+    let response: supertest.Response
+
+    beforeEach(() => {
+      findAny = jest.spyOn(VotesModel, 'findAny').mockResolvedValue([
+        { proposal_id: 'first', votes: { a: 1 } },
+        { proposal_id: 'second', votes: { b: 2 } },
+      ] as never)
+    })
+
+    describe('when no proposal ids are given', () => {
+      beforeEach(async () => {
+        response = await supertest(app).get('/api/votes')
+      })
+
+      it('should respond with a 400', () => {
+        expect(response.status).toBe(400)
+      })
+
+      it('should not run the query', () => {
+        expect(findAny).not.toHaveBeenCalled()
+      })
+    })
+
+    describe('when proposal ids are given', () => {
+      beforeEach(async () => {
+        response = await supertest(app).get('/api/votes?id=first&id=second')
+      })
+
+      it('should key the result by proposal id', () => {
+        expect(response.body.data).toEqual({ first: { a: 1 }, second: { b: 2 } })
+      })
+    })
+  })
+
+  describe('GET /api/votes/:address', () => {
+    let getVotesByAddresses: jest.SpyInstance
+    let response: supertest.Response
+
+    beforeEach(() => {
+      getVotesByAddresses = jest.spyOn(SnapshotService, 'getVotesByAddresses').mockResolvedValue([] as never)
+      jest.spyOn(ProposalModel, 'findFromSnapshotIds').mockResolvedValue([] as never)
+    })
+
+    describe('when the address is not an ethereum address', () => {
+      beforeEach(async () => {
+        response = await supertest(app).get('/api/votes/not-an-address')
+      })
+
+      it('should respond with a 400', () => {
+        expect(response.status).toBe(400)
+      })
+
+      it('should not query snapshot', () => {
+        expect(getVotesByAddresses).not.toHaveBeenCalled()
+      })
+    })
+
+    describe('when paging arguments are whole numbers', () => {
+      beforeEach(async () => {
+        await supertest(app).get(`/api/votes/${ADDRESS}?first=10&skip=5`)
+      })
+
+      it('should pass them through', () => {
+        expect(getVotesByAddresses).toHaveBeenCalledWith([ADDRESS], 10, 5)
+      })
+    })
+
+    describe('when paging arguments are not whole numbers', () => {
+      beforeEach(async () => {
+        await supertest(app).get(`/api/votes/${ADDRESS}?first=abc&skip=1.5`)
+      })
+
+      it('should drop them rather than forward a NaN', () => {
+        expect(getVotesByAddresses).toHaveBeenCalledWith([ADDRESS], undefined, undefined)
+      })
+    })
+
+    describe('when the address has no votes', () => {
+      beforeEach(async () => {
+        response = await supertest(app).get(`/api/votes/${ADDRESS}`)
+      })
+
+      it('should return an empty list', () => {
+        expect(response.body.data).toEqual([])
+      })
+    })
+
+    describe('when a vote has no matching stored proposal', () => {
+      beforeEach(async () => {
+        getVotesByAddresses.mockResolvedValue([
+          { created: 2, proposal: { id: 'known' } },
+          { created: 1, proposal: { id: 'unknown' } },
+        ])
+        ;(ProposalModel.findFromSnapshotIds as jest.Mock).mockResolvedValue([
+          { ...createTestProposal(ProposalType.Poll, ProposalStatus.Active), snapshot_id: 'known', id: PROPOSAL_ID },
+        ])
+        response = await supertest(app).get(`/api/votes/${ADDRESS}`)
+      })
+
+      it('should drop the vote it cannot describe', () => {
+        expect(response.body.data).toHaveLength(1)
+      })
+
+      it('should decorate the one it can with the stored proposal', () => {
+        expect(response.body.data[0].proposal.proposal_id).toBe(PROPOSAL_ID)
+      })
+    })
+
+    describe('when several votes match stored proposals', () => {
+      beforeEach(async () => {
+        getVotesByAddresses.mockResolvedValue([
+          { created: 1, proposal: { id: 'older' } },
+          { created: 3, proposal: { id: 'newer' } },
+        ])
+        ;(ProposalModel.findFromSnapshotIds as jest.Mock).mockResolvedValue([
+          { ...createTestProposal(ProposalType.Poll, ProposalStatus.Active), snapshot_id: 'older' },
+          { ...createTestProposal(ProposalType.Poll, ProposalStatus.Active), snapshot_id: 'newer' },
+        ])
+        response = await supertest(app).get(`/api/votes/${ADDRESS}`)
+      })
+
+      it('should return the most recent vote first', () => {
+        expect(response.body.data.map((vote: { created: number }) => vote.created)).toEqual([3, 1])
+      })
+    })
+  })
+
+  describe('GET /api/votes/top-voters', () => {
+    let getTopVoters: jest.SpyInstance
+
+    beforeEach(() => {
+      getTopVoters = jest.spyOn(VoteService, 'getTopVotersForLast30Days').mockResolvedValue([] as never)
+    })
+
+    describe('when no limit is given', () => {
+      beforeEach(async () => {
+        await supertest(app).get('/api/votes/top-voters')
+      })
+
+      it('should query without one', () => {
+        expect(getTopVoters).toHaveBeenCalledWith(undefined)
+      })
+    })
+
+    // Recorded, not endorsed: the handler reads the limit from the request body, but this is a GET,
+    // so a caller has no way to supply one and the query string is ignored.
+    describe('when a limit is given in the query string', () => {
+      beforeEach(async () => {
+        await supertest(app).get('/api/votes/top-voters?limit=5')
+      })
+
+      it('should ignore it', () => {
+        expect(getTopVoters).toHaveBeenCalledWith(undefined)
+      })
+    })
+  })
+
+  describe('GET /api/votes/participation', () => {
+    let getParticipation: jest.SpyInstance
+
+    beforeEach(() => {
+      getParticipation = jest.spyOn(VoteService, 'getParticipation').mockResolvedValue({} as never)
+    })
+
+    describe('when it is requested', () => {
+      beforeEach(async () => {
+        await supertest(app).get('/api/votes/participation')
+      })
+
+      it('should be served without requiring authentication', () => {
+        expect(getParticipation).toHaveBeenCalled()
+      })
+    })
+  })
+})

--- a/src/routes/webhooks.test.ts
+++ b/src/routes/webhooks.test.ts
@@ -119,8 +119,11 @@ describe('POST /api/webhooks/alchemy/delegation', () => {
         expect(response.status).toBe(201)
       })
 
-      it('should process the block it parsed out of those bytes', () => {
-        expect(delegationUpdate).toHaveBeenCalledTimes(1)
+      it('should process the block parsed out of those exact bytes', () => {
+        expect(delegationUpdate).toHaveBeenCalledWith({
+          number: 1,
+          transactions: [{ hash: '0xaa' }],
+        })
       })
     })
 

--- a/src/routes/webhooks.test.ts
+++ b/src/routes/webhooks.test.ts
@@ -287,6 +287,56 @@ describe('POST /api/webhooks/discourse/comment', () => {
     })
   })
 
+  // Same reasoning as the alchemy endpoint: signing what JSON.stringify produces and sending that
+  // same object cannot distinguish the captured bytes from the re-serialised fallback.
+  describe('when the signed bytes differ from what re-serialising the body would produce', () => {
+    const rawBody = '{ "post" : { "id" : 7 , "topic_id" : 42 } }'
+
+    describe('and the signature covers the bytes actually sent', () => {
+      let response: supertest.Response
+
+      beforeEach(async () => {
+        response = await supertest(app)
+          .post('/api/webhooks/discourse/comment')
+          .set('Content-Type', 'application/json')
+          .set('X-Discourse-Event-Signature', `sha256=${sign(DISCOURSE_SECRET, rawBody)}`)
+          .set('X-Discourse-Event-Id', '1')
+          .set('X-Discourse-Event', 'post_created')
+          .send(rawBody)
+      })
+
+      it('should accept it', () => {
+        expect(response.status).toBe(201)
+      })
+
+      it('should record the comment parsed out of those bytes', () => {
+        expect(commented).toHaveBeenCalledWith('1', 'post_created', { id: 7, topic_id: 42 })
+      })
+    })
+
+    describe('and the signature covers the re-serialised form instead', () => {
+      let response: supertest.Response
+
+      beforeEach(async () => {
+        response = await supertest(app)
+          .post('/api/webhooks/discourse/comment')
+          .set('Content-Type', 'application/json')
+          .set('X-Discourse-Event-Signature', `sha256=${sign(DISCOURSE_SECRET, JSON.stringify(JSON.parse(rawBody)))}`)
+          .set('X-Discourse-Event-Id', '1')
+          .set('X-Discourse-Event', 'post_created')
+          .send(rawBody)
+      })
+
+      it('should respond with a 403', () => {
+        expect(response.status).toBe(403)
+      })
+
+      it('should not record the comment', () => {
+        expect(commented).not.toHaveBeenCalled()
+      })
+    })
+  })
+
   describe('when the signature and event headers are valid', () => {
     let response: supertest.Response
 

--- a/src/routes/webhooks.test.ts
+++ b/src/routes/webhooks.test.ts
@@ -180,7 +180,7 @@ describe('POST /api/webhooks/alchemy/delegation', () => {
     // Alchemy retries on a non-2xx, and delegationUpdate is idempotent, so the failure must not
     // be masked with a 200.
     it('should respond with a non-2xx so delivery is retried', () => {
-      expect(response.status).toBeGreaterThanOrEqual(400)
+      expect(response.status).toBe(500)
     })
   })
 })

--- a/src/routes/webhooks.test.ts
+++ b/src/routes/webhooks.test.ts
@@ -1,5 +1,5 @@
 import crypto from 'crypto'
-import { Express } from 'express'
+import { Server } from 'http'
 import supertest from 'supertest'
 
 import { ErrorService } from '../services/ErrorService'
@@ -26,7 +26,7 @@ function alchemyBody(transactions: unknown[]) {
 }
 
 describe('POST /api/webhooks/alchemy/delegation', () => {
-  let app: Express
+  let app: Server
   let delegationUpdate: jest.SpyInstance
 
   beforeEach(() => {
@@ -186,7 +186,7 @@ describe('POST /api/webhooks/alchemy/delegation', () => {
 })
 
 describe('POST /api/webhooks/discourse/comment', () => {
-  let app: Express
+  let app: Server
   let commented: jest.SpyInstance
   const body = { post: { id: 7 } }
 

--- a/src/routes/webhooks.test.ts
+++ b/src/routes/webhooks.test.ts
@@ -96,6 +96,55 @@ describe('POST /api/webhooks/alchemy/delegation', () => {
     })
   })
 
+  // The route captures the exact bytes before parsing and falls back to re-serialising the parsed
+  // body when it cannot. These payloads are deliberately not what JSON.stringify would produce —
+  // the spacing and key order differ — so they only verify if the captured bytes are used. Signing
+  // JSON.stringify(body) and sending that same object cannot tell the two paths apart.
+  describe('when the signed bytes differ from what re-serialising the body would produce', () => {
+    const rawBody =
+      '{ "event" : { "data" : { "block" : { "transactions" : [ { "hash" : "0xaa" } ] , "number" : 1 } } } }'
+
+    describe('and the signature covers the bytes actually sent', () => {
+      let response: supertest.Response
+
+      beforeEach(async () => {
+        response = await supertest(app)
+          .post('/api/webhooks/alchemy/delegation')
+          .set('Content-Type', 'application/json')
+          .set('x-alchemy-signature', sign(ALCHEMY_SECRET, rawBody))
+          .send(rawBody)
+      })
+
+      it('should accept it', () => {
+        expect(response.status).toBe(201)
+      })
+
+      it('should process the block it parsed out of those bytes', () => {
+        expect(delegationUpdate).toHaveBeenCalledTimes(1)
+      })
+    })
+
+    describe('and the signature covers the re-serialised form instead', () => {
+      let response: supertest.Response
+
+      beforeEach(async () => {
+        response = await supertest(app)
+          .post('/api/webhooks/alchemy/delegation')
+          .set('Content-Type', 'application/json')
+          .set('x-alchemy-signature', sign(ALCHEMY_SECRET, JSON.stringify(JSON.parse(rawBody))))
+          .send(rawBody)
+      })
+
+      it('should respond with a 403', () => {
+        expect(response.status).toBe(403)
+      })
+
+      it('should not process the block', () => {
+        expect(delegationUpdate).not.toHaveBeenCalled()
+      })
+    })
+  })
+
   describe('when the block carries no transactions', () => {
     let response: supertest.Response
 

--- a/src/services/VestingService.test.ts
+++ b/src/services/VestingService.test.ts
@@ -1,0 +1,276 @@
+import { SubgraphVesting } from '../clients/VestingSubgraphTypes'
+import { VestingsSubgraph } from '../clients/VestingsSubgraph'
+import { VestingStatus } from '../entities/Grant/types'
+
+import { VestingService } from './VestingService'
+
+const VESTING_ADDRESS = '0x1111111111111111111111111111111111111111'
+const OTHER_ADDRESS = '0x2222222222222222222222222222222222222222'
+const DAY = 24 * 60 * 60
+
+const now = Math.floor(Date.now() / 1000)
+
+// A vesting that started 100 days ago and runs for 200, so "now" sits halfway through it.
+function subgraphVesting(overrides: Partial<SubgraphVesting> = {}): SubgraphVesting {
+  return {
+    id: VESTING_ADDRESS,
+    version: 2,
+    duration: String(200 * DAY),
+    cliff: String(now - 90 * DAY),
+    beneficiary: '0x3333333333333333333333333333333333333333',
+    revoked: false,
+    revocable: true,
+    released: '0',
+    start: String(now - 100 * DAY),
+    periodDuration: String(30 * DAY),
+    vestedPerPeriod: ['100', '100', '100', '100', '100', '100'],
+    paused: false,
+    pausable: true,
+    stop: '0',
+    linear: false,
+    token: '0x0f5d2fb29fb7d3cfee444a200298f468908cc942',
+    owner: '0x4444444444444444444444444444444444444444',
+    total: '600',
+    releaseLogs: [],
+    pausedLogs: [],
+    revokeTimestamp: BigInt(0),
+    ...overrides,
+  }
+}
+
+// parseSubgraphVesting is private; this is the thinnest public route to it, since it only maps.
+async function parse(vesting: SubgraphVesting) {
+  jest
+    .spyOn(VestingsSubgraph, 'get')
+    .mockReturnValue({ getVestingsWithRecentlyEndedCliffs: jest.fn().mockResolvedValue([vesting]) } as never)
+  const [parsed] = await VestingService.getVestingsWithRecentlyEndedCliffs()
+  return parsed
+}
+
+describe('VestingService', () => {
+  afterEach(() => {
+    jest.restoreAllMocks()
+  })
+
+  describe('when the cliff has not been reached yet', () => {
+    it('should report nothing as vested, however much time has passed', async () => {
+      const parsed = await parse(subgraphVesting({ cliff: String(now + 10 * DAY) }))
+      expect(parsed.vested).toBe(0)
+    })
+
+    it('should still owe nothing, since nothing has vested', async () => {
+      const parsed = await parse(subgraphVesting({ cliff: String(now + 10 * DAY) }))
+      expect(parsed.releasable).toBe(0)
+    })
+  })
+
+  describe('when the vesting is linear and past its cliff', () => {
+    it('should vest in proportion to the time elapsed', async () => {
+      const parsed = await parse(subgraphVesting({ linear: true }))
+      expect(Math.round(parsed.vested)).toBe(300)
+    })
+
+    // Past the end the proportion would exceed one, so it is capped rather than over-vesting.
+    it('should stop at the total once the contract has finished', async () => {
+      const parsed = await parse(
+        subgraphVesting({ linear: true, start: String(now - 300 * DAY), cliff: String(now - 290 * DAY) })
+      )
+      expect(parsed.vested).toBe(600)
+    })
+  })
+
+  describe('when the vesting is periodic', () => {
+    // Three whole 30-day periods have completed in the 100 days since it started.
+    it('should vest only the periods that have completed', async () => {
+      const parsed = await parse(subgraphVesting())
+      expect(parsed.vested).toBe(300)
+    })
+
+    it('should not vest beyond the periods it was given', async () => {
+      const parsed = await parse(subgraphVesting({ vestedPerPeriod: ['100', '100'] }))
+      expect(parsed.vested).toBe(200)
+    })
+
+    it('should subtract what has already been released', async () => {
+      const parsed = await parse(subgraphVesting({ released: '120' }))
+      expect(parsed.releasable).toBe(180)
+    })
+  })
+
+  // Pausing freezes the clock, so a paused contract must not keep vesting while it is stopped.
+  describe('when a periodic vesting is paused', () => {
+    const pausedAt = String(now - 50 * DAY)
+
+    it('should count only the periods completed before the pause', async () => {
+      const parsed = await parse(
+        subgraphVesting({ paused: true, pausedLogs: [{ timestamp: pausedAt, eventType: 'Paused' }] as never })
+      )
+      expect(parsed.vested).toBe(100)
+    })
+
+    it('should take the latest pause when several are recorded', async () => {
+      const parsed = await parse(
+        subgraphVesting({
+          paused: true,
+          pausedLogs: [
+            { timestamp: String(now - 80 * DAY), eventType: 'Paused' },
+            { timestamp: pausedAt, eventType: 'Paused' },
+          ] as never,
+        })
+      )
+      expect(parsed.vested).toBe(100)
+    })
+
+    it('should keep vesting normally when it carries no pause log', async () => {
+      const parsed = await parse(subgraphVesting({ paused: true }))
+      expect(parsed.vested).toBe(300)
+    })
+  })
+
+  describe('when reporting the status', () => {
+    it('should report a running vesting as in progress', async () => {
+      const parsed = await parse(subgraphVesting())
+      expect(parsed.status).toBe(VestingStatus.InProgress)
+    })
+
+    it('should report a paused vesting as paused', async () => {
+      const parsed = await parse(subgraphVesting({ paused: true }))
+      expect(parsed.status).toBe(VestingStatus.Paused)
+    })
+
+    // Revocation is terminal, so it wins over a pause that is also set.
+    it('should report a revoked vesting as revoked even when it is also paused', async () => {
+      const parsed = await parse(subgraphVesting({ revoked: true, paused: true }))
+      expect(parsed.status).toBe(VestingStatus.Revoked)
+    })
+  })
+
+  describe('when parsing the logs', () => {
+    it('should return them newest first regardless of the order they arrive in', async () => {
+      const parsed = await parse(
+        subgraphVesting({
+          releaseLogs: [
+            { timestamp: String(now - 10 * DAY), amount: '50' },
+            { timestamp: String(now - 80 * DAY), amount: '20' },
+          ] as never,
+          pausedLogs: [{ timestamp: String(now - 40 * DAY), eventType: 'Paused' }] as never,
+        })
+      )
+      const timestamps = parsed.logs.map((log) => new Date(log.timestamp).getTime())
+      expect(timestamps).toEqual([...timestamps].sort((a, b) => b - a))
+    })
+
+    it('should include both the releases and the pause events', async () => {
+      const parsed = await parse(
+        subgraphVesting({
+          releaseLogs: [{ timestamp: String(now - 10 * DAY), amount: '50' }] as never,
+          pausedLogs: [{ timestamp: String(now - 40 * DAY), eventType: 'Paused' }] as never,
+        })
+      )
+      expect(parsed.logs).toHaveLength(2)
+    })
+
+    it('should distinguish a pause from an unpause', async () => {
+      const parsed = await parse(
+        subgraphVesting({
+          pausedLogs: [
+            { timestamp: String(now - 40 * DAY), eventType: 'Paused' },
+            { timestamp: String(now - 20 * DAY), eventType: 'Unpaused' },
+          ] as never,
+        })
+      )
+      expect(parsed.logs[0].topic).not.toBe(parsed.logs[1].topic)
+    })
+  })
+
+  describe('VestingService.getVestings', () => {
+    describe('when no addresses are given', () => {
+      it('should return nothing without querying', async () => {
+        const getVestings = jest.fn()
+        jest.spyOn(VestingsSubgraph, 'get').mockReturnValue({ getVestings } as never)
+        expect(await VestingService.getVestings([])).toEqual([])
+        expect(getVestings).not.toHaveBeenCalled()
+      })
+    })
+
+    describe('when the same address is given more than once, in mixed case', () => {
+      let getVestings: jest.Mock
+
+      beforeEach(async () => {
+        getVestings = jest.fn().mockResolvedValue([])
+        jest.spyOn(VestingsSubgraph, 'get').mockReturnValue({ getVestings } as never)
+        jest.spyOn(VestingService, 'getVestingWithLogs').mockRejectedValue(new Error('not found'))
+        await VestingService.getVestings([VESTING_ADDRESS, VESTING_ADDRESS.toUpperCase().replace('0X', '0x')])
+      })
+
+      it('should ask for it once, lowercased', () => {
+        expect(getVestings).toHaveBeenCalledWith([VESTING_ADDRESS])
+      })
+    })
+
+    describe('when an address is missing from the subgraph', () => {
+      let result: Awaited<ReturnType<typeof VestingService.getVestings>>
+
+      beforeEach(async () => {
+        jest
+          .spyOn(VestingsSubgraph, 'get')
+          .mockReturnValue({ getVestings: jest.fn().mockResolvedValue([subgraphVesting()]) } as never)
+        jest
+          .spyOn(VestingService, 'getVestingWithLogs')
+          .mockResolvedValue({ address: OTHER_ADDRESS, logs: [], start_at: new Date().toISOString() } as never)
+        result = await VestingService.getVestings([VESTING_ADDRESS, OTHER_ADDRESS])
+      })
+
+      it('should fall back to fetching it directly', () => {
+        expect(VestingService.getVestingWithLogs).toHaveBeenCalledWith(OTHER_ADDRESS)
+      })
+
+      it('should return both the subgraph and the fallback results', () => {
+        expect(result).toHaveLength(2)
+      })
+    })
+
+    // One address failing everywhere must not lose the ones that resolved.
+    describe('when the fallback also fails for an address', () => {
+      let result: Awaited<ReturnType<typeof VestingService.getVestings>>
+
+      beforeEach(async () => {
+        jest
+          .spyOn(VestingsSubgraph, 'get')
+          .mockReturnValue({ getVestings: jest.fn().mockResolvedValue([subgraphVesting()]) } as never)
+        jest.spyOn(VestingService, 'getVestingWithLogs').mockRejectedValue(new Error('nowhere to be found'))
+        result = await VestingService.getVestings([VESTING_ADDRESS, OTHER_ADDRESS])
+      })
+
+      it('should drop the one that could not be resolved', () => {
+        expect(result).toHaveLength(1)
+      })
+
+      it('should still return the one that could', () => {
+        expect(result[0].address).toBe(VESTING_ADDRESS)
+      })
+    })
+  })
+
+  describe('VestingService.getVestingWithLogs', () => {
+    describe('when the address is empty', () => {
+      it('should refuse rather than query for nothing', async () => {
+        await expect(VestingService.getVestingWithLogs('')).rejects.toThrow('empty contract address')
+      })
+
+      it('should refuse a null address too', async () => {
+        await expect(VestingService.getVestingWithLogs(null)).rejects.toThrow('empty contract address')
+      })
+    })
+
+    describe('when the subgraph has the vesting', () => {
+      it('should return it parsed', async () => {
+        jest
+          .spyOn(VestingsSubgraph, 'get')
+          .mockReturnValue({ getVesting: jest.fn().mockResolvedValue(subgraphVesting()) } as never)
+        const parsed = await VestingService.getVestingWithLogs(VESTING_ADDRESS)
+        expect(parsed.address).toBe(VESTING_ADDRESS)
+      })
+    })
+  })
+})

--- a/test/integration/bidQueries.test.ts
+++ b/test/integration/bidQueries.test.ts
@@ -1,0 +1,185 @@
+import BidModel from '../../src/entities/Bid/model'
+import { UnpublishedBidStatus } from '../../src/entities/Bid/types'
+import { ProposalStatus, ProposalType } from '../../src/entities/Proposal/types'
+import { cleanTables, closeTestDb, initTestDb } from '../setup/db'
+import { insertProposalWith } from '../setup/factories'
+
+const AUTHOR = '0x2AC89522CB415AC333E64F52a1a5693218cEBD58'
+const OTHER_AUTHOR = '0x56d0b5ed3d525332f00c9bc938f93598ab16aaa7'
+const TENDER = '00000000-0000-0000-0000-000000000001'
+const OTHER_TENDER = '00000000-0000-0000-0000-000000000002'
+
+const IN_THE_PAST = new Date(Date.now() - 60 * 60 * 1000).toISOString()
+const IN_THE_FUTURE = new Date(Date.now() + 60 * 60 * 1000).toISOString()
+
+const BID_DATA = { title: 'A bid', summary: 'What it proposes' }
+
+async function createBid(overrides: { tender?: string; author?: string; publishAt?: string } = {}) {
+  await BidModel.createBid({
+    linked_proposal_id: overrides.tender ?? TENDER,
+    author_address: overrides.author ?? AUTHOR,
+    bid_proposal_data: JSON.stringify(BID_DATA) as never,
+    publish_at: overrides.publishAt ?? IN_THE_PAST,
+    status: UnpublishedBidStatus.Pending,
+  })
+}
+
+/**
+ * These feed publishBids, which is one of the two jobs serialized by the advisory lock because it
+ * is not idempotent. The bid payload is encrypted in the column, so the encrypt and decrypt halves
+ * only prove they agree when they run against a real database.
+ */
+describe('the bid queries', () => {
+  beforeAll(async () => {
+    await initTestDb()
+  })
+
+  afterAll(async () => {
+    await closeTestDb()
+  })
+
+  afterEach(async () => {
+    await cleanTables()
+  })
+
+  // A bid references the tender it is placed on, so the tenders have to exist first.
+  beforeEach(async () => {
+    await insertProposalWith({ id: TENDER, type: ProposalType.Tender, status: ProposalStatus.Passed })
+    await insertProposalWith({ id: OTHER_TENDER, type: ProposalType.Tender, status: ProposalStatus.Passed })
+  })
+
+  describe('getBidsReadyToPublish', () => {
+    describe('when a pending bid is due', () => {
+      beforeEach(async () => {
+        await createBid()
+      })
+
+      it('should return it', async () => {
+        expect(await BidModel.getBidsReadyToPublish()).toHaveLength(1)
+      })
+
+      // The round trip is the point: stored encrypted, read back as the object that went in.
+      it('should decrypt the payload back to what was stored', async () => {
+        const [bid] = await BidModel.getBidsReadyToPublish()
+        expect(bid.bid_proposal_data).toEqual(BID_DATA)
+      })
+
+      it('should lowercase the author it stores', async () => {
+        const [bid] = await BidModel.getBidsReadyToPublish()
+        expect(bid.author_address).toBe(AUTHOR.toLowerCase())
+      })
+    })
+
+    describe('when a pending bid is not due yet', () => {
+      beforeEach(async () => {
+        await createBid({ publishAt: IN_THE_FUTURE })
+      })
+
+      it('should leave it alone until its publish time', async () => {
+        expect(await BidModel.getBidsReadyToPublish()).toEqual([])
+      })
+    })
+
+    describe('when a due bid has already been rejected', () => {
+      beforeEach(async () => {
+        await createBid()
+        await BidModel.rejectBidsFromTenders([TENDER])
+      })
+
+      it('should not offer it for publishing', async () => {
+        expect(await BidModel.getBidsReadyToPublish()).toEqual([])
+      })
+    })
+  })
+
+  describe('rejectBidsFromTenders', () => {
+    describe('when bids exist on two tenders', () => {
+      beforeEach(async () => {
+        await createBid({ tender: TENDER })
+        await createBid({ tender: OTHER_TENDER })
+        await BidModel.rejectBidsFromTenders([TENDER])
+      })
+
+      it('should leave the bid on the other tender publishable', async () => {
+        const ready = await BidModel.getBidsReadyToPublish()
+        expect(ready.map((bid) => bid.linked_proposal_id)).toEqual([OTHER_TENDER])
+      })
+    })
+
+    // Rejection rewrites the payload column, so it has to re-encrypt rather than leave plaintext or
+    // corrupt what a later read decrypts.
+    describe('when a rejected bid is read again', () => {
+      beforeEach(async () => {
+        await createBid({ tender: TENDER })
+        await createBid({ tender: OTHER_TENDER })
+        await BidModel.rejectBidsFromTenders([TENDER])
+      })
+
+      it('should still decrypt the untouched bid correctly', async () => {
+        const [bid] = await BidModel.getBidsReadyToPublish()
+        expect(bid.bid_proposal_data).toEqual(BID_DATA)
+      })
+    })
+
+    describe('when no tenders are given', () => {
+      beforeEach(async () => {
+        await createBid()
+      })
+
+      it('should reject nothing', async () => {
+        await BidModel.rejectBidsFromTenders([])
+        expect(await BidModel.getBidsReadyToPublish()).toHaveLength(1)
+      })
+    })
+  })
+
+  describe('removePendingBid', () => {
+    describe('when the author withdraws their own bid', () => {
+      beforeEach(async () => {
+        await createBid({ author: AUTHOR })
+        await BidModel.removePendingBid(AUTHOR, TENDER)
+      })
+
+      it('should remove it', async () => {
+        expect(await BidModel.getBidsReadyToPublish()).toEqual([])
+      })
+    })
+
+    // Scoped to the author, so withdrawing cannot remove a competitor's bid from the same tender.
+    describe('when another author withdraws from the same tender', () => {
+      beforeEach(async () => {
+        await createBid({ author: AUTHOR })
+        await BidModel.removePendingBid(OTHER_AUTHOR, TENDER)
+      })
+
+      it('should leave the first author’s bid in place', async () => {
+        expect(await BidModel.getBidsReadyToPublish()).toHaveLength(1)
+      })
+    })
+
+    describe('when the author’s address differs in case from the stored one', () => {
+      beforeEach(async () => {
+        await createBid({ author: AUTHOR.toLowerCase() })
+        await BidModel.removePendingBid(AUTHOR, TENDER)
+      })
+
+      it('should still remove it, since both sides are lowercased', async () => {
+        expect(await BidModel.getBidsReadyToPublish()).toEqual([])
+      })
+    })
+  })
+
+  describe('getOpenTendersTotal', () => {
+    describe('when several bids sit on the same tender', () => {
+      beforeEach(async () => {
+        await createBid({ tender: TENDER, author: AUTHOR })
+        await createBid({ tender: TENDER, author: OTHER_AUTHOR })
+        await createBid({ tender: OTHER_TENDER, author: AUTHOR })
+      })
+
+      it('should count tenders rather than bids', async () => {
+        expect(Number((await BidModel.getOpenTendersTotal()).total)).toBe(2)
+      })
+    })
+  })
+})

--- a/test/integration/coauthorQueries.test.ts
+++ b/test/integration/coauthorQueries.test.ts
@@ -184,13 +184,28 @@ describe('ProjectModel.getUserProjects', () => {
     })
   })
 
-  // Personnel are on the team without being coauthors, so they see the project too.
+  // Personnel are on the team without being coauthors, so the query reaches a project through them
+  // as well. Asserting only that a stranger is refused would pass with the branch removed.
   describe('when the caller is listed as personnel', () => {
     beforeEach(async () => {
-      await insertPersonnel(projectId, 'A member')
+      await insertPersonnel(projectId, 'A member', { address: STRANGER })
     })
 
-    it('should not return it for an unrelated address', async () => {
+    it('should return the project for them', async () => {
+      expect(await ProjectModel.getUserProjects(STRANGER)).toHaveLength(1)
+    })
+
+    it('should still refuse an address that is on no team', async () => {
+      expect(await ProjectModel.getUserProjects('0x1111111111111111111111111111111111111111')).toEqual([])
+    })
+  })
+
+  describe('when the caller was removed from the team', () => {
+    beforeEach(async () => {
+      await insertPersonnel(projectId, 'A former member', { address: STRANGER, deleted: true })
+    })
+
+    it('should no longer return the project for them', async () => {
       expect(await ProjectModel.getUserProjects(STRANGER)).toEqual([])
     })
   })

--- a/test/integration/coauthorQueries.test.ts
+++ b/test/integration/coauthorQueries.test.ts
@@ -1,0 +1,222 @@
+import { randomUUID } from 'crypto'
+
+import CoauthorModel from '../../src/entities/Coauthor/model'
+import { CoauthorStatus } from '../../src/entities/Coauthor/types'
+import { ProposalStatus, ProposalType } from '../../src/entities/Proposal/types'
+import ProjectModel from '../../src/models/Project'
+import { cleanTables, closeTestDb, initTestDb } from '../setup/db'
+import { insertCoauthor, insertPersonnel, insertProject, insertProposalWith } from '../setup/factories'
+
+const AUTHOR = '0x2ac89522cb415ac333e64f52a1a5693218cebd58'
+const COAUTHOR = '0x56d0b5ed3d525332f00c9bc938f93598ab16aaa7'
+const STRANGER = '0x49e4dbff86a2e5da27c540c9a9e8d2c3726e278f'
+
+describe('CoauthorModel', () => {
+  let proposalId: string
+
+  beforeAll(async () => {
+    await initTestDb()
+  })
+
+  afterAll(async () => {
+    await closeTestDb()
+  })
+
+  afterEach(async () => {
+    await cleanTables()
+  })
+
+  beforeEach(async () => {
+    const proposal = await insertProposalWith({ id: randomUUID(), user: AUTHOR })
+    proposalId = proposal.id
+  })
+
+  describe('createMultiple', () => {
+    describe('when several addresses are invited at once', () => {
+      beforeEach(async () => {
+        await CoauthorModel.createMultiple(proposalId, [COAUTHOR, STRANGER])
+      })
+
+      it('should invite both', async () => {
+        expect(await CoauthorModel.findCoauthors(proposalId)).toHaveLength(2)
+      })
+
+      // Stored lowercased, which is what lets the case-insensitive lookups elsewhere match.
+      it('should store the addresses lowercased', async () => {
+        const found = await CoauthorModel.findCoauthors(proposalId)
+        expect(found.map((c) => c.address).sort()).toEqual([COAUTHOR, STRANGER].sort())
+      })
+
+      it('should leave every invitation pending', async () => {
+        const found = await CoauthorModel.findCoauthors(proposalId)
+        expect(found.every((c) => c.status === CoauthorStatus.PENDING)).toBe(true)
+      })
+    })
+
+    describe('when an address is invited in a different case', () => {
+      beforeEach(async () => {
+        await CoauthorModel.createMultiple(proposalId, [COAUTHOR.toUpperCase().replace('0X', '0x')])
+      })
+
+      it('should still store it lowercased', async () => {
+        const [found] = await CoauthorModel.findCoauthors(proposalId)
+        expect(found.address).toBe(COAUTHOR)
+      })
+    })
+  })
+
+  describe('findCoauthors', () => {
+    beforeEach(async () => {
+      await insertCoauthor(proposalId, COAUTHOR, CoauthorStatus.APPROVED)
+      await insertCoauthor(proposalId, STRANGER, CoauthorStatus.PENDING)
+    })
+
+    describe('when no status is given', () => {
+      it('should return every invitation on the proposal', async () => {
+        expect(await CoauthorModel.findCoauthors(proposalId)).toHaveLength(2)
+      })
+    })
+
+    describe('when a status is given', () => {
+      it('should return only invitations in that status', async () => {
+        const found = await CoauthorModel.findCoauthors(proposalId, CoauthorStatus.APPROVED)
+        expect(found.map((c) => c.address)).toEqual([COAUTHOR])
+      })
+    })
+
+    describe('when the proposal has no invitations', () => {
+      it('should return nothing', async () => {
+        expect(await CoauthorModel.findCoauthors(randomUUID())).toEqual([])
+      })
+    })
+  })
+
+  describe('findProposals', () => {
+    let otherProposalId: string
+
+    beforeEach(async () => {
+      const other = await insertProposalWith({ id: randomUUID(), user: STRANGER })
+      otherProposalId = other.id
+      await insertCoauthor(proposalId, COAUTHOR, CoauthorStatus.APPROVED)
+      await insertCoauthor(otherProposalId, COAUTHOR, CoauthorStatus.PENDING)
+      await insertCoauthor(proposalId, STRANGER, CoauthorStatus.APPROVED)
+    })
+
+    describe('when an address is looked up', () => {
+      it('should return every proposal it was invited to', async () => {
+        expect(await CoauthorModel.findProposals(COAUTHOR)).toHaveLength(2)
+      })
+
+      it('should not return another address’s invitations', async () => {
+        const found = await CoauthorModel.findProposals(COAUTHOR)
+        expect(found.every((c) => c.address === COAUTHOR)).toBe(true)
+      })
+    })
+
+    // The lookup lowers both sides, so a checksummed address still finds its invitations.
+    describe('when the address is looked up in a different case', () => {
+      it('should still find them', async () => {
+        const checksummed = COAUTHOR.toUpperCase().replace('0X', '0x')
+        expect(await CoauthorModel.findProposals(checksummed)).toHaveLength(2)
+      })
+    })
+
+    describe('when a status is given', () => {
+      it('should narrow to that status', async () => {
+        const found = await CoauthorModel.findProposals(COAUTHOR, CoauthorStatus.PENDING)
+        expect(found.map((c) => c.proposal_id)).toEqual([otherProposalId])
+      })
+    })
+  })
+})
+
+describe('ProjectModel.getUserProjects', () => {
+  let projectId: string
+  let proposalId: string
+
+  beforeAll(async () => {
+    await initTestDb()
+  })
+
+  afterAll(async () => {
+    await closeTestDb()
+  })
+
+  afterEach(async () => {
+    await cleanTables()
+  })
+
+  beforeEach(async () => {
+    const proposal = await insertProposalWith({
+      id: randomUUID(),
+      type: ProposalType.Grant,
+      status: ProposalStatus.Enacted,
+      user: AUTHOR,
+    })
+    proposalId = proposal.id
+    projectId = await insertProject(proposalId)
+  })
+
+  describe('when the caller authored the proposal', () => {
+    it('should return their project', async () => {
+      const projects = await ProjectModel.getUserProjects(AUTHOR)
+      expect(projects.map((p) => p.id)).toEqual([projectId])
+    })
+  })
+
+  describe('when the caller is an accepted coauthor', () => {
+    beforeEach(async () => {
+      await insertCoauthor(proposalId, COAUTHOR, CoauthorStatus.APPROVED)
+    })
+
+    it('should return the project', async () => {
+      expect(await ProjectModel.getUserProjects(COAUTHOR)).toHaveLength(1)
+    })
+  })
+
+  describe('when the caller was invited but has not accepted', () => {
+    beforeEach(async () => {
+      await insertCoauthor(proposalId, COAUTHOR, CoauthorStatus.PENDING)
+    })
+
+    it('should not return the project yet', async () => {
+      expect(await ProjectModel.getUserProjects(COAUTHOR)).toEqual([])
+    })
+  })
+
+  // Personnel are on the team without being coauthors, so they see the project too.
+  describe('when the caller is listed as personnel', () => {
+    beforeEach(async () => {
+      await insertPersonnel(projectId, 'A member')
+    })
+
+    it('should not return it for an unrelated address', async () => {
+      expect(await ProjectModel.getUserProjects(STRANGER)).toEqual([])
+    })
+  })
+
+  describe('when the caller has no relationship to the project', () => {
+    it('should return nothing', async () => {
+      expect(await ProjectModel.getUserProjects(STRANGER)).toEqual([])
+    })
+  })
+
+  // Unlike isAuthorOrCoauthor before it was fixed, this query lowers both sides.
+  describe('when the caller’s address differs in case', () => {
+    it('should still return their project', async () => {
+      const checksummed = AUTHOR.toUpperCase().replace('0X', '0x')
+      expect(await ProjectModel.getUserProjects(checksummed)).toHaveLength(1)
+    })
+  })
+
+  describe('when the proposal behind the project is not a grant', () => {
+    beforeEach(async () => {
+      const poll = await insertProposalWith({ id: randomUUID(), type: ProposalType.Poll, user: AUTHOR })
+      await insertProject(poll.id)
+    })
+
+    it('should return only the grant project', async () => {
+      expect(await ProjectModel.getUserProjects(AUTHOR)).toHaveLength(1)
+    })
+  })
+})

--- a/test/integration/delegationReplayGuard.test.ts
+++ b/test/integration/delegationReplayGuard.test.ts
@@ -1,0 +1,90 @@
+import EventModel from '../../src/models/Event'
+import { EventsService } from '../../src/services/events'
+import { EventType } from '../../src/shared/types/events'
+import { cleanTables, closeTestDb, initTestDb } from '../setup/db'
+
+const DELEGATE = '0x2ac89522cb415ac333e64f52a1a5693218cebd58'
+const DELEGATOR = '0x56d0b5ed3d525332f00c9bc938f93598ab16aaa7'
+const TX_HASH = '0x00000000000000000000000000000000000000000000000000000000000000aa'
+const OTHER_TX_HASH = '0x00000000000000000000000000000000000000000000000000000000000000bb'
+
+jest.mock('../../src/services/notification', () => ({ NotificationService: {} }))
+
+/**
+ * This is what stops the delegation webhook recording the same block twice, and it matters because
+ * the webhook deliberately returns a non-2xx on failure so Alchemy retries. The guard reads a JSONB
+ * path out of the stored event, so the only way to know it matches what the writer puts there is to
+ * write a real row and ask.
+ */
+describe('EventModel.isDelegationTxRegistered', () => {
+  beforeAll(async () => {
+    await initTestDb()
+  })
+
+  afterAll(async () => {
+    await closeTestDb()
+  })
+
+  afterEach(async () => {
+    await cleanTables()
+  })
+
+  describe('when no delegation has been recorded', () => {
+    it('should report the transaction as unseen', async () => {
+      expect(await EventModel.isDelegationTxRegistered(TX_HASH)).toBe(false)
+    })
+  })
+
+  describe('when a delegation set was recorded by the service that writes it', () => {
+    beforeEach(async () => {
+      await EventsService.delegationSet(DELEGATE, DELEGATOR, TX_HASH, new Date())
+    })
+
+    it('should recognise that transaction', async () => {
+      expect(await EventModel.isDelegationTxRegistered(TX_HASH)).toBe(true)
+    })
+
+    it('should not confuse it with a different transaction', async () => {
+      expect(await EventModel.isDelegationTxRegistered(OTHER_TX_HASH)).toBe(false)
+    })
+  })
+
+  describe('when a delegation clear was recorded', () => {
+    beforeEach(async () => {
+      await EventsService.delegationClear(DELEGATE, DELEGATOR, TX_HASH, new Date())
+    })
+
+    it('should recognise that transaction too', async () => {
+      expect(await EventModel.isDelegationTxRegistered(TX_HASH)).toBe(true)
+    })
+  })
+
+  // The guard filters on the delegation event types, so an unrelated event carrying the same hash
+  // must not make a genuine delegation look already handled.
+  describe('when an unrelated event carries the same transaction hash', () => {
+    beforeEach(async () => {
+      await EventModel.create({
+        id: '00000000-0000-0000-0000-0000000000ff',
+        address: DELEGATOR,
+        event_type: EventType.ProposalCreated,
+        event_data: { transaction_hash: TX_HASH, proposal_id: 'a-proposal', proposal_title: 'A proposal' },
+        created_at: new Date(),
+      } as never)
+    })
+
+    it('should still report the delegation as unseen', async () => {
+      expect(await EventModel.isDelegationTxRegistered(TX_HASH)).toBe(false)
+    })
+  })
+
+  describe('when the same transaction is recorded twice', () => {
+    beforeEach(async () => {
+      await EventsService.delegationSet(DELEGATE, DELEGATOR, TX_HASH, new Date())
+      await EventsService.delegationSet(DELEGATE, DELEGATOR, TX_HASH, new Date())
+    })
+
+    it('should still report it as seen rather than miscounting', async () => {
+      expect(await EventModel.isDelegationTxRegistered(TX_HASH)).toBe(true)
+    })
+  })
+})

--- a/test/integration/projectAuthorization.test.ts
+++ b/test/integration/projectAuthorization.test.ts
@@ -1,0 +1,137 @@
+import { randomUUID } from 'crypto'
+
+import { CoauthorStatus } from '../../src/entities/Coauthor/types'
+import { ProposalStatus, ProposalType } from '../../src/entities/Proposal/types'
+import ProjectModel from '../../src/models/Project'
+import { cleanTables, closeTestDb, initTestDb } from '../setup/db'
+import { insertCoauthor, insertProject, insertProposalWith } from '../setup/factories'
+
+const AUTHOR = '0x2ac89522cb415ac333e64f52a1a5693218cebd58'
+const COAUTHOR = '0x56d0b5ed3d525332f00c9bc938f93598ab16aaa7'
+const STRANGER = '0x49e4dbff86a2e5da27c540c9a9e8d2c3726e278f'
+
+// Every write route on a project funnels through this, so what it answers decides who may add or
+// remove personnel, links and milestones. It is a single sql statement, so only a database can say
+// what it really returns.
+describe('ProjectModel.isAuthorOrCoauthor', () => {
+  let projectId: string
+  let proposalId: string
+
+  beforeAll(async () => {
+    await initTestDb()
+  })
+
+  afterAll(async () => {
+    await closeTestDb()
+  })
+
+  afterEach(async () => {
+    await cleanTables()
+  })
+
+  beforeEach(async () => {
+    const proposal = await insertProposalWith({
+      id: randomUUID(),
+      type: ProposalType.Grant,
+      status: ProposalStatus.Enacted,
+      user: AUTHOR,
+    })
+    proposalId = proposal.id
+    projectId = await insertProject(proposalId)
+  })
+
+  describe('when the caller authored the proposal behind the project', () => {
+    it('should allow them', async () => {
+      expect(await ProjectModel.isAuthorOrCoauthor(AUTHOR, projectId)).toBe(true)
+    })
+  })
+
+  describe('when the caller is an accepted coauthor', () => {
+    beforeEach(async () => {
+      await insertCoauthor(proposalId, COAUTHOR, CoauthorStatus.APPROVED)
+    })
+
+    it('should allow them', async () => {
+      expect(await ProjectModel.isAuthorOrCoauthor(COAUTHOR, projectId)).toBe(true)
+    })
+  })
+
+  // An invitation that has not been accepted confers nothing yet.
+  describe('when the caller was invited but has not accepted', () => {
+    beforeEach(async () => {
+      await insertCoauthor(proposalId, COAUTHOR, CoauthorStatus.PENDING)
+    })
+
+    it('should refuse them', async () => {
+      expect(await ProjectModel.isAuthorOrCoauthor(COAUTHOR, projectId)).toBe(false)
+    })
+  })
+
+  describe('when the caller declined the invitation', () => {
+    beforeEach(async () => {
+      await insertCoauthor(proposalId, COAUTHOR, CoauthorStatus.REJECTED)
+    })
+
+    it('should refuse them', async () => {
+      expect(await ProjectModel.isAuthorOrCoauthor(COAUTHOR, projectId)).toBe(false)
+    })
+  })
+
+  describe('when the caller has no relationship to the project', () => {
+    it('should refuse them', async () => {
+      expect(await ProjectModel.isAuthorOrCoauthor(STRANGER, projectId)).toBe(false)
+    })
+  })
+
+  // The join is anchored on the project id, so a coauthor of a different proposal must not carry
+  // over to this one.
+  describe('when the caller is an accepted coauthor of a different project', () => {
+    beforeEach(async () => {
+      const otherProposal = await insertProposalWith({ id: randomUUID(), user: STRANGER })
+      await insertProject(otherProposal.id)
+      await insertCoauthor(otherProposal.id, COAUTHOR, CoauthorStatus.APPROVED)
+    })
+
+    it('should refuse them on this project', async () => {
+      expect(await ProjectModel.isAuthorOrCoauthor(COAUTHOR, projectId)).toBe(false)
+    })
+  })
+
+  describe('when the project does not exist', () => {
+    it('should refuse rather than allow an unknown project', async () => {
+      expect(await ProjectModel.isAuthorOrCoauthor(AUTHOR, randomUUID())).toBe(false)
+    })
+  })
+
+  describe('when the project id is not a uuid', () => {
+    it('should refuse before querying', async () => {
+      await expect(ProjectModel.isAuthorOrCoauthor(AUTHOR, 'not-a-uuid')).rejects.toThrow('Invalid project id')
+    })
+  })
+
+  describe('when the caller is not an address', () => {
+    it('should refuse before querying', async () => {
+      await expect(ProjectModel.isAuthorOrCoauthor('not-an-address', projectId)).rejects.toThrow('Invalid user')
+    })
+  })
+
+  // The comparison is exact, unlike the coauthor filters elsewhere which lower() both sides. These
+  // record what the statement actually does for an address that differs only in case.
+  describe('when the caller’s address differs in case from the stored author', () => {
+    it('should report what the exact comparison yields', async () => {
+      const checksummed = '0x2AC89522CB415AC333E64F52a1a5693218cEBD58'
+      expect(await ProjectModel.isAuthorOrCoauthor(checksummed, projectId)).toBe(false)
+    })
+  })
+
+  describe('when the caller’s address differs in case from the stored coauthor', () => {
+    beforeEach(async () => {
+      await insertCoauthor(proposalId, COAUTHOR, CoauthorStatus.APPROVED)
+    })
+
+    it('should report what the exact comparison yields', async () => {
+      const checksummed = '0x56d0B5eD3D525332F00C9BC938f93598ab16AAA7'
+      expect(await ProjectModel.isAuthorOrCoauthor(checksummed, projectId)).toBe(false)
+    })
+  })
+})

--- a/test/integration/projectQueries.test.ts
+++ b/test/integration/projectQueries.test.ts
@@ -49,7 +49,7 @@ describe('ProjectModel.getProject', () => {
       })
       projectId = await insertProject(proposal.id)
       livePersonnel = await insertPersonnel(projectId, 'Live member')
-      deletedPersonnel = await insertPersonnel(projectId, 'Removed member', true)
+      deletedPersonnel = await insertPersonnel(projectId, 'Removed member', { deleted: true })
       milestoneId = await insertMilestone(projectId, 'First milestone')
       linkId = await insertProjectLink(projectId, 'Repository')
       await insertCoauthor(proposal.id, APPROVED_COAUTHOR, CoauthorStatus.APPROVED)

--- a/test/integration/supportingQueries.test.ts
+++ b/test/integration/supportingQueries.test.ts
@@ -1,0 +1,217 @@
+import { randomUUID } from 'crypto'
+
+import { ProposalStatus } from '../../src/entities/Proposal/types'
+import { FinancialRecordCateogry, UpdateStatus } from '../../src/entities/Updates/types'
+import VotesModel from '../../src/entities/Votes/model'
+import AirdropJobModel from '../../src/models/AirdropJob'
+import FinancialModel from '../../src/models/Financial'
+import { AirdropJobStatus } from '../../src/types/AirdropJob'
+import { cleanTables, closeTestDb, initTestDb } from '../setup/db'
+import { insertProject, insertProposalWith, insertUpdate } from '../setup/factories'
+
+const RECIPIENT = '0x2ac89522cb415ac333e64f52a1a5693218cebd58'
+
+describe('VotesModel', () => {
+  let proposalId: string
+  let otherProposalId: string
+
+  beforeAll(async () => {
+    await initTestDb()
+  })
+
+  afterAll(async () => {
+    await closeTestDb()
+  })
+
+  afterEach(async () => {
+    await cleanTables()
+  })
+
+  beforeEach(async () => {
+    proposalId = (await insertProposalWith({ id: randomUUID() })).id
+    otherProposalId = (await insertProposalWith({ id: randomUUID() })).id
+  })
+
+  describe('createEmpty', () => {
+    describe('when a proposal gets its vote row', () => {
+      beforeEach(async () => {
+        await VotesModel.createEmpty(proposalId)
+      })
+
+      it('should be readable back', async () => {
+        expect(await VotesModel.getVotes(proposalId)).not.toBeNull()
+      })
+
+      it('should start with no votes recorded', async () => {
+        const stored = await VotesModel.getVotes(proposalId)
+        expect(stored?.votes).toEqual({})
+      })
+    })
+  })
+
+  describe('getVotes', () => {
+    describe('when the proposal has no vote row', () => {
+      it('should return nothing rather than an empty row', async () => {
+        expect(await VotesModel.getVotes(randomUUID())).toBeNull()
+      })
+    })
+  })
+
+  describe('findAny', () => {
+    beforeEach(async () => {
+      await VotesModel.createEmpty(proposalId)
+      await VotesModel.createEmpty(otherProposalId)
+    })
+
+    describe('when several proposals are asked about', () => {
+      it('should return a row for each', async () => {
+        expect(await VotesModel.findAny([proposalId, otherProposalId])).toHaveLength(2)
+      })
+    })
+
+    describe('when one of the ids has no row', () => {
+      it('should return only the ones that do', async () => {
+        const found = await VotesModel.findAny([proposalId, randomUUID()])
+        expect(found.map((v) => v.proposal_id)).toEqual([proposalId])
+      })
+    })
+
+    describe('when no ids are given', () => {
+      it('should return nothing without querying', async () => {
+        expect(await VotesModel.findAny([])).toEqual([])
+      })
+    })
+  })
+})
+
+describe('FinancialModel', () => {
+  let updateId: string
+
+  beforeAll(async () => {
+    await initTestDb()
+  })
+
+  afterAll(async () => {
+    await closeTestDb()
+  })
+
+  afterEach(async () => {
+    await cleanTables()
+  })
+
+  beforeEach(async () => {
+    const proposal = await insertProposalWith({ id: randomUUID(), status: ProposalStatus.Enacted })
+    const projectId = await insertProject(proposal.id)
+    const update = await insertUpdate(proposal.id, projectId, UpdateStatus.Done)
+    updateId = update.id
+    // Written through the real insert: the id column is a serial, not a uuid, and the token is
+    // uppercased on the way in.
+    await FinancialModel.createRecords(updateId, [
+      {
+        category: FinancialRecordCateogry.Other,
+        description: 'A cost',
+        amount: 1234.56,
+        token: 'mana',
+        receiver: RECIPIENT,
+        link: 'https://example.com',
+      },
+    ] as never)
+  })
+
+  describe('getRecords', () => {
+    describe('when the update has records', () => {
+      it('should return them', async () => {
+        expect(await FinancialModel.getRecords(updateId)).toHaveLength(1)
+      })
+
+      // The column is numeric, which the driver hands back as a string, so the read parses it.
+      it('should return the amount as a number rather than a string', async () => {
+        const [record] = await FinancialModel.getRecords(updateId)
+        expect(record.amount).toBe(1234.56)
+      })
+
+      it('should uppercase the token the insert stored', async () => {
+        const [record] = await FinancialModel.getRecords(updateId)
+        expect(record.token).toBe('MANA')
+      })
+    })
+
+    describe('when the update has no records', () => {
+      it('should return nothing', async () => {
+        expect(await FinancialModel.getRecords(randomUUID())).toEqual([])
+      })
+    })
+  })
+
+  describe('getAllRecords', () => {
+    describe('when the page size is beyond what is allowed', () => {
+      it('should refuse rather than read the table', async () => {
+        await expect(FinancialModel.getAllRecords(0, 101)).rejects.toThrow('page_size')
+      })
+    })
+
+    describe('when the paging arguments are negative', () => {
+      it('should refuse', async () => {
+        await expect(FinancialModel.getAllRecords(-1, 10)).rejects.toThrow('Invalid page_number')
+      })
+    })
+
+    describe('when the paging arguments are valid', () => {
+      it('should return the stored record', async () => {
+        expect(await FinancialModel.getAllRecords(0, 10)).toHaveLength(1)
+      })
+    })
+  })
+})
+
+describe('AirdropJobModel', () => {
+  beforeAll(async () => {
+    await initTestDb()
+  })
+
+  afterAll(async () => {
+    await closeTestDb()
+  })
+
+  afterEach(async () => {
+    await cleanTables()
+  })
+
+  beforeEach(async () => {
+    await AirdropJobModel.create({
+      id: randomUUID(),
+      badge_spec: 'a-badge-spec',
+      recipients: [RECIPIENT],
+      status: AirdropJobStatus.PENDING,
+      created_at: new Date(),
+      updated_at: new Date(),
+    })
+    await AirdropJobModel.create({
+      id: randomUUID(),
+      badge_spec: 'another-badge-spec',
+      recipients: [RECIPIENT],
+      status: AirdropJobStatus.FINISHED,
+      created_at: new Date(),
+      updated_at: new Date(),
+    })
+  })
+
+  describe('getPending', () => {
+    // The runner acts on what this returns, so a finished job coming back would be re-run.
+    it('should return only the jobs still to run', async () => {
+      const pending = await AirdropJobModel.getPending()
+      expect(pending.map((job) => job.badge_spec)).toEqual(['a-badge-spec'])
+    })
+
+    it('should keep the recipient list intact', async () => {
+      const [job] = await AirdropJobModel.getPending()
+      expect(job.recipients).toEqual([RECIPIENT])
+    })
+  })
+
+  describe('getAll', () => {
+    it('should return the finished jobs as well', async () => {
+      expect(await AirdropJobModel.getAll()).toHaveLength(2)
+    })
+  })
+})

--- a/test/integration/userAccounts.test.ts
+++ b/test/integration/userAccounts.test.ts
@@ -1,0 +1,174 @@
+import UserModel from '../../src/entities/User/model'
+import { AccountType } from '../../src/entities/User/types'
+import { cleanTables, closeTestDb, initTestDb } from '../setup/db'
+
+const ADDRESS = '0x2AC89522CB415AC333E64F52a1a5693218cEBD58'
+const OTHER_ADDRESS = '0x56d0b5ed3d525332f00c9bc938f93598ab16aaa7'
+const FORUM_ID = '1234'
+const DISCORD_ID = 'discord-user-1'
+
+/**
+ * These decide whether a wallet counts as having a linked forum or discord account, which gates
+ * what the ui offers and what notifications are sent. isValidated in particular compares a Postgres
+ * COUNT against a string, which only holds because the driver returns bigint as one.
+ */
+describe('the user account queries', () => {
+  beforeAll(async () => {
+    await initTestDb()
+  })
+
+  afterAll(async () => {
+    await closeTestDb()
+  })
+
+  afterEach(async () => {
+    await cleanTables()
+  })
+
+  describe('isValidated', () => {
+    describe('when the wallet has no stored user at all', () => {
+      it('should report it as not validated', async () => {
+        expect(await UserModel.isValidated(ADDRESS, new Set([AccountType.Forum]))).toBe(false)
+      })
+    })
+
+    describe('when the wallet has a linked forum account', () => {
+      beforeEach(async () => {
+        await UserModel.createForumConnection(ADDRESS, FORUM_ID)
+      })
+
+      it('should report the forum account as validated', async () => {
+        expect(await UserModel.isValidated(ADDRESS, new Set([AccountType.Forum]))).toBe(true)
+      })
+
+      it('should not report discord as validated', async () => {
+        expect(await UserModel.isValidated(ADDRESS, new Set([AccountType.Discord]))).toBe(false)
+      })
+
+      // Asking about both requires both, so a partially linked wallet does not pass.
+      it('should refuse when both accounts are required', async () => {
+        expect(await UserModel.isValidated(ADDRESS, new Set([AccountType.Forum, AccountType.Discord]))).toBe(false)
+      })
+    })
+
+    describe('when the wallet has both accounts linked', () => {
+      beforeEach(async () => {
+        await UserModel.createForumConnection(ADDRESS, FORUM_ID)
+        await UserModel.createDiscordConnection(ADDRESS, DISCORD_ID)
+      })
+
+      it('should report both as validated', async () => {
+        expect(await UserModel.isValidated(ADDRESS, new Set([AccountType.Forum, AccountType.Discord]))).toBe(true)
+      })
+    })
+
+    describe('when the wallet is asked about in a different case', () => {
+      beforeEach(async () => {
+        await UserModel.createForumConnection(ADDRESS, FORUM_ID)
+      })
+
+      it('should still recognise it, since the address is lowercased on both sides', async () => {
+        expect(await UserModel.isValidated(ADDRESS.toLowerCase(), new Set([AccountType.Forum]))).toBe(true)
+      })
+    })
+
+    describe('when no accounts are asked about', () => {
+      it('should refuse rather than answer for nothing', async () => {
+        await expect(UserModel.isValidated(ADDRESS, new Set())).rejects.toThrow('No accounts provided')
+      })
+    })
+  })
+
+  describe('createForumConnection', () => {
+    describe('when the wallet links a forum account twice', () => {
+      beforeEach(async () => {
+        await UserModel.createForumConnection(ADDRESS, FORUM_ID)
+        await UserModel.createForumConnection(ADDRESS, '5678')
+      })
+
+      it('should replace the link rather than fail on the existing row', async () => {
+        const [found] = await UserModel.getAddressesByForumId(['5678'])
+        expect(found?.address).toBe(ADDRESS.toLowerCase())
+      })
+
+      it('should no longer resolve the previous forum id', async () => {
+        expect(await UserModel.getAddressesByForumId([FORUM_ID])).toEqual([])
+      })
+    })
+
+    // A forum account belongs to one wallet, enforced by a unique constraint rather than by code.
+    describe('when a second wallet claims the same forum account', () => {
+      let outcome: unknown
+
+      beforeEach(async () => {
+        await UserModel.createForumConnection(ADDRESS, FORUM_ID)
+        outcome = await UserModel.createForumConnection(OTHER_ADDRESS, FORUM_ID).catch((error) => error)
+      })
+
+      it('should refuse the second claim', () => {
+        expect(outcome).toBeInstanceOf(Error)
+      })
+
+      it('should leave the first wallet holding it', async () => {
+        const [found] = await UserModel.getAddressesByForumId([FORUM_ID])
+        expect(found?.address).toBe(ADDRESS.toLowerCase())
+      })
+    })
+  })
+
+  describe('unlinkAccount', () => {
+    beforeEach(async () => {
+      await UserModel.createForumConnection(ADDRESS, FORUM_ID)
+      await UserModel.createDiscordConnection(ADDRESS, DISCORD_ID)
+    })
+
+    describe('when the forum account is unlinked', () => {
+      beforeEach(async () => {
+        await UserModel.unlinkAccount(ADDRESS, AccountType.Forum)
+      })
+
+      it('should no longer report it as validated', async () => {
+        expect(await UserModel.isValidated(ADDRESS, new Set([AccountType.Forum]))).toBe(false)
+      })
+
+      it('should leave the discord account linked', async () => {
+        expect(await UserModel.isValidated(ADDRESS, new Set([AccountType.Discord]))).toBe(true)
+      })
+
+      // Clearing the id has to free it, otherwise the unique constraint locks the account forever.
+      it('should free the forum id for another wallet to claim', async () => {
+        await UserModel.createForumConnection(OTHER_ADDRESS, FORUM_ID)
+        const [found] = await UserModel.getAddressesByForumId([FORUM_ID])
+        expect(found?.address).toBe(OTHER_ADDRESS)
+      })
+    })
+
+    describe('when the discord account is unlinked', () => {
+      beforeEach(async () => {
+        await UserModel.unlinkAccount(ADDRESS, AccountType.Discord)
+      })
+
+      it('should no longer report it as validated', async () => {
+        expect(await UserModel.isValidated(ADDRESS, new Set([AccountType.Discord]))).toBe(false)
+      })
+
+      it('should leave the forum account linked', async () => {
+        expect(await UserModel.isValidated(ADDRESS, new Set([AccountType.Forum]))).toBe(true)
+      })
+    })
+  })
+
+  describe('getAddressesByForumId', () => {
+    describe('when no ids are given', () => {
+      it('should return nothing without querying', async () => {
+        expect(await UserModel.getAddressesByForumId([])).toEqual([])
+      })
+    })
+
+    describe('when an id belongs to no wallet', () => {
+      it('should return nothing', async () => {
+        expect(await UserModel.getAddressesByForumId(['9999'])).toEqual([])
+      })
+    })
+  })
+})

--- a/test/setup/closeTestApps.ts
+++ b/test/setup/closeTestApps.ts
@@ -1,0 +1,7 @@
+import { closeTestApps } from '../../src/routes/testApp'
+
+// Route suites bind a listener per router; this shuts them down when the file finishes so a long
+// run does not hold one open per suite. A no-op for files that never build one.
+afterAll(async () => {
+  await closeTestApps()
+})

--- a/test/setup/db.ts
+++ b/test/setup/db.ts
@@ -2,6 +2,9 @@ import database from 'decentraland-gatsby/dist/entities/Database/database'
 
 // Dependents first; TRUNCATE ... CASCADE handles the FKs regardless, but this keeps intent clear.
 const TABLES_TO_CLEAN = [
+  'airdrop_jobs',
+  'financial_records',
+  'scores',
   'events',
   'users',
   'unpublished_bids',

--- a/test/setup/db.ts
+++ b/test/setup/db.ts
@@ -2,6 +2,9 @@ import database from 'decentraland-gatsby/dist/entities/Database/database'
 
 // Dependents first; TRUNCATE ... CASCADE handles the FKs regardless, but this keeps intent clear.
 const TABLES_TO_CLEAN = [
+  'events',
+  'users',
+  'unpublished_bids',
   'coauthors',
   'proposal_subscriptions',
   'project_updates',

--- a/test/setup/factories.ts
+++ b/test/setup/factories.ts
@@ -85,13 +85,18 @@ export async function insertUpdate(
   return update
 }
 
-export async function insertPersonnel(projectId: string, name: string, deleted = false): Promise<string> {
+export async function insertPersonnel(
+  projectId: string,
+  name: string,
+  options: { deleted?: boolean; address?: string | null } = {}
+): Promise<string> {
+  const { deleted = false, address = null } = options
   const id = randomUUID()
   await PersonnelModel.create({
     id,
     project_id: projectId,
     name,
-    address: null,
+    address,
     role: 'Engineer',
     about: 'About the team member',
     deleted,


### PR DESCRIPTION
continues the coverage work from #1944, starting with the routes that carry
ownership checks. split along where the behaviour lives: anything the database
decides is covered against a real postgres, everything else is a unit test.

## the ownership query — integration
`ProjectModel.isAuthorOrCoauthor` is what every project write depends on, and it
is a single sql statement, so only a database can say what it returns. covered:
the author is allowed, an accepted coauthor is allowed, an invitation that is
still pending or was declined is not, a stranger is not, and an accepted coauthor
of a different project does not carry over. an unknown project is refused rather
than allowed, and a non-uuid project or non-address caller is refused before the
query runs.

## the routes — unit
what the routes add is the guard and the shape checks, so they run without a
database. every add and delete is covered for the unauthenticated caller, one who
may not edit, and the owner. the deletes read the owning project from the stored
row rather than the request, so a missing row is a 404 before ownership is
consulted and a non-uuid id never reaches the lookup. the editable-status half of
the guard is covered as well: a finished or revoked project refuses edits from
its own author.

removing either half of `validateCanEditProject` fails these — the status rule
three cases, the ownership check five.

## a finding, not fixed here
`ProjectModel.isAuthorOrCoauthor` compares addresses exactly:

```sql
AND (p.user = ${user} OR co.address = ${user})
```

while `getUserProjects` in the same file normalises both sides with `lower()`,
coauthor rows are always written lowercased, and `routes/coauthor.ts` lowercases
`req.auth` before matching — so that value is not reliably lowercase. a caller
whose authenticated address arrives checksummed would therefore be refused edit
access to a project they genuinely coauthor.

it fails closed, so it denies rather than grants, which is why this is a
follow-up rather than a fix here. two tests record the current behaviour and are
labelled as recording it; flipping them is a one-line change once the intended
semantics are confirmed.

## testing
752 unit and 169 integration, all passing. every case was checked by reverting
the behaviour it guards and confirming the test fails.