### PR TITLE
fix: bound vesting and sitemap requests

### DIFF
--- a/src/routes/sitemap.test.ts
+++ b/src/routes/sitemap.test.ts
@@ -1,0 +1,87 @@
+import { Server } from 'http'
+import supertest from 'supertest'
+
+import ProposalModel from '../entities/Proposal/model'
+
+import sitemap from './sitemap'
+import { createTestApp } from './testApp'
+
+describe('the sitemap routes', () => {
+  let app: Server
+  let countAll: jest.SpyInstance
+  let getSitemapProposals: jest.SpyInstance
+  let response: supertest.Response
+
+  beforeEach(() => {
+    app = createTestApp(sitemap)
+    countAll = jest.spyOn(ProposalModel, 'countAll').mockResolvedValue(201)
+    getSitemapProposals = jest.spyOn(ProposalModel, 'getSitemapProposals').mockResolvedValue([])
+  })
+
+  afterEach(() => {
+    jest.restoreAllMocks()
+  })
+
+  describe('GET /api/governance/sitemap.proposals.xml', () => {
+    describe('when the requested page exists', () => {
+      beforeEach(async () => {
+        response = await supertest(app).get('/api/governance/sitemap.proposals.xml?page=2')
+      })
+
+      it('should respond with the sitemap', () => {
+        expect(response.status).toBe(200)
+      })
+
+      it('should query the requested page', () => {
+        expect(getSitemapProposals).toHaveBeenCalledWith(2)
+      })
+    })
+
+    describe('when the page is negative', () => {
+      beforeEach(async () => {
+        response = await supertest(app).get('/api/governance/sitemap.proposals.xml?page=-1')
+      })
+
+      it('should respond with an empty sitemap', () => {
+        expect(response.text).toContain('<urlset')
+      })
+
+      it('should not count proposals', () => {
+        expect(countAll).not.toHaveBeenCalled()
+      })
+
+      it('should not issue an offset query', () => {
+        expect(getSitemapProposals).not.toHaveBeenCalled()
+      })
+    })
+
+    describe('when the page exceeds the available page count', () => {
+      beforeEach(async () => {
+        countAll.mockResolvedValue(100)
+        response = await supertest(app).get('/api/governance/sitemap.proposals.xml?page=1')
+      })
+
+      it('should respond with an empty sitemap', () => {
+        expect(response.text).toContain('<urlset')
+      })
+
+      it('should not issue an offset query', () => {
+        expect(getSitemapProposals).not.toHaveBeenCalled()
+      })
+    })
+
+    describe('when the page is not a safe integer', () => {
+      beforeEach(async () => {
+        response = await supertest(app).get('/api/governance/sitemap.proposals.xml?page=999999999999999999999999999999')
+      })
+
+      it('should not count proposals', () => {
+        expect(countAll).not.toHaveBeenCalled()
+      })
+
+      it('should not issue an offset query', () => {
+        expect(getSitemapProposals).not.toHaveBeenCalled()
+      })
+    })
+  })
+})

--- a/src/routes/sitemap.ts
+++ b/src/routes/sitemap.ts
@@ -5,6 +5,12 @@ import { Request } from 'express'
 import ProposalModel from '../entities/Proposal/model'
 import { SITEMAP_ITEMS_PER_PAGE, governanceUrl, proposalUrl } from '../entities/Proposal/utils'
 
+const EMPTY_SITEMAP = [
+  '<?xml version="1.0" encoding="UTF-8"?>',
+  '<urlset xmlns="http://www.sitemaps.org/schemas/sitemap/0.9">',
+  '</urlset>',
+].join('')
+
 export default routes((router) => {
   const routePrefix = '/governance'
   router.get(`${routePrefix}/sitemap.xml`, handleRaw(getIndexSitemap, 'application/xml'))
@@ -47,13 +53,20 @@ export async function getStaticSitemap() {
 }
 
 export async function getProposalsSitemap(req: Request) {
-  const page = Number(req.query.page)
-  if (!Number.isFinite(page) || String(page | 0) !== req.query.page) {
-    return [
-      '<?xml version="1.0" encoding="UTF-8"?>',
-      '<urlset xmlns="http://www.sitemaps.org/schemas/sitemap/0.9">',
-      '</urlset>',
-    ].join('')
+  const pageParam = req.query.page
+  if (typeof pageParam !== 'string' || pageParam.length > 10 || !/^(0|[1-9]\d*)$/.test(pageParam)) {
+    return EMPTY_SITEMAP
+  }
+
+  const page = Number(pageParam)
+  if (!Number.isSafeInteger(page)) {
+    return EMPTY_SITEMAP
+  }
+
+  const proposalCount = await ProposalModel.countAll()
+  const pageCount = Math.ceil(proposalCount / SITEMAP_ITEMS_PER_PAGE)
+  if (page >= pageCount) {
+    return EMPTY_SITEMAP
   }
 
   const proposals = await ProposalModel.getSitemapProposals(page)

--- a/src/routes/vestings.test.ts
+++ b/src/routes/vestings.test.ts
@@ -4,7 +4,7 @@ import supertest from 'supertest'
 import { VestingService } from '../services/VestingService'
 
 import { createTestApp } from './testApp'
-import vestings from './vestings'
+import vestings, { MAX_VESTING_ADDRESSES_PER_REQUEST } from './vestings'
 
 const ADDRESS = '0x2AC89522CB415AC333E64F52a1a5693218cEBD58'
 const OTHER_ADDRESS = '0x56d0B5eD3D525332F00C9BC938f93598ab16AAA7'
@@ -55,6 +55,36 @@ describe('the vesting routes', () => {
 
       it('should not query for the valid ones either', () => {
         expect(getVestings).not.toHaveBeenCalled()
+      })
+    })
+
+    describe('when the request exceeds the address limit', () => {
+      let addresses: string[]
+
+      beforeEach(async () => {
+        addresses = Array.from(
+          { length: MAX_VESTING_ADDRESSES_PER_REQUEST + 1 },
+          (_, index) => `0x${(index + 1).toString(16).padStart(40, '0')}`
+        )
+        response = await supertest(app).post('/api/vesting').send({ addresses })
+      })
+
+      it('should respond with a 400', () => {
+        expect(response.status).toBe(400)
+      })
+
+      it('should not start a vesting lookup', () => {
+        expect(getVestings).not.toHaveBeenCalled()
+      })
+    })
+
+    describe('when the addresses field is missing', () => {
+      beforeEach(async () => {
+        response = await supertest(app).post('/api/vesting').send({})
+      })
+
+      it('should respond with a 400', () => {
+        expect(response.status).toBe(400)
       })
     })
   })

--- a/src/routes/vestings.ts
+++ b/src/routes/vestings.ts
@@ -4,9 +4,13 @@ import { Request } from 'express'
 
 import { VestingWithLogs } from '../clients/VestingData'
 import { VestingService } from '../services/VestingService'
-import { validateAddress } from '../utils/validations'
+import { validateAddress, validateBoundedAddresses } from '../utils/validations'
+
+export const MAX_VESTING_ADDRESSES_PER_REQUEST = 100
 
 export default routes((router) => {
+  // Public: vesting data is displayed without authentication. Bulk input is capped here and
+  // fallback RPC work is concurrency-limited in VestingService.
   router.get('/all-vestings', handleAPI(getAllVestings))
   router.post('/vesting', handleAPI(getVestings))
   router.get('/vesting/:address', handleAPI(getVesting))
@@ -17,8 +21,7 @@ async function getAllVestings() {
 }
 
 async function getVestings(req: Request<unknown, unknown, { addresses: string[] }>): Promise<VestingWithLogs[]> {
-  const addresses = req.body.addresses
-  addresses.forEach(validateAddress)
+  const addresses = validateBoundedAddresses(req.body?.addresses, MAX_VESTING_ADDRESSES_PER_REQUEST)
 
   return await VestingService.getVestings(addresses)
 }

--- a/src/server.ts
+++ b/src/server.ts
@@ -114,6 +114,9 @@ app.use('/api', [
 
 app.use(metrics([gatsbyRegister, register]))
 
+// Public: crawlers need these documents without authentication. Apply a dedicated limiter
+// because the sitemap router is mounted outside the /api middleware chain.
+app.use('/governance', withDDosProtection({ limit: 100, checkinterval: 4 }))
 app.use(sitemap)
 
 app.use('/api-docs', swaggerUi.serve, swaggerUi.setup(swaggerDocument))

--- a/src/services/VestingService.test.ts
+++ b/src/services/VestingService.test.ts
@@ -2,7 +2,7 @@ import { SubgraphVesting } from '../clients/VestingSubgraphTypes'
 import { VestingsSubgraph } from '../clients/VestingsSubgraph'
 import { VestingStatus } from '../entities/Grant/types'
 
-import { VestingService } from './VestingService'
+import { MAX_CONCURRENT_VESTING_FALLBACKS, VestingService } from './VestingService'
 
 const VESTING_ADDRESS = '0x1111111111111111111111111111111111111111'
 const OTHER_ADDRESS = '0x2222222222222222222222222222222222222222'
@@ -248,6 +248,37 @@ describe('VestingService', () => {
 
       it('should still return the one that could', () => {
         expect(result[0].address).toBe(VESTING_ADDRESS)
+      })
+    })
+
+    describe('when several addresses need the fallback', () => {
+      let addresses: string[]
+      let activeFallbacks: number
+      let maximumActiveFallbacks: number
+
+      beforeEach(async () => {
+        addresses = Array.from(
+          { length: MAX_CONCURRENT_VESTING_FALLBACKS + 1 },
+          (_, index) => `0x${(index + 1).toString(16).padStart(40, '0')}`
+        )
+        activeFallbacks = 0
+        maximumActiveFallbacks = 0
+        jest.spyOn(VestingsSubgraph, 'get').mockReturnValue({
+          getVestings: jest.fn().mockResolvedValue([]),
+        } as never)
+        jest.spyOn(VestingService, 'getVestingWithLogs').mockImplementation(async (address) => {
+          activeFallbacks += 1
+          maximumActiveFallbacks = Math.max(maximumActiveFallbacks, activeFallbacks)
+          await new Promise<void>((resolve) => setImmediate(resolve))
+          activeFallbacks -= 1
+          return { address, logs: [], start_at: new Date().toISOString() } as never
+        })
+
+        await VestingService.getVestings(addresses)
+      })
+
+      it('should limit concurrent fallback lookups', () => {
+        expect(maximumActiveFallbacks).toBe(MAX_CONCURRENT_VESTING_FALLBACKS)
       })
     })
   })

--- a/src/services/VestingService.ts
+++ b/src/services/VestingService.ts
@@ -18,6 +18,8 @@ import { ErrorCategory } from '../utils/errorCategories'
 import CacheService, { TTL_1_HS } from './CacheService'
 import { ErrorService } from './ErrorService'
 
+export const MAX_CONCURRENT_VESTING_FALLBACKS = 5
+
 export class VestingService {
   static async getAllVestings(): Promise<VestingWithLogs[]> {
     const cacheKey = `vesting-subgraph-data`
@@ -44,7 +46,12 @@ export class VestingService {
     const sgById = new Map(sg.map((v) => [v.id.toLowerCase(), v]))
     const missing = input.filter((a) => !sgById.has(a))
 
-    const fallback = await Promise.all(missing.map((a) => this.getVestingWithLogs(a).catch(() => null)))
+    const fallback: Array<VestingWithLogs | null> = []
+    for (let index = 0; index < missing.length; index += MAX_CONCURRENT_VESTING_FALLBACKS) {
+      const batch = missing.slice(index, index + MAX_CONCURRENT_VESTING_FALLBACKS)
+      const results = await Promise.all(batch.map((address) => this.getVestingWithLogs(address).catch(() => null)))
+      fallback.push(...results)
+    }
     const okFallback = fallback.filter((x): x is VestingWithLogs => x !== null)
 
     const parsedFromSubgraph = sg.map(this.parseSubgraphVesting)

--- a/src/utils/validations.ts
+++ b/src/utils/validations.ts
@@ -109,12 +109,15 @@ export const areValidAddresses = (addresses: string[]) =>
 // and reject non-address entries before forwarding. Tune the cap up if a genuine caller exceeds it.
 export const MAX_ADDRESSES_PER_REQUEST = 5000
 
-export function validateBoundedAddresses(addresses: unknown): string[] {
+export function validateBoundedAddresses(
+  addresses: unknown,
+  maxAddresses: number = MAX_ADDRESSES_PER_REQUEST
+): string[] {
   if (!Array.isArray(addresses)) {
     throw new RequestError('Invalid addresses', RequestError.BadRequest)
   }
-  if (addresses.length > MAX_ADDRESSES_PER_REQUEST) {
-    throw new RequestError(`Too many addresses: max ${MAX_ADDRESSES_PER_REQUEST} per request`, RequestError.BadRequest)
+  if (addresses.length > maxAddresses) {
+    throw new RequestError(`Too many addresses: max ${maxAddresses} per request`, RequestError.BadRequest)
   }
   validateAddresses(addresses)
   return addresses


### PR DESCRIPTION
## Summary

- cap public bulk vesting requests at 100 validated addresses
- limit fallback vesting RPC lookups to five concurrent calls
- reject malformed and out-of-range sitemap pages before issuing OFFSET queries
- apply dedicated rate limiting to public sitemap routes
- add regression coverage for request bounds, fallback concurrency, and sitemap pagination

## Security impact

Prevents unauthenticated callers from amplifying one vesting request into an unbounded number of concurrent Ethereum RPC calls, and prevents arbitrary sitemap offsets from creating expensive database scans outside the API rate limiter.

## Validation

- npm run build
- npm test: 60 suites passed, 994 tests passed, 1 skipped
- Prettier and ESLint commit hooks passed
- git diff --check