### PR TITLE
fix: harden external URL handling

### DIFF
--- a/src/entities/Project/types.ts
+++ b/src/entities/Project/types.ts
@@ -4,6 +4,7 @@ import { ZodSchema, z } from 'zod'
 import { PersonnelAttributes } from '../../models/Personnel'
 import { ProjectLink } from '../../models/ProjectLink'
 import { ProjectMilestone } from '../../models/ProjectMilestone'
+import { isSafeWebUrl } from '../../utils/url'
 
 const addressCheck = (data: string) => !data || (!!data && isEthereumAddress(data))
 
@@ -16,14 +17,14 @@ export const PersonnelInCreationSchema: ZodSchema<PersonnelInCreation> = z.objec
   address: z.string().refine(addressCheck).optional().or(z.null()),
   role: z.string().min(1).max(80),
   about: z.string().min(1).max(750),
-  relevantLink: z.string().min(0).max(200).url().optional().or(z.literal('')),
+  relevantLink: z.string().min(0).max(200).url().refine(isSafeWebUrl).optional().or(z.literal('')),
   project_id: z.string().min(0),
 })
 
 export type ProjectLinkInCreation = Pick<ProjectLink, 'label' | 'url' | 'project_id'>
 export const ProjectLinkInCreationSchema: ZodSchema<ProjectLinkInCreation> = z.object({
   label: z.string().min(1).max(80),
-  url: z.string().min(0).max(200).url(),
+  url: z.string().min(0).max(200).url().refine(isSafeWebUrl),
   project_id: z.string().min(0),
 })
 

--- a/src/entities/Updates/types.ts
+++ b/src/entities/Updates/types.ts
@@ -1,6 +1,8 @@
 import isEthereumAddress from 'validator/lib/isEthereumAddress'
 import { z } from 'zod'
 
+import { isSafeWebUrl } from '../../utils/url'
+
 export type UpdateSubmissionDetails = {
   id?: string
   author: string
@@ -112,7 +114,7 @@ const FinancialRecordSchema = z
       .transform((s) => s.replace(/\s/g, '')),
     amount: z.number().min(1),
     receiver: z.string().min(42).max(42),
-    link: z.string().url().optional(),
+    link: z.string().url().refine(isSafeWebUrl).optional(),
   })
   .refine(({ receiver }) => isEthereumAddress(receiver), {
     message: 'Invalid ethereum address',

--- a/src/routes/common.test.ts
+++ b/src/routes/common.test.ts
@@ -1,6 +1,7 @@
+import RequestError from 'decentraland-gatsby/dist/entities/Route/error'
 import dns from 'dns'
 
-import { assertPublicUrl, isPrivateIp } from './common'
+import { assertPublicUrl, getTitle, isPrivateIp } from './common'
 
 describe('isPrivateIp', () => {
   describe('when given IPv4 addresses in a private, loopback, link-local or CGNAT range', () => {
@@ -115,6 +116,58 @@ describe('assertPublicUrl', () => {
 
     it('should reject because at least one resolved address is private', async () => {
       await expect(assertPublicUrl('https://rebind.example/')).rejects.toThrow('private address')
+    })
+  })
+})
+
+describe('getTitle', () => {
+  let fetchMock: jest.SpyInstance
+
+  beforeEach(() => {
+    fetchMock = jest.spyOn(global, 'fetch')
+  })
+
+  afterEach(() => {
+    jest.restoreAllMocks()
+  })
+
+  describe('when the response contains a title within the size limit', () => {
+    beforeEach(() => {
+      fetchMock.mockResolvedValue(new Response('<html><head><title>Example title</title></head><body></body></html>'))
+    })
+
+    it('should return the title', async () => {
+      await expect(getTitle('https://example.com')).resolves.toBe('Example title')
+    })
+  })
+
+  describe('when the declared response size exceeds the limit', () => {
+    beforeEach(() => {
+      fetchMock.mockResolvedValue(
+        new Response('not read', {
+          headers: {
+            'content-length': String(64 * 1024 + 1),
+          },
+        })
+      )
+    })
+
+    it('should reject the response as too large', async () => {
+      await expect(getTitle('https://example.com')).rejects.toMatchObject({
+        statusCode: RequestError.PayloadTooLarge,
+      })
+    })
+  })
+
+  describe('when a streamed response exceeds the limit without declaring its size', () => {
+    beforeEach(() => {
+      fetchMock.mockResolvedValue(new Response(new Uint8Array(64 * 1024 + 1)))
+    })
+
+    it('should reject the response as too large', async () => {
+      await expect(getTitle('https://example.com')).rejects.toMatchObject({
+        statusCode: RequestError.PayloadTooLarge,
+      })
     })
   })
 })

--- a/src/routes/common.ts
+++ b/src/routes/common.ts
@@ -1,4 +1,5 @@
 import { auth } from 'decentraland-gatsby/dist/entities/Auth/middleware'
+import RequestError from 'decentraland-gatsby/dist/entities/Route/error'
 import handleAPI from 'decentraland-gatsby/dist/entities/Route/handle'
 import routes from 'decentraland-gatsby/dist/entities/Route/routes'
 import dns from 'dns'
@@ -12,6 +13,7 @@ export default routes((router) => {
 })
 
 const isHttpsURL = (url: string) => isURL(url, { protocols: ['https'], require_protocol: true })
+const MAX_TITLE_RESPONSE_BYTES = 64 * 1024
 
 // Parses any valid IPv6 textual form (compact, expanded, or with an embedded IPv4 suffix)
 // into its 16 bytes, so range checks below cannot be bypassed by an alternate spelling
@@ -109,17 +111,48 @@ export async function assertPublicUrl(url: string) {
   }
 }
 
-async function getTitle(url: string) {
+export async function getTitle(url: string) {
   const controller = new AbortController()
   const timeoutId = setTimeout(() => controller.abort(), 6000)
+  let reader: ReadableStreamDefaultReader<Uint8Array> | undefined
   try {
     // redirect: 'manual' prevents a public URL from 3xx-redirecting to an internal host
     // after the address check has passed.
     const response = await fetch(url, { redirect: 'manual', signal: controller.signal })
-    const text = await response.text()
-    return text.match(/<title>([^<]+)<\/title>/)?.[1]
+    reader = response.body?.getReader()
+    const declaredLength = Number(response.headers.get('content-length'))
+    if (Number.isFinite(declaredLength) && declaredLength > MAX_TITLE_RESPONSE_BYTES) {
+      throw new RequestError('Response is too large', RequestError.PayloadTooLarge)
+    }
+
+    if (!reader) {
+      return undefined
+    }
+
+    const decoder = new TextDecoder()
+    let bytesRead = 0
+    let text = ''
+    for (;;) {
+      const { done, value } = await reader.read()
+      if (done) {
+        text += decoder.decode()
+        return text.match(/<title>([^<]+)<\/title>/i)?.[1]
+      }
+
+      bytesRead += value.byteLength
+      if (bytesRead > MAX_TITLE_RESPONSE_BYTES) {
+        throw new RequestError('Response is too large', RequestError.PayloadTooLarge)
+      }
+
+      text += decoder.decode(value, { stream: true })
+      const title = text.match(/<title>([^<]+)<\/title>/i)?.[1]
+      if (title) {
+        return title
+      }
+    }
   } finally {
     clearTimeout(timeoutId)
+    await reader?.cancel().catch(() => undefined)
   }
 }
 

--- a/src/routes/project.test.ts
+++ b/src/routes/project.test.ts
@@ -181,6 +181,33 @@ describe('the project routes', () => {
         expect(addLink).not.toHaveBeenCalled()
       })
     })
+
+    describe('when the owner submits a link with an executable URL scheme', () => {
+      let response: supertest.Response
+      let addLink: jest.SpyInstance
+
+      beforeEach(async () => {
+        addLink = jest.spyOn(ProjectService, 'addLink').mockResolvedValue({} as never)
+        response = await supertest(app)
+          .post('/api/projects/links/')
+          .set('x-test-auth', OWNER)
+          .send({
+            project_link: {
+              project_id: PROJECT_ID,
+              label: 'Repository',
+              url: 'javascript:alert(document.domain)',
+            },
+          })
+      })
+
+      it('should reject the link', () => {
+        expect(response.status).toBe(400)
+      })
+
+      it('should not store the link', () => {
+        expect(addLink).not.toHaveBeenCalled()
+      })
+    })
   })
 
   describe('the routes that delete from a project', () => {

--- a/src/utils/url.test.ts
+++ b/src/utils/url.test.ts
@@ -1,0 +1,18 @@
+import { isSafeWebUrl } from './url'
+
+describe('isSafeWebUrl', () => {
+  describe.each(['https://example.com/path', 'http://example.com/path'])('when the URL is %s', (value) => {
+    it('should accept the URL', () => {
+      expect(isSafeWebUrl(value)).toBe(true)
+    })
+  })
+
+  describe.each(['javascript:alert(document.domain)', 'data:text/html,unsafe', 'file:///etc/passwd', 'not a url'])(
+    'when the value is %s',
+    (value) => {
+      it('should reject the value', () => {
+        expect(isSafeWebUrl(value)).toBe(false)
+      })
+    }
+  )
+})

--- a/src/utils/url.ts
+++ b/src/utils/url.ts
@@ -1,0 +1,7 @@
+export function isSafeWebUrl(value: string): boolean {
+  try {
+    return ['http:', 'https:'].includes(new URL(value).protocol)
+  } catch {
+    return false
+  }
+}


### PR DESCRIPTION
## Summary
- allow only HTTP(S) schemes for stored project, personnel, and financial-record links
- reject executable schemes such as `javascript:` and `data:` at the API boundary
- stream `/url-title` responses with a 64 KiB cap instead of buffering arbitrary response bodies
- cancel response readers and preserve the existing request timeout

## Verification
- `npm run build`
- full test suite: 59 suites, 981 passed, 1 skipped
- focused route and URL tests cover executable schemes and oversized declared/streamed bodies

## Security impact
Prevents stored executable URLs from entering link-bearing records and bounds memory consumption for authenticated URL-title fetches.