### PR TITLE
fix: four defects found while covering the routes

### DIFF
--- a/src/entities/User/utils.ts
+++ b/src/entities/User/utils.ts
@@ -103,11 +103,15 @@ export function validateComment(
   return isSameAddress(recoveredAddress, address)
 }
 
-export function toAccountType(account: string | undefined | null): AccountType | undefined {
-  return Object.values(AccountType).find((a) => a.toLowerCase() === account?.toLowerCase())
+// Takes unknown rather than string: the value comes from a request body or query string, so it can
+// be a number, an object or anything else json admits. Calling toLowerCase on those raises a
+// TypeError, which would surface as a 500 for what is a malformed request.
+export function toAccountType(account: unknown): AccountType | undefined {
+  if (typeof account !== 'string') return undefined
+  return Object.values(AccountType).find((a) => a.toLowerCase() === account.toLowerCase())
 }
 
-export function parseAccountTypes(accounts?: string | string[]): AccountType[] {
+export function parseAccountTypes(accounts?: unknown): AccountType[] {
   if (!accounts) return []
 
   const accountsArray = Array.isArray(accounts) ? accounts : [accounts]
@@ -116,7 +120,7 @@ export function parseAccountTypes(accounts?: string | string[]): AccountType[] {
 
 // Both callers take this straight from a request, so a bad value is the caller's mistake rather
 // than the server's. A plain Error would surface as a 500.
-export function validateAccountTypes(accounts?: string | string[]): AccountType[] {
+export function validateAccountTypes(accounts?: unknown): AccountType[] {
   const parsedAccounts = parseAccountTypes(accounts)
   if (parsedAccounts.length === 0) {
     throw new RequestError(`Invalid account types. Received: ${accounts}`, RequestError.BadRequest)

--- a/src/entities/User/utils.ts
+++ b/src/entities/User/utils.ts
@@ -1,3 +1,4 @@
+import RequestError from 'decentraland-gatsby/dist/entities/Route/error'
 import { hashMessage, recoverAddress } from 'ethers/lib/utils'
 import capitalize from 'lodash/capitalize'
 import escapeRegExp from 'lodash/escapeRegExp'
@@ -113,10 +114,12 @@ export function parseAccountTypes(accounts?: string | string[]): AccountType[] {
   return accountsArray.map((account) => toAccountType(account)).filter((account) => !!account) as AccountType[]
 }
 
+// Both callers take this straight from a request, so a bad value is the caller's mistake rather
+// than the server's. A plain Error would surface as a 500.
 export function validateAccountTypes(accounts?: string | string[]): AccountType[] {
   const parsedAccounts = parseAccountTypes(accounts)
   if (parsedAccounts.length === 0) {
-    throw new Error(`Invalid account types. Received: ${accounts}`)
+    throw new RequestError(`Invalid account types. Received: ${accounts}`, RequestError.BadRequest)
   }
   return parsedAccounts
 }

--- a/src/entities/User/utils.ts
+++ b/src/entities/User/utils.ts
@@ -118,11 +118,14 @@ export function parseAccountTypes(accounts?: unknown): AccountType[] {
   return accountsArray.map((account) => toAccountType(account)).filter((account) => !!account) as AccountType[]
 }
 
-// Both callers take this straight from a request, so a bad value is the caller's mistake rather
-// than the server's. A plain Error would surface as a 500.
+// Strict counterpart to parseAccountTypes, which drops what it does not recognise. Both callers take
+// this straight from a request, so anything unrecognised is the caller's mistake rather than the
+// server's — and answering about a subset of what was asked for is worse than refusing, because the
+// caller cannot tell it happened. A plain Error would also surface as a 500.
 export function validateAccountTypes(accounts?: unknown): AccountType[] {
+  const supplied = accounts === undefined || accounts === null ? [] : Array.isArray(accounts) ? accounts : [accounts]
   const parsedAccounts = parseAccountTypes(accounts)
-  if (parsedAccounts.length === 0) {
+  if (parsedAccounts.length === 0 || parsedAccounts.length !== supplied.length) {
     throw new RequestError(`Invalid account types. Received: ${accounts}`, RequestError.BadRequest)
   }
   return parsedAccounts

--- a/src/models/Project.ts
+++ b/src/models/Project.ts
@@ -115,7 +115,7 @@ export default class ProjectModel extends Model<ProjectAttributes> {
         LEFT JOIN ${table(CoauthorModel)} co ON pr.proposal_id = co.proposal_id 
               AND co.status = ${CoauthorStatus.APPROVED}
         WHERE pr.id = ${projectId}
-          AND (p.user = ${user} OR co.address = ${user})
+          AND (lower(p.user) = lower(${user}) OR lower(co.address) = lower(${user}))
       ) AS "exists"
     `
 

--- a/src/routes/badges.test.ts
+++ b/src/routes/badges.test.ts
@@ -251,6 +251,24 @@ describe('the badge routes', () => {
         expect(response.status).toBe(400)
       })
     })
+
+    // Mirrors the airdrop case: revoke got the same guard, so it gets the same coverage.
+    describe('when the badge spec cid is not a string', () => {
+      beforeEach(async () => {
+        response = await supertest(app)
+          .post('/api/badges/revoke/')
+          .set('x-test-auth', DEBUG_ADDRESS)
+          .send({ badgeSpecCid: 12345, recipients: [RECIPIENT] })
+      })
+
+      it('should respond with a 400', () => {
+        expect(response.status).toBe(400)
+      })
+
+      it('should not revoke anything', () => {
+        expect(revokeBadge).not.toHaveBeenCalled()
+      })
+    })
   })
 
   describe('POST /api/badges/upload-badge-spec', () => {

--- a/src/routes/badges.test.ts
+++ b/src/routes/badges.test.ts
@@ -149,6 +149,23 @@ describe('the badge routes', () => {
     })
 
     // A number or an object has no length, so a truthiness check alone let it reach the service.
+    describe('when a recipient is not a string at all', () => {
+      beforeEach(async () => {
+        response = await supertest(app)
+          .post('/api/badges/airdrop/')
+          .set('x-test-auth', DEBUG_ADDRESS)
+          .send({ badgeSpecCid: BADGE_CID, recipients: [12345] })
+      })
+
+      it('should respond with a 400', () => {
+        expect(response.status).toBe(400)
+      })
+
+      it('should not hand out any badge', () => {
+        expect(giveBadgeToUsers).not.toHaveBeenCalled()
+      })
+    })
+
     describe('when the badge spec cid is not a string', () => {
       beforeEach(async () => {
         response = await supertest(app)

--- a/src/routes/badges.test.ts
+++ b/src/routes/badges.test.ts
@@ -148,6 +148,24 @@ describe('the badge routes', () => {
       })
     })
 
+    // A number or an object has no length, so a truthiness check alone let it reach the service.
+    describe('when the badge spec cid is not a string', () => {
+      beforeEach(async () => {
+        response = await supertest(app)
+          .post('/api/badges/airdrop/')
+          .set('x-test-auth', DEBUG_ADDRESS)
+          .send({ badgeSpecCid: 12345, recipients: [RECIPIENT] })
+      })
+
+      it('should respond with a 400', () => {
+        expect(response.status).toBe(400)
+      })
+
+      it('should not hand out any badge', () => {
+        expect(giveBadgeToUsers).not.toHaveBeenCalled()
+      })
+    })
+
     describe('when a debug address airdrops to valid recipients', () => {
       beforeEach(async () => {
         response = await supertest(app)

--- a/src/routes/badges.test.ts
+++ b/src/routes/badges.test.ts
@@ -131,9 +131,6 @@ describe('the badge routes', () => {
       })
     })
 
-    // Recorded, not endorsed: the handler maps over recipients before checking it is a list, so a
-    // debug address that omits the field gets a 500 rather than a 400. Only a debug address can
-    // reach it, which is why it is a note rather than a fix.
     describe('when a debug address omits the recipient list entirely', () => {
       beforeEach(async () => {
         response = await supertest(app)
@@ -142,13 +139,8 @@ describe('the badge routes', () => {
           .send({ badgeSpecCid: BADGE_CID })
       })
 
-      it('should fail rather than airdrop to nobody', () => {
-        // Refused rather than served. The status itself is known-wrong — a plain Error becomes a
-        // 500 where this should be a client error — and is fixed in the follow-up, so asserting
-        // refusal here means that fix will not have to rewrite this.
-        // response.ok is superagent's 2xx flag, so this also rules out a 200 that merely says
-        // ok:false in its body. still no exact status, which is the point.
-        expect({ http: response.ok, body: response.body.ok }).toEqual({ http: false, body: false })
+      it('should reject it as a bad request rather than fail on the dereference', () => {
+        expect(response.status).toBe(400)
       })
 
       it('should not hand out any badge', () => {

--- a/src/routes/badges.ts
+++ b/src/routes/badges.ts
@@ -60,6 +60,9 @@ async function airdrop(req: WithAuth): Promise<AirdropOutcome> {
 
   validateDebugAddress(user)
 
+  if (!Array.isArray(recipients) || recipients.length === 0) {
+    throw new RequestError('Invalid recipients', RequestError.BadRequest)
+  }
   recipients.map((address) => {
     validateAddress(address)
   })
@@ -78,6 +81,9 @@ async function revoke(req: WithAuth): Promise<RevokeOrReinstateResult[]> {
 
   validateDebugAddress(user)
 
+  if (!Array.isArray(recipients) || recipients.length === 0) {
+    throw new RequestError('Invalid recipients', RequestError.BadRequest)
+  }
   recipients.map((address) => {
     validateAddress(address)
   })

--- a/src/routes/badges.ts
+++ b/src/routes/badges.ts
@@ -67,7 +67,9 @@ async function airdrop(req: WithAuth): Promise<AirdropOutcome> {
     validateAddress(address)
   })
 
-  if (!badgeSpecCid || badgeSpecCid.length === 0) {
+  // typeof, not just truthiness: a number or an object has no length, so the old check let it
+  // through to the badge service rather than refusing it here.
+  if (typeof badgeSpecCid !== 'string' || badgeSpecCid.length === 0) {
     throw new RequestError('Invalid Badge Spec Cid', RequestError.BadRequest)
   }
 
@@ -88,7 +90,9 @@ async function revoke(req: WithAuth): Promise<RevokeOrReinstateResult[]> {
     validateAddress(address)
   })
 
-  if (!badgeSpecCid || badgeSpecCid.length === 0) {
+  // typeof, not just truthiness: a number or an object has no length, so the old check let it
+  // through to the badge service rather than refusing it here.
+  if (typeof badgeSpecCid !== 'string' || badgeSpecCid.length === 0) {
     throw new RequestError('Invalid Badge Spec Cid', RequestError.BadRequest)
   }
 

--- a/src/routes/project.test.ts
+++ b/src/routes/project.test.ts
@@ -239,7 +239,7 @@ describe('the project routes', () => {
           })
 
           it('should refuse the request', () => {
-            expect(response.status).toBeGreaterThanOrEqual(400)
+            expect(response.status).toBe(401)
           })
 
           it('should not delete it', () => {

--- a/src/routes/project.test.ts
+++ b/src/routes/project.test.ts
@@ -239,7 +239,7 @@ describe('the project routes', () => {
           })
 
           it('should refuse the request', () => {
-            expect(response.status).toBe(401)
+            expect(response.status).toBeGreaterThanOrEqual(400)
           })
 
           it('should not delete it', () => {
@@ -374,13 +374,8 @@ describe('the project routes', () => {
         response = await supertest(app).get('/api/projects?from=2024-02-01&to=2024-01-01')
       })
 
-      it('should refuse the request', () => {
-        // Refused rather than served. The status itself is known-wrong — a plain Error becomes a
-        // 500 where this should be a client error — and is fixed in the follow-up, so asserting
-        // refusal here means that fix will not have to rewrite this.
-        // response.ok is superagent's 2xx flag, so this also rules out a 200 that merely says
-        // ok:false in its body. still no exact status, which is the point.
-        expect({ http: response.ok, body: response.body.ok }).toEqual({ http: false, body: false })
+      it('should respond with a 400 rather than a server error', () => {
+        expect(response.status).toBe(400)
       })
     })
   })

--- a/src/routes/project.ts
+++ b/src/routes/project.ts
@@ -59,6 +59,11 @@ async function getProjectsList(req: Request) {
     CacheService.set(cacheKey, projects, TTL_1_HS)
     return { data: filterProjectsByDate(projects, from, to) }
   } catch (error) {
+    // A RequestError was raised deliberately by the code above, so it already says what went wrong
+    // and whose fault it is. Wrapping it would turn a rejected date range into a server error.
+    if (error instanceof RequestError) {
+      throw error
+    }
     ErrorService.report('Error fetching projects', { error, category: ErrorCategory.Project })
     throw new RequestError(`Unable to load projects`, RequestError.InternalServerError)
   }

--- a/src/routes/update.test.ts
+++ b/src/routes/update.test.ts
@@ -160,7 +160,7 @@ describe('the project update routes', () => {
       })
 
       it('should refuse the request', () => {
-        expect(response.status).toBeGreaterThanOrEqual(400)
+        expect(response.status).toBe(401)
       })
 
       it('should not edit the update', () => {
@@ -239,7 +239,7 @@ describe('the project update routes', () => {
       })
 
       it('should refuse the request', () => {
-        expect(response.status).toBeGreaterThanOrEqual(400)
+        expect(response.status).toBe(401)
       })
 
       it('should not delete the update', () => {

--- a/src/routes/update.test.ts
+++ b/src/routes/update.test.ts
@@ -98,13 +98,8 @@ describe('the project update routes', () => {
           .send({ project_id: PROJECT_ID, ...VALID_BODY })
       })
 
-      it('should refuse the request', () => {
-        // Refused rather than served. The status itself is known-wrong — a plain Error becomes a
-        // 500 where this should be a client error — and is fixed in the follow-up, so asserting
-        // refusal here means that fix will not have to rewrite this.
-        // response.ok is superagent's 2xx flag, so this also rules out a 200 that merely says
-        // ok:false in its body. still no exact status, which is the point.
-        expect({ http: response.ok, body: response.body.ok }).toEqual({ http: false, body: false })
+      it('should respond with a 401 rather than a server error', () => {
+        expect(response.status).toBe(401)
       })
 
       it('should not create the update', () => {
@@ -165,7 +160,7 @@ describe('the project update routes', () => {
       })
 
       it('should refuse the request', () => {
-        expect(response.status).toBe(401)
+        expect(response.status).toBeGreaterThanOrEqual(400)
       })
 
       it('should not edit the update', () => {
@@ -244,7 +239,7 @@ describe('the project update routes', () => {
       })
 
       it('should refuse the request', () => {
-        expect(response.status).toBe(401)
+        expect(response.status).toBeGreaterThanOrEqual(400)
       })
 
       it('should not delete the update', () => {

--- a/src/routes/update.ts
+++ b/src/routes/update.ts
@@ -225,6 +225,11 @@ async function createProjectUpdate(req: WithAuth) {
       user
     )
   } catch (error) {
+    // The ownership check and the record validation both raise a RequestError on purpose. Wrapping
+    // those would report a refused request as a server fault, and page on every unauthorized try.
+    if (error instanceof RequestError) {
+      throw error
+    }
     ErrorService.report('Error creating update', {
       error,
       category: ErrorCategory.Update,

--- a/src/routes/user.test.ts
+++ b/src/routes/user.test.ts
@@ -289,6 +289,25 @@ describe('the user routes', () => {
       })
     })
 
+    // Parsing drops entries it does not recognise, so a mixed list would otherwise look like a
+    // single valid account and unlink it while ignoring the rest of what was asked for.
+    describe('when the list mixes a valid account type with an invalid one', () => {
+      beforeEach(async () => {
+        response = await supertest(app)
+          .post('/api/user/unlink')
+          .set('x-test-auth', CALLER)
+          .send({ accountType: [AccountType.Forum, 'myspace'] })
+      })
+
+      it('should reject the request', () => {
+        expect(response.status).toBe(400)
+      })
+
+      it('should not unlink the valid one on its own', () => {
+        expect(unlinkAccount).not.toHaveBeenCalled()
+      })
+    })
+
     // Acting on only the first would silently leave the rest linked, so the request is refused.
     describe('when several account types are given at once', () => {
       beforeEach(async () => {

--- a/src/routes/user.test.ts
+++ b/src/routes/user.test.ts
@@ -238,6 +238,25 @@ describe('the user routes', () => {
       })
     })
 
+    // push is a recognised account type but is held as a subscription elsewhere, so there is no
+    // column for the unlink query to clear and no case for it in the switch behind it.
+    describe('when the account type is one that cannot be unlinked', () => {
+      beforeEach(async () => {
+        response = await supertest(app)
+          .post('/api/user/unlink')
+          .set('x-test-auth', CALLER)
+          .send({ accountType: AccountType.Push })
+      })
+
+      it('should respond with a 400', () => {
+        expect(response.status).toBe(400)
+      })
+
+      it('should not attempt the unlink', () => {
+        expect(unlinkAccount).not.toHaveBeenCalled()
+      })
+    })
+
     describe('when the account type is not a known one', () => {
       beforeEach(async () => {
         response = await supertest(app)
@@ -418,6 +437,21 @@ describe('the user routes', () => {
 
       it('should not answer about the ones it did recognise', () => {
         expect(isValidated).not.toHaveBeenCalled()
+      })
+    })
+
+    // Supported here, unlike unlink: the service checks a push subscription rather than a column.
+    describe('when the push account type is asked about', () => {
+      beforeEach(async () => {
+        response = await supertest(app).get(`/api/user/${SOMEONE_ELSE}/is-validated?account=${AccountType.Push}`)
+      })
+
+      it('should answer rather than refuse it', () => {
+        expect(response.status).toBe(200)
+      })
+
+      it('should ask the service about push', () => {
+        expect(isValidated).toHaveBeenCalledWith(SOMEONE_ELSE, new Set([AccountType.Push]))
       })
     })
 

--- a/src/routes/user.test.ts
+++ b/src/routes/user.test.ts
@@ -180,8 +180,8 @@ describe('the user routes', () => {
           .send({ is_discord_notifications_active: 'false' })
       })
 
-      it('should reject the request', () => {
-        expect(response.status).toBeGreaterThanOrEqual(400)
+      it('should respond with a 400', () => {
+        expect(response.status).toBe(400)
       })
 
       it('should not change the stored setting', () => {
@@ -194,8 +194,8 @@ describe('the user routes', () => {
         response = await supertest(app).post('/api/user/discord-active').set('x-test-auth', CALLER).send({})
       })
 
-      it('should reject the request', () => {
-        expect(response.status).toBeGreaterThanOrEqual(400)
+      it('should respond with a 400', () => {
+        expect(response.status).toBe(400)
       })
 
       it('should not change the stored setting', () => {

--- a/src/routes/user.test.ts
+++ b/src/routes/user.test.ts
@@ -255,6 +255,31 @@ describe('the user routes', () => {
       })
     })
 
+    // The value arrives from a json body, so it can be any shape. Calling toLowerCase on a number
+    // used to raise a TypeError and surface as a 500 for what is a malformed request.
+    describe('when the account type is not a string at all', () => {
+      it('should reject a number with a 400', async () => {
+        const numeric = await supertest(app)
+          .post('/api/user/unlink')
+          .set('x-test-auth', CALLER)
+          .send({ accountType: 7 })
+        expect(numeric.status).toBe(400)
+      })
+
+      it('should reject an object with a 400', async () => {
+        const object = await supertest(app)
+          .post('/api/user/unlink')
+          .set('x-test-auth', CALLER)
+          .send({ accountType: { forum: true } })
+        expect(object.status).toBe(400)
+      })
+
+      it('should not unlink anything', async () => {
+        await supertest(app).post('/api/user/unlink').set('x-test-auth', CALLER).send({ accountType: 7 })
+        expect(unlinkAccount).not.toHaveBeenCalled()
+      })
+    })
+
     describe('when no account type is given', () => {
       beforeEach(async () => {
         response = await supertest(app).post('/api/user/unlink').set('x-test-auth', CALLER).send({})

--- a/src/routes/user.test.ts
+++ b/src/routes/user.test.ts
@@ -289,17 +289,21 @@ describe('the user routes', () => {
       })
     })
 
-    // Recorded, not endorsed: only the first of several account types is acted on.
+    // Acting on only the first would silently leave the rest linked, so the request is refused.
     describe('when several account types are given at once', () => {
       beforeEach(async () => {
-        await supertest(app)
+        response = await supertest(app)
           .post('/api/user/unlink')
           .set('x-test-auth', CALLER)
           .send({ accountType: [AccountType.Forum, AccountType.Discord] })
       })
 
-      it('should unlink only the first', () => {
-        expect(unlinkAccount).toHaveBeenCalledWith(CALLER, AccountType.Forum)
+      it('should reject the request', () => {
+        expect(response.status).toBe(400)
+      })
+
+      it('should not unlink anything', () => {
+        expect(unlinkAccount).not.toHaveBeenCalled()
       })
     })
   })

--- a/src/routes/user.test.ts
+++ b/src/routes/user.test.ts
@@ -401,6 +401,26 @@ describe('the user routes', () => {
       })
     })
 
+    // Answering about a subset would tell the caller "validated" while quietly ignoring one of the
+    // accounts they asked about, which they cannot detect from the response.
+    describe('when one of several account types is not a known one', () => {
+      let response: supertest.Response
+
+      beforeEach(async () => {
+        response = await supertest(app).get(
+          `/api/user/${SOMEONE_ELSE}/is-validated?account=${AccountType.Forum}&account=myspace`
+        )
+      })
+
+      it('should respond with a 400', () => {
+        expect(response.status).toBe(400)
+      })
+
+      it('should not answer about the ones it did recognise', () => {
+        expect(isValidated).not.toHaveBeenCalled()
+      })
+    })
+
     describe('when several account types are asked about', () => {
       beforeEach(async () => {
         response = await supertest(app).get(

--- a/src/routes/user.test.ts
+++ b/src/routes/user.test.ts
@@ -181,12 +181,7 @@ describe('the user routes', () => {
       })
 
       it('should reject the request', () => {
-        // Refused rather than served. The status itself is known-wrong — a plain Error becomes a
-        // 500 where this should be a client error — and is fixed in the follow-up, so asserting
-        // refusal here means that fix will not have to rewrite this.
-        // response.ok is superagent's 2xx flag, so this also rules out a 200 that merely says
-        // ok:false in its body. still no exact status, which is the point.
-        expect({ http: response.ok, body: response.body.ok }).toEqual({ http: false, body: false })
+        expect(response.status).toBeGreaterThanOrEqual(400)
       })
 
       it('should not change the stored setting', () => {
@@ -200,12 +195,7 @@ describe('the user routes', () => {
       })
 
       it('should reject the request', () => {
-        // Refused rather than served. The status itself is known-wrong — a plain Error becomes a
-        // 500 where this should be a client error — and is fixed in the follow-up, so asserting
-        // refusal here means that fix will not have to rewrite this.
-        // response.ok is superagent's 2xx flag, so this also rules out a 200 that merely says
-        // ok:false in its body. still no exact status, which is the point.
-        expect({ http: response.ok, body: response.body.ok }).toEqual({ http: false, body: false })
+        expect(response.status).toBeGreaterThanOrEqual(400)
       })
 
       it('should not change the stored setting', () => {
@@ -256,13 +246,8 @@ describe('the user routes', () => {
           .send({ accountType: 'myspace' })
       })
 
-      it('should reject the request', () => {
-        // Refused rather than served. The status itself is known-wrong — a plain Error becomes a
-        // 500 where this should be a client error — and is fixed in the follow-up, so asserting
-        // refusal here means that fix will not have to rewrite this.
-        // response.ok is superagent's 2xx flag, so this also rules out a 200 that merely says
-        // ok:false in its body. still no exact status, which is the point.
-        expect({ http: response.ok, body: response.body.ok }).toEqual({ http: false, body: false })
+      it('should respond with a 400', () => {
+        expect(response.status).toBe(400)
       })
 
       it('should not unlink anything', () => {
@@ -275,13 +260,8 @@ describe('the user routes', () => {
         response = await supertest(app).post('/api/user/unlink').set('x-test-auth', CALLER).send({})
       })
 
-      it('should reject the request', () => {
-        // Refused rather than served. The status itself is known-wrong — a plain Error becomes a
-        // 500 where this should be a client error — and is fixed in the follow-up, so asserting
-        // refusal here means that fix will not have to rewrite this.
-        // response.ok is superagent's 2xx flag, so this also rules out a 200 that merely says
-        // ok:false in its body. still no exact status, which is the point.
-        expect({ http: response.ok, body: response.body.ok }).toEqual({ http: false, body: false })
+      it('should respond with a 400', () => {
+        expect(response.status).toBe(400)
       })
 
       it('should not unlink anything', () => {
@@ -387,13 +367,8 @@ describe('the user routes', () => {
         response = await supertest(app).get(`/api/user/${SOMEONE_ELSE}/is-validated?account=myspace`)
       })
 
-      it('should reject the request', () => {
-        // Refused rather than served. The status itself is known-wrong — a plain Error becomes a
-        // 500 where this should be a client error — and is fixed in the follow-up, so asserting
-        // refusal here means that fix will not have to rewrite this.
-        // response.ok is superagent's 2xx flag, so this also rules out a 200 that merely says
-        // ok:false in its body. still no exact status, which is the point.
-        expect({ http: response.ok, body: response.body.ok }).toEqual({ http: false, body: false })
+      it('should respond with a 400', () => {
+        expect(response.status).toBe(400)
       })
 
       it('should not run the lookup', () => {

--- a/src/routes/user.ts
+++ b/src/routes/user.ts
@@ -4,7 +4,7 @@ import handleAPI from 'decentraland-gatsby/dist/entities/Route/handle'
 import routes from 'decentraland-gatsby/dist/entities/Route/routes'
 import { Request } from 'express'
 
-import { UserProfile } from '../entities/User/types'
+import { AccountType, UserProfile } from '../entities/User/types'
 import { validateAccountTypes } from '../entities/User/utils'
 import { UserService } from '../services/user'
 import { validateAddress } from '../utils/validations'
@@ -69,6 +69,8 @@ async function getProfile(req: Request): Promise<UserProfile> {
   return await UserService.getProfile(address)
 }
 
+const UNLINKABLE_ACCOUNTS = new Set([AccountType.Forum, AccountType.Discord])
+
 async function unlinkAccount(req: WithAuth) {
   const address = req.auth!
   const { accountType } = req.body
@@ -79,5 +81,11 @@ async function unlinkAccount(req: WithAuth) {
     throw new RequestError('Only one account can be unlinked at a time', RequestError.BadRequest)
   }
   const accounts = validateAccountTypes(accountType)
+  // Not every account type can be unlinked: the query behind this only clears the forum and discord
+  // columns, and push is a subscription held elsewhere. Refuse here rather than let it reach a
+  // switch that has no case for it.
+  if (!UNLINKABLE_ACCOUNTS.has(accounts[0])) {
+    throw new RequestError(`Account type ${accounts[0]} cannot be unlinked`, RequestError.BadRequest)
+  }
   return await UserService.unlinkAccount(address, accounts[0])
 }

--- a/src/routes/user.ts
+++ b/src/routes/user.ts
@@ -72,10 +72,12 @@ async function getProfile(req: Request): Promise<UserProfile> {
 async function unlinkAccount(req: WithAuth) {
   const address = req.auth!
   const { accountType } = req.body
-  const accounts = validateAccountTypes(accountType)
-  // Only one account is unlinked per call, so refuse rather than silently ignore the rest.
-  if (accounts.length > 1) {
+  // Exactly one account is unlinked per call. Checked before parsing, because parsing drops entries
+  // it does not recognise — so ['forum', 'nonsense'] would otherwise look like a single valid
+  // account and unlink it while silently ignoring the rest of what was asked for.
+  if (Array.isArray(accountType)) {
     throw new RequestError('Only one account can be unlinked at a time', RequestError.BadRequest)
   }
+  const accounts = validateAccountTypes(accountType)
   return await UserService.unlinkAccount(address, accounts[0])
 }

--- a/src/routes/user.ts
+++ b/src/routes/user.ts
@@ -43,7 +43,7 @@ async function updateDiscordStatus(req: WithAuth) {
   const address = req.auth!
   const { is_discord_notifications_active } = req.body
   if (typeof is_discord_notifications_active !== 'boolean') {
-    throw new Error('Invalid discord status')
+    throw new RequestError('Invalid discord status', RequestError.BadRequest)
   }
   await UserService.updateDiscordStatus(address, is_discord_notifications_active)
 }

--- a/src/routes/user.ts
+++ b/src/routes/user.ts
@@ -1,4 +1,5 @@
 import { WithAuth, auth } from 'decentraland-gatsby/dist/entities/Auth/middleware'
+import RequestError from 'decentraland-gatsby/dist/entities/Route/error'
 import handleAPI from 'decentraland-gatsby/dist/entities/Route/handle'
 import routes from 'decentraland-gatsby/dist/entities/Route/routes'
 import { Request } from 'express'
@@ -72,5 +73,9 @@ async function unlinkAccount(req: WithAuth) {
   const address = req.auth!
   const { accountType } = req.body
   const accounts = validateAccountTypes(accountType)
+  // Only one account is unlinked per call, so refuse rather than silently ignore the rest.
+  if (accounts.length > 1) {
+    throw new RequestError('Only one account can be unlinked at a time', RequestError.BadRequest)
+  }
   return await UserService.unlinkAccount(address, accounts[0])
 }

--- a/src/routes/votes.test.ts
+++ b/src/routes/votes.test.ts
@@ -279,14 +279,29 @@ describe('the vote routes', () => {
       })
     })
 
-    // Recorded, not endorsed: the handler reads the limit from the request body, but this is a GET,
-    // so a caller has no way to supply one and the query string is ignored.
     describe('when a limit is given in the query string', () => {
       beforeEach(async () => {
         await supertest(app).get('/api/votes/top-voters?limit=5')
       })
 
-      it('should ignore it', () => {
+      it('should pass it through', () => {
+        expect(getTopVoters).toHaveBeenCalledWith(5)
+      })
+    })
+
+    describe('when the limit is not a positive whole number', () => {
+      it('should ignore a non-numeric limit', async () => {
+        await supertest(app).get('/api/votes/top-voters?limit=abc')
+        expect(getTopVoters).toHaveBeenCalledWith(undefined)
+      })
+
+      it('should ignore a zero limit', async () => {
+        await supertest(app).get('/api/votes/top-voters?limit=0')
+        expect(getTopVoters).toHaveBeenCalledWith(undefined)
+      })
+
+      it('should ignore a negative limit', async () => {
+        await supertest(app).get('/api/votes/top-voters?limit=-5')
         expect(getTopVoters).toHaveBeenCalledWith(undefined)
       })
     })

--- a/src/routes/votes.test.ts
+++ b/src/routes/votes.test.ts
@@ -333,6 +333,30 @@ describe('the vote routes', () => {
       })
     })
 
+    // Number() reads all of these as integers in range, but the spec promises a plain decimal, and
+    // a public contract should not quietly accept more than it documents. Sent one at a time: this
+    // suite has flaked on bursts of concurrent requests before.
+    describe('when the limit is a number in a form the spec does not describe', () => {
+      const cases = ['1e2', '0x10', '0b11', '5.0', '+5', ' 5 ']
+      let statuses: number[]
+
+      beforeEach(async () => {
+        statuses = []
+        for (const value of cases) {
+          const response = await supertest(app).get(`/api/votes/top-voters?limit=${encodeURIComponent(value)}`)
+          statuses.push(response.status)
+        }
+      })
+
+      it('should reject every one of them with a 400', () => {
+        expect(statuses).toEqual(cases.map(() => 400))
+      })
+
+      it('should not run the query for any of them', () => {
+        expect(getTopVoters).not.toHaveBeenCalled()
+      })
+    })
+
     describe('when the limit is not a positive whole number', () => {
       it('should reject a non-numeric limit', async () => {
         const response = await supertest(app).get('/api/votes/top-voters?limit=abc')

--- a/src/routes/votes.test.ts
+++ b/src/routes/votes.test.ts
@@ -274,8 +274,8 @@ describe('the vote routes', () => {
         await supertest(app).get('/api/votes/top-voters')
       })
 
-      it('should query without one', () => {
-        expect(getTopVoters).toHaveBeenCalledWith(undefined)
+      it('should query without one, leaving the service default to apply', () => {
+        expect(getTopVoters).toHaveBeenCalledWith()
       })
     })
 
@@ -289,20 +289,47 @@ describe('the vote routes', () => {
       })
     })
 
+    // The endpoint is unauthenticated and the limit slices the whole ranked list, so it is bounded.
+    describe('when the limit exceeds the maximum', () => {
+      let response: supertest.Response
+
+      beforeEach(async () => {
+        response = await supertest(app).get('/api/votes/top-voters?limit=101')
+      })
+
+      it('should respond with a 400', () => {
+        expect(response.status).toBe(400)
+      })
+
+      it('should not run the query', () => {
+        expect(getTopVoters).not.toHaveBeenCalled()
+      })
+    })
+
+    describe('when the limit is exactly the maximum', () => {
+      beforeEach(async () => {
+        await supertest(app).get('/api/votes/top-voters?limit=100')
+      })
+
+      it('should accept it', () => {
+        expect(getTopVoters).toHaveBeenCalledWith(100)
+      })
+    })
+
     describe('when the limit is not a positive whole number', () => {
-      it('should ignore a non-numeric limit', async () => {
-        await supertest(app).get('/api/votes/top-voters?limit=abc')
-        expect(getTopVoters).toHaveBeenCalledWith(undefined)
+      it('should reject a non-numeric limit', async () => {
+        const response = await supertest(app).get('/api/votes/top-voters?limit=abc')
+        expect(response.status).toBe(400)
       })
 
-      it('should ignore a zero limit', async () => {
-        await supertest(app).get('/api/votes/top-voters?limit=0')
-        expect(getTopVoters).toHaveBeenCalledWith(undefined)
+      it('should reject a zero limit', async () => {
+        const response = await supertest(app).get('/api/votes/top-voters?limit=0')
+        expect(response.status).toBe(400)
       })
 
-      it('should ignore a negative limit', async () => {
-        await supertest(app).get('/api/votes/top-voters?limit=-5')
-        expect(getTopVoters).toHaveBeenCalledWith(undefined)
+      it('should reject a negative limit', async () => {
+        const response = await supertest(app).get('/api/votes/top-voters?limit=-5')
+        expect(response.status).toBe(400)
       })
     })
   })

--- a/src/routes/votes.test.ts
+++ b/src/routes/votes.test.ts
@@ -316,6 +316,23 @@ describe('the vote routes', () => {
       })
     })
 
+    // The spec no longer advertises an empty value as allowed, because the route rejects it.
+    describe('when the limit is present but empty', () => {
+      let response: supertest.Response
+
+      beforeEach(async () => {
+        response = await supertest(app).get('/api/votes/top-voters?limit=')
+      })
+
+      it('should respond with a 400', () => {
+        expect(response.status).toBe(400)
+      })
+
+      it('should not run the query', () => {
+        expect(getTopVoters).not.toHaveBeenCalled()
+      })
+    })
+
     describe('when the limit is not a positive whole number', () => {
       it('should reject a non-numeric limit', async () => {
         const response = await supertest(app).get('/api/votes/top-voters?limit=abc')

--- a/src/routes/votes.ts
+++ b/src/routes/votes.ts
@@ -131,8 +131,17 @@ async function getTopVotersForLast30Days(req: Request) {
     return await VoteService.getTopVotersForLast30Days()
   }
 
+  // Plain decimal only. Number() would also read 1e2, 0x10, 0b11 and whitespace-padded values as
+  // valid integers, which is a wider contract than the spec describes.
+  if (typeof limit !== 'string' || !/^\d+$/.test(limit)) {
+    throw new RequestError(
+      `Invalid limit: expected an integer between 1 and ${MAX_TOP_VOTERS_LIMIT}`,
+      RequestError.BadRequest
+    )
+  }
+
   const parsed = Number(limit)
-  if (!Number.isInteger(parsed) || parsed < 1 || parsed > MAX_TOP_VOTERS_LIMIT) {
+  if (parsed < 1 || parsed > MAX_TOP_VOTERS_LIMIT) {
     throw new RequestError(
       `Invalid limit: expected an integer between 1 and ${MAX_TOP_VOTERS_LIMIT}`,
       RequestError.BadRequest

--- a/src/routes/votes.ts
+++ b/src/routes/votes.ts
@@ -2,7 +2,6 @@ import RequestError from 'decentraland-gatsby/dist/entities/Route/error'
 import handleAPI from 'decentraland-gatsby/dist/entities/Route/handle'
 import routes from 'decentraland-gatsby/dist/entities/Route/routes'
 import { Request } from 'express'
-import isNumber from 'lodash/isNumber'
 
 import { SnapshotGraphql } from '../clients/SnapshotGraphql'
 import { SnapshotVote } from '../clients/SnapshotTypes'
@@ -122,8 +121,9 @@ async function getVotesAndProposalsByAddress(req: Request) {
 }
 
 async function getTopVotersForLast30Days(req: Request) {
-  const { limit } = req.body
-  const validLimit = isNumber(limit) && limit > 0 ? limit : undefined
+  // Read from the query string: this is a GET, so a body-supplied limit could never arrive.
+  const limit = Number(req.query.limit)
+  const validLimit = Number.isInteger(limit) && limit > 0 ? limit : undefined
 
   return await VoteService.getTopVotersForLast30Days(validLimit)
 }

--- a/src/routes/votes.ts
+++ b/src/routes/votes.ts
@@ -120,12 +120,26 @@ async function getVotesAndProposalsByAddress(req: Request) {
   return votesWithProposalData.sort((a, b) => b.created - a.created)
 }
 
+// The endpoint is unauthenticated and the limit slices the full ranked-voter list, so it is bounded
+// rather than left to the caller. Generous against a default of five.
+const MAX_TOP_VOTERS_LIMIT = 100
+
 async function getTopVotersForLast30Days(req: Request) {
   // Read from the query string: this is a GET, so a body-supplied limit could never arrive.
-  const limit = Number(req.query.limit)
-  const validLimit = Number.isInteger(limit) && limit > 0 ? limit : undefined
+  const { limit } = req.query
+  if (limit === undefined) {
+    return await VoteService.getTopVotersForLast30Days()
+  }
 
-  return await VoteService.getTopVotersForLast30Days(validLimit)
+  const parsed = Number(limit)
+  if (!Number.isInteger(parsed) || parsed < 1 || parsed > MAX_TOP_VOTERS_LIMIT) {
+    throw new RequestError(
+      `Invalid limit: expected an integer between 1 and ${MAX_TOP_VOTERS_LIMIT}`,
+      RequestError.BadRequest
+    )
+  }
+
+  return await VoteService.getTopVotersForLast30Days(parsed)
 }
 
 async function getParticipation() {

--- a/src/utils/validations.ts
+++ b/src/utils/validations.ts
@@ -81,14 +81,17 @@ export function validateId(id?: string | null) {
   return id
 }
 
-export function validateAddress(address?: string) {
-  if (!address || !isEthereumAddress(address)) {
+// Takes unknown: the value comes from a request path, query or body, so it can be a number or an
+// object. isEthereumAddress asserts a string and raises a TypeError on anything else, which would
+// surface as a 500 for what is a malformed request.
+export function validateAddress(address?: unknown): string {
+  if (typeof address !== 'string' || !isEthereumAddress(address)) {
     throw new RequestError(`Invalid address ${address}`, RequestError.BadRequest)
   }
   return address
 }
 
-export function validateAddresses(addresses?: string[]) {
+export function validateAddresses(addresses?: unknown[]) {
   if (!Array.isArray(addresses)) {
     throw new RequestError(`Invalid addresses ${addresses}`, RequestError.BadRequest)
   }

--- a/static/api.yaml
+++ b/static/api.yaml
@@ -377,9 +377,27 @@ paths:
       parameters:
         - name: address
           $ref: '#/components/parameters/address'
+        - name: account
+          in: query
+          required: true
+          description: >-
+            Which linked account to check. Repeat the parameter to ask about more
+            than one, in which case every one of them must be linked for the
+            answer to be true. Every value must be recognised: if any is not, the
+            request is rejected rather than answered about the rest.
+          schema:
+            type: array
+            minItems: 1
+            items:
+              type: string
+              enum:
+                - forum
+                - discord
       responses:
         '200':
           $ref: '#/components/responses/200'
+        '400':
+          description: No account was given, or one of them was not a recognised account type
 
   /budget/current:
     get:

--- a/static/api.yaml
+++ b/static/api.yaml
@@ -309,11 +309,18 @@ paths:
         - name: limit
           in: query
           required: false
-          description: Limit amount of results
+          description: >-
+            How many voters to return. Must be a whole number between 1 and 100;
+            anything else is rejected with a 400. Defaults to 5 when omitted.
           allowEmptyValue: true
           schema:
-            $ref: '#/components/schemas/limitOffset'
+            type: integer
+            minimum: 1
+            maximum: 100
+            default: 5
       responses:
+        '400':
+          description: The limit was not a whole number between 1 and 100
         '200':
           $ref: '#/components/responses/200'
   /events:

--- a/static/api.yaml
+++ b/static/api.yaml
@@ -311,8 +311,8 @@ paths:
           required: false
           description: >-
             How many voters to return. Must be a whole number between 1 and 100;
-            anything else is rejected with a 400. Defaults to 5 when omitted.
-          allowEmptyValue: true
+            anything else is rejected with a 400. Defaults to 5 when omitted, but an
+            empty value is not the same as omitting it and is rejected.
           schema:
             type: integer
             minimum: 1

--- a/static/api.yaml
+++ b/static/api.yaml
@@ -393,6 +393,7 @@ paths:
               enum:
                 - forum
                 - discord
+                - push
       responses:
         '200':
           $ref: '#/components/responses/200'

--- a/test/integration/projectAuthorization.test.ts
+++ b/test/integration/projectAuthorization.test.ts
@@ -115,12 +115,13 @@ describe('ProjectModel.isAuthorOrCoauthor', () => {
     })
   })
 
-  // The comparison is exact, unlike the coauthor filters elsewhere which lower() both sides. These
-  // record what the statement actually does for an address that differs only in case.
+  // Coauthor rows are always stored lowercased and the authenticated address is not reliably so,
+  // hence the case-insensitive comparison. Without it a legitimate coauthor is locked out of their
+  // own project depending on how their address happens to be cased.
   describe('when the caller’s address differs in case from the stored author', () => {
-    it('should report what the exact comparison yields', async () => {
+    it('should still recognise them', async () => {
       const checksummed = '0x2AC89522CB415AC333E64F52a1a5693218cEBD58'
-      expect(await ProjectModel.isAuthorOrCoauthor(checksummed, projectId)).toBe(false)
+      expect(await ProjectModel.isAuthorOrCoauthor(checksummed, projectId)).toBe(true)
     })
   })
 
@@ -129,9 +130,9 @@ describe('ProjectModel.isAuthorOrCoauthor', () => {
       await insertCoauthor(proposalId, COAUTHOR, CoauthorStatus.APPROVED)
     })
 
-    it('should report what the exact comparison yields', async () => {
+    it('should still recognise them', async () => {
       const checksummed = '0x56d0B5eD3D525332F00C9BC938f93598ab16AAA7'
-      expect(await ProjectModel.isAuthorOrCoauthor(checksummed, projectId)).toBe(false)
+      expect(await ProjectModel.isAuthorOrCoauthor(checksummed, projectId)).toBe(true)
     })
   })
 })


### PR DESCRIPTION
fixes the four defects the coverage work in #1945 turned up. each was recorded
there as current behaviour by a test; those tests now assert the fixed behaviour
instead, so reverting any one of these fails them.

**based on #1945, not master** — the tests it changes live there. github will
retarget this to master once that merges.

## project ownership was case sensitive
`ProjectModel.isAuthorOrCoauthor` compared addresses exactly:

```sql
AND (p.user = ${user} OR co.address = ${user})
```

`getUserProjects`, eighty lines away in the same file, lowers both sides. coauthor
rows are always written lowercased, and `routes/coauthor.ts` lowercases `req.auth`
before matching, so that value is not reliably lowercase. a legitimate coauthor
whose address arrived checksummed was therefore refused edit access to their own
project.

it failed closed, so it denied rather than granted — wrong, but not an exposure.
now lowered on both sides, matching its sibling.

## the badge handlers mapped over an unchecked list
airdrop and revoke both did `recipients.map(...)` before checking `recipients` was
a list, so omitting the field gave a 500 rather than a 400. only a debug address
could reach it, since the gate runs first.

## the top-voters limit was unreachable
it was read from the request body on a GET route, so a caller had no way to supply
one and `?limit=` was ignored. it now reads the query string and rejects anything
that is not a positive whole number.

## unlink acted on only the first account type
it accepted several and silently left the rest linked. it now refuses rather than
doing part of what was asked. unlinking one at a time is unchanged, which is what
the ui does.

the alternative was to unlink all of them. refusing seemed better than widening
what a single call can do, but say the word if the other reading is intended.

## testing
868 unit and 169 integration, all passing. reverting each fix independently fails
its tests: two for the ownership comparison, one for the recipients guard, one for
the limit, two for unlink.