### PR TITLE
fix: harden account linking and the discord verification read

### DIFF
--- a/src/entities/User/model.ts
+++ b/src/entities/User/model.ts
@@ -76,10 +76,11 @@ export default class UserModel extends Model<UserAttributes> {
   }
 
   static async isValidated(address: string, accounts: Set<AccountType>): Promise<boolean> {
-    const columnMap: Record<AccountType, string> = {
+    // Push has no column here; it is left out so the guard below reports it rather than letting a
+    // placeholder name through into the query.
+    const columnMap: Partial<Record<AccountType, string>> = {
       [AccountType.Forum]: 'forum_id',
       [AccountType.Discord]: 'discord_id',
-      [AccountType.Push]: 'NOT_IMPLEMENTED',
     }
 
     if (accounts.size === 0) {

--- a/src/entities/User/types.ts
+++ b/src/entities/User/types.ts
@@ -19,6 +19,7 @@ export type UserProfile = Pick<
 export type ValidationMessage = {
   address: string
   timestamp: string
+  account: AccountType
   message_timeout: NodeJS.Timeout
 }
 

--- a/src/entities/User/utils.test.ts
+++ b/src/entities/User/utils.test.ts
@@ -1,11 +1,13 @@
+import { Wallet } from 'ethers'
+
 import { FORUM_URL } from '../../constants'
 import { DiscoursePostInTopic, DiscourseTopic } from '../../shared/types/discourse'
 import { ProposalCommentsInDiscourse } from '../Proposal/types'
 
 import { ONE_USER_POST, SEVERAL_USERS_POST, createWithPosts } from './__data__/discourse_samples'
 
-import { ValidationComment } from './types'
-import { DISCOURSE_USER, filterComments, getValidationComment } from './utils'
+import { AccountType, ValidationComment } from './types'
+import { DISCOURSE_USER, filterComments, formatValidationMessage, getValidationComment } from './utils'
 
 jest.mock('../../constants', () => ({
   FORUM_URL: 'https://forum.test.url',
@@ -85,19 +87,27 @@ describe('filterUserComments', () => {
 })
 
 describe('getValidationComment', () => {
-  const address = '0xf1e1c1d1a1b1c1d1e1f1a1b1c1d1e1f1a1b1c1d1'
   const timestamp = '2026-07-23T12:00:00.000Z'
+  let signer: Wallet
+  let address: string
+  let signedContent: string
 
-  describe('when exactly one recent comment contains the address and timestamp', () => {
-    let comments: ValidationComment[]
+  beforeEach(async () => {
+    signer = Wallet.createRandom()
+    address = signer.address
+    const message = formatValidationMessage(address, timestamp, AccountType.Discord)
+    signedContent = `${message}\n\n${await signer.signMessage(message)}`
+  })
+
+  describe('when exactly one recent comment carries a signature for the address', () => {
     let result: ValidationComment | undefined
 
     beforeEach(() => {
-      comments = [
+      const comments: ValidationComment[] = [
         { id: '1', userId: '100', content: 'unrelated chatter', timestamp: Date.now() },
-        { id: '2', userId: '200', content: `Linking ${address} Date: ${timestamp} 0xsignature`, timestamp: Date.now() },
+        { id: '2', userId: '200', content: signedContent, timestamp: Date.now() },
       ]
-      result = getValidationComment(comments, address, timestamp)
+      result = getValidationComment(comments, address, timestamp, AccountType.Discord)
     })
 
     it('should return the matching comment', () => {
@@ -106,12 +116,13 @@ describe('getValidationComment', () => {
   })
 
   describe('when no comment contains both the address and the timestamp', () => {
-    let comments: ValidationComment[]
     let result: ValidationComment | undefined
 
     beforeEach(() => {
-      comments = [{ id: '1', userId: '100', content: `Linking ${address} Date: 1999-01-01`, timestamp: Date.now() }]
-      result = getValidationComment(comments, address, timestamp)
+      const comments: ValidationComment[] = [
+        { id: '1', userId: '100', content: `Linking ${address} Date: 1999-01-01`, timestamp: Date.now() },
+      ]
+      result = getValidationComment(comments, address, timestamp, AccountType.Discord)
     })
 
     it('should return undefined', () => {
@@ -120,12 +131,11 @@ describe('getValidationComment', () => {
   })
 
   describe('when the only matching comment is older than the validation window', () => {
-    let comments: ValidationComment[]
     let result: ValidationComment | undefined
 
     beforeEach(() => {
-      comments = [{ id: '1', userId: '100', content: `Linking ${address} Date: ${timestamp}`, timestamp: 0 }]
-      result = getValidationComment(comments, address, timestamp)
+      const comments: ValidationComment[] = [{ id: '1', userId: '100', content: signedContent, timestamp: 0 }]
+      result = getValidationComment(comments, address, timestamp, AccountType.Discord)
     })
 
     it('should ignore it and return undefined', () => {
@@ -133,19 +143,145 @@ describe('getValidationComment', () => {
     })
   })
 
-  describe('when a second comment copies the same address and timestamp from another account', () => {
+  describe('when the comment carries the address and timestamp but no valid signature', () => {
+    let result: ValidationComment | undefined
+
+    beforeEach(() => {
+      const comments: ValidationComment[] = [
+        {
+          id: '1',
+          userId: '100',
+          content: `Linking ${address} Date: ${timestamp} 0xnotasignature`,
+          timestamp: Date.now(),
+        },
+      ]
+      result = getValidationComment(comments, address, timestamp, AccountType.Discord)
+    })
+
+    it('should not treat it as a candidate', () => {
+      expect(result).toBeUndefined()
+    })
+  })
+
+  // Well formed enough to be extracted, but recovery throws on it. That must be a rejected
+  // candidate rather than an error escaping to the caller as a 500.
+  describe('when the extracted signature cannot be recovered at all', () => {
+    let result: ValidationComment | undefined
+
+    beforeEach(() => {
+      const unrecoverable = `0x${'aa'.repeat(64)}05`
+      const comments: ValidationComment[] = [
+        {
+          id: '1',
+          userId: '100',
+          content: `Linking ${address} Date: ${timestamp} ${unrecoverable}`,
+          timestamp: Date.now(),
+        },
+      ]
+      result = getValidationComment(comments, address, timestamp, AccountType.Discord)
+    })
+
+    it('should return undefined instead of throwing', () => {
+      expect(result).toBeUndefined()
+    })
+  })
+
+  describe('when the signature belongs to a different address', () => {
+    let result: ValidationComment | undefined
+
+    beforeEach(async () => {
+      const other = Wallet.createRandom()
+      const message = formatValidationMessage(address, timestamp, AccountType.Discord)
+      const content = `${message}\n\n${await other.signMessage(message)}`
+      const comments: ValidationComment[] = [{ id: '1', userId: '100', content, timestamp: Date.now() }]
+      result = getValidationComment(comments, address, timestamp, AccountType.Discord)
+    })
+
+    it('should return undefined', () => {
+      expect(result).toBeUndefined()
+    })
+  })
+
+  describe('when another account reposts the signed message verbatim', () => {
     let action: () => ValidationComment | undefined
 
     beforeEach(() => {
       const comments: ValidationComment[] = [
-        { id: '1', userId: '200', content: `Linking ${address} Date: ${timestamp} 0xsignature`, timestamp: Date.now() },
-        { id: '2', userId: '999', content: `Linking ${address} Date: ${timestamp} 0xsignature`, timestamp: Date.now() },
+        { id: '2', userId: '999', content: signedContent, timestamp: Date.now() + 1200 },
+        { id: '1', userId: '200', content: signedContent, timestamp: Date.now() },
       ]
-      action = () => getValidationComment(comments, address, timestamp)
+      action = () => getValidationComment(comments, address, timestamp, AccountType.Discord)
     })
 
     it('should throw instead of linking an ambiguous account', () => {
       expect(action).toThrow('Multiple matching verification comments found')
+    })
+  })
+
+  describe('when the signer posts their own verification message twice', () => {
+    let result: ValidationComment | undefined
+
+    beforeEach(() => {
+      const comments: ValidationComment[] = [
+        { id: '2', userId: '200', content: signedContent, timestamp: Date.now() + 500 },
+        { id: '1', userId: '200', content: signedContent, timestamp: Date.now() },
+      ]
+      result = getValidationComment(comments, address, timestamp, AccountType.Discord)
+    })
+
+    it('should link that account rather than treat one account as ambiguous', () => {
+      expect(result?.userId).toBe('200')
+    })
+  })
+
+  describe('when matching comments carry no author id', () => {
+    let action: () => ValidationComment | undefined
+
+    beforeEach(() => {
+      const comments: ValidationComment[] = [
+        { id: '1', userId: '', content: signedContent, timestamp: Date.now() },
+        { id: '2', userId: '', content: signedContent, timestamp: Date.now() + 500 },
+      ]
+      action = () => getValidationComment(comments, address, timestamp, AccountType.Discord)
+    })
+
+    it('should ignore them rather than link an unattributable comment', () => {
+      expect(action()).toBeUndefined()
+    })
+  })
+
+  // A copy can be made to look older than the original, so age must not decide the winner.
+  describe('and the copy carries an earlier timestamp than the genuine message', () => {
+    let action: () => ValidationComment | undefined
+
+    beforeEach(() => {
+      const comments: ValidationComment[] = [
+        { id: '1', userId: '200', content: signedContent, timestamp: Date.now() },
+        { id: '2', userId: '999', content: signedContent, timestamp: Date.now() - 3000 },
+      ]
+      action = () => getValidationComment(comments, address, timestamp, AccountType.Discord)
+    })
+
+    it('should still refuse rather than prefer the older one', () => {
+      expect(action).toThrow('Multiple matching verification comments found')
+    })
+  })
+
+  // Only signature-valid comments are candidates, so the address and timestamp alone — both public
+  // the moment the genuine message is posted — cannot be used to make the match ambiguous.
+  describe('and an unsigned copy is posted to interfere with the link', () => {
+    let result: ValidationComment | undefined
+
+    beforeEach(() => {
+      const comments: ValidationComment[] = [
+        { id: '2', userId: '999', content: `Linking ${address} Date: ${timestamp}`, timestamp: Date.now() - 5000 },
+        { id: '1', userId: '200', content: signedContent, timestamp: Date.now() },
+      ]
+      result = getValidationComment(comments, address, timestamp, AccountType.Discord)
+    })
+
+    it('should ignore it and return the genuine signer', () => {
+      expect(result?.userId).toBe('200')
     })
   })
 })

--- a/src/entities/User/utils.ts
+++ b/src/entities/User/utils.ts
@@ -60,31 +60,57 @@ export function filterComments(
   }
 }
 
-export function formatValidationMessage(address: string, timestamp: string, account?: AccountType) {
-  return `By signing and posting this message I'm linking my Decentraland DAO account ${address} with this ${
-    account ? `${capitalize(account)} ` : ''
-  }account\n\nDate: ${timestamp}`
+// account is required: it is part of the string that gets signed, so omitting it here silently
+// makes every signature fail to verify instead of failing where the mistake was made.
+export function formatValidationMessage(address: string, timestamp: string, account: AccountType) {
+  return `By signing and posting this message I'm linking my Decentraland DAO account ${address} with this ${capitalize(
+    account
+  )} account\n\nDate: ${timestamp}`
 }
 
-export function getValidationComment(comments: ValidationComment[], address: string, timestamp: string) {
+// Named so the caller can tell deliberate interference apart from a generic validation failure.
+export class AmbiguousValidationError extends Error {
+  constructor() {
+    super('Multiple matching verification comments found; aborting to avoid linking the wrong account')
+    this.name = 'AmbiguousValidationError'
+  }
+}
+
+export function getValidationComment(
+  comments: ValidationComment[],
+  address: string,
+  timestamp: string,
+  account: AccountType
+) {
   const timeWindow = new Date(new Date().getTime() - MESSAGE_TIMEOUT_TIME)
   // escapeRegExp so the address/timestamp are matched literally (defense-in-depth against a
   // regex-injection/ReDoS if the source of these values ever changes to accept free-form input).
   const addressRegex = new RegExp(escapeRegExp(address), 'i')
   const dateRegex = new RegExp(escapeRegExp(timestamp), 'i')
 
-  const matchingComments = comments.filter((comment) => {
-    return (
-      new Date(comment.timestamp) > timeWindow && addressRegex.test(comment.content) && dateRegex.test(comment.content)
-    )
-  })
+  // The signature is checked here rather than by the caller so that a comment carrying the address
+  // and timestamp without a valid signature is simply not a candidate: anyone can copy those two
+  // public values, and letting them count would let a stranger interfere with someone else's link.
+  const matchingComments = comments.filter(
+    (comment) =>
+      // An unattributable comment cannot be linked to anything, and must not be able to pair with
+      // another one and read as two accounts.
+      !!comment.userId &&
+      new Date(comment.timestamp) > timeWindow &&
+      addressRegex.test(comment.content) &&
+      dateRegex.test(comment.content) &&
+      validateComment(comment, address, timestamp, account)
+  )
 
-  // Fail closed on ambiguity. The address, timestamp, and signature are all public the moment the
-  // user posts their verification comment, so anyone can copy them into a second comment from a
-  // different forum/Discord account. If more than one comment matches we cannot tell which account
-  // is the genuine owner, so we refuse to link rather than risk binding the wallet to an impersonator.
-  if (matchingComments.length > 1) {
-    throw new Error('Multiple matching verification comments found; aborting to avoid linking the wrong account')
+  // Refuse rather than choose. The signature is public once posted, so another account can carry a
+  // valid copy of it, and no timestamp identifies the original: discord keeps createdTimestamp on
+  // the snowflake when a message is edited, and discourse moves updated_at for reasons other than
+  // an edit. Anything that ranks these candidates can be steered, so nothing ranks them.
+  //
+  // Counted per account, not per comment: two posts from one account resolve to the same link, so
+  // someone who posts their own verification message twice is unambiguous and should still link.
+  if (new Set(matchingComments.map((comment) => comment.userId)).size > 1) {
+    throw new AmbiguousValidationError()
   }
 
   return matchingComments[0]
@@ -94,13 +120,24 @@ export function validateComment(
   validationComment: ValidationComment,
   address: string,
   timestamp: string,
-  account?: AccountType
+  account: AccountType
 ) {
   const signatureRegex = /0x([a-fA-F\d]{130})/
-  const signature = '0x' + validationComment.content.match(signatureRegex)?.[1]
-  const recoveredAddress = recoverAddress(hashMessage(formatValidationMessage(address, timestamp, account)), signature)
+  const signature = validationComment.content.match(signatureRegex)?.[1]
+  if (!signature) {
+    return false
+  }
 
-  return isSameAddress(recoveredAddress, address)
+  try {
+    const recoveredAddress = recoverAddress(
+      hashMessage(formatValidationMessage(address, timestamp, account)),
+      `0x${signature}`
+    )
+    return isSameAddress(recoveredAddress, address)
+  } catch {
+    // A malformed signature is a rejected candidate, not a server error.
+    return false
+  }
 }
 
 // Takes unknown rather than string: the value comes from a request body or query string, so it can

--- a/src/entities/User/utils.ts
+++ b/src/entities/User/utils.ts
@@ -76,6 +76,13 @@ export class AmbiguousValidationError extends Error {
   }
 }
 
+export class ValidationTimeoutError extends Error {
+  constructor() {
+    super('Validation timed out')
+    this.name = 'ValidationTimeoutError'
+  }
+}
+
 export function getValidationComment(
   comments: ValidationComment[],
   address: string,

--- a/src/routes/user.test.ts
+++ b/src/routes/user.test.ts
@@ -1,3 +1,4 @@
+import RequestError from 'decentraland-gatsby/dist/entities/Route/error'
 import { Server } from 'http'
 import supertest from 'supertest'
 
@@ -87,23 +88,51 @@ describe('the user routes', () => {
       })
     })
 
+    // The account type is part of the signed message, so a message issued without one could never
+    // validate against either flow.
     describe('when no account is named', () => {
+      let response: supertest.Response
+
       beforeEach(async () => {
-        await supertest(app).get('/api/user/validate').set('x-test-auth', CALLER)
+        response = await supertest(app).get('/api/user/validate').set('x-test-auth', CALLER)
       })
 
-      it('should ask without one', () => {
-        expect(getValidationMessage).toHaveBeenCalledWith(CALLER, undefined)
+      it('should respond with a 400', () => {
+        expect(response.status).toBe(400)
+      })
+
+      it('should not build a message', () => {
+        expect(getValidationMessage).not.toHaveBeenCalled()
       })
     })
 
     describe('when the account is repeated in the query', () => {
+      let response: supertest.Response
+
       beforeEach(async () => {
-        await supertest(app).get('/api/user/validate?account=forum&account=discord').set('x-test-auth', CALLER)
+        response = await supertest(app)
+          .get('/api/user/validate?account=forum&account=discord')
+          .set('x-test-auth', CALLER)
       })
 
-      it('should ignore the array rather than pass one through', () => {
-        expect(getValidationMessage).toHaveBeenCalledWith(CALLER, undefined)
+      it('should respond with a 400', () => {
+        expect(response.status).toBe(400)
+      })
+
+      it('should not build a message', () => {
+        expect(getValidationMessage).not.toHaveBeenCalled()
+      })
+    })
+
+    describe('when the named account cannot be linked by signature', () => {
+      let response: supertest.Response
+
+      beforeEach(async () => {
+        response = await supertest(app).get(`/api/user/validate?account=${AccountType.Push}`).set('x-test-auth', CALLER)
+      })
+
+      it('should respond with a 400', () => {
+        expect(response.status).toBe(400)
       })
     })
   })
@@ -127,6 +156,31 @@ describe('the user routes', () => {
         expect(validateForumUser).toHaveBeenCalledWith(CALLER)
       })
     })
+
+    describe('when multiple forum accounts post the same valid verification', () => {
+      let response: supertest.Response
+
+      beforeEach(async () => {
+        validateForumUser.mockRejectedValueOnce(
+          new RequestError('Multiple forum accounts posted the same valid verification message', 409, {
+            code: 'ambiguous_validation',
+          })
+        )
+        response = await supertest(app).post('/api/user/validate/forum').set('x-test-auth', CALLER)
+      })
+
+      it('should respond with a conflict', () => {
+        expect(response.status).toBe(409)
+      })
+
+      it('should identify the ambiguous validation in the response body', () => {
+        expect(response.body).toEqual({
+          ok: false,
+          error: 'Multiple forum accounts posted the same valid verification message',
+          code: 'ambiguous_validation',
+        })
+      })
+    })
   })
 
   describe('POST /api/user/validate/discord', () => {
@@ -146,6 +200,31 @@ describe('the user routes', () => {
 
       it('should link the authenticated address, not the one supplied', () => {
         expect(validateDiscordUser).toHaveBeenCalledWith(CALLER)
+      })
+    })
+
+    describe('when multiple Discord accounts post the same valid verification', () => {
+      let response: supertest.Response
+
+      beforeEach(async () => {
+        validateDiscordUser.mockRejectedValueOnce(
+          new RequestError('Multiple Discord accounts posted the same valid verification message', 409, {
+            code: 'ambiguous_validation',
+          })
+        )
+        response = await supertest(app).post('/api/user/validate/discord').set('x-test-auth', CALLER)
+      })
+
+      it('should respond with a conflict', () => {
+        expect(response.status).toBe(409)
+      })
+
+      it('should identify the ambiguous validation in the response body', () => {
+        expect(response.body).toEqual({
+          ok: false,
+          error: 'Multiple Discord accounts posted the same valid verification message',
+          code: 'ambiguous_validation',
+        })
       })
     })
   })

--- a/src/routes/user.test.ts
+++ b/src/routes/user.test.ts
@@ -268,6 +268,27 @@ describe('the user routes', () => {
       })
     })
 
+    describe('when the Discord verification history cannot be read completely', () => {
+      let response: supertest.Response
+
+      beforeEach(async () => {
+        validateDiscordUser.mockRejectedValueOnce(
+          new RequestError('Could not read the complete Discord verification history; please retry', 503, {
+            code: 'validation_source_incomplete',
+          })
+        )
+        response = await supertest(app).post('/api/user/validate/discord').set('x-test-auth', CALLER)
+      })
+
+      it('should respond with a retryable service-unavailable status', () => {
+        expect(response.status).toBe(503)
+      })
+
+      it('should identify the incomplete validation source', () => {
+        expect(response.body.code).toBe('validation_source_incomplete')
+      })
+    })
+
     describe('when the Discord validation window has expired', () => {
       let response: supertest.Response
 

--- a/src/routes/user.test.ts
+++ b/src/routes/user.test.ts
@@ -181,6 +181,46 @@ describe('the user routes', () => {
         })
       })
     })
+
+    describe('when the forum verification history cannot be read completely', () => {
+      let response: supertest.Response
+
+      beforeEach(async () => {
+        validateForumUser.mockRejectedValueOnce(
+          new RequestError('Could not read the complete forum verification history; please retry', 503, {
+            code: 'validation_source_incomplete',
+          })
+        )
+        response = await supertest(app).post('/api/user/validate/forum').set('x-test-auth', CALLER)
+      })
+
+      it('should respond with a retryable service-unavailable status', () => {
+        expect(response.status).toBe(503)
+      })
+
+      it('should identify the incomplete validation source', () => {
+        expect(response.body.code).toBe('validation_source_incomplete')
+      })
+    })
+
+    describe('when the forum validation window has expired', () => {
+      let response: supertest.Response
+
+      beforeEach(async () => {
+        validateForumUser.mockRejectedValueOnce(
+          new RequestError('Validation timed out', 408, { code: 'validation_timeout' })
+        )
+        response = await supertest(app).post('/api/user/validate/forum').set('x-test-auth', CALLER)
+      })
+
+      it('should respond with a request-timeout status', () => {
+        expect(response.status).toBe(408)
+      })
+
+      it('should identify the expired validation window', () => {
+        expect(response.body.code).toBe('validation_timeout')
+      })
+    })
   })
 
   describe('POST /api/user/validate/discord', () => {
@@ -225,6 +265,25 @@ describe('the user routes', () => {
           error: 'Multiple Discord accounts posted the same valid verification message',
           code: 'ambiguous_validation',
         })
+      })
+    })
+
+    describe('when the Discord validation window has expired', () => {
+      let response: supertest.Response
+
+      beforeEach(async () => {
+        validateDiscordUser.mockRejectedValueOnce(
+          new RequestError('Validation timed out', 408, { code: 'validation_timeout' })
+        )
+        response = await supertest(app).post('/api/user/validate/discord').set('x-test-auth', CALLER)
+      })
+
+      it('should respond with a request-timeout status', () => {
+        expect(response.status).toBe(408)
+      })
+
+      it('should identify the expired validation window', () => {
+        expect(response.body.code).toBe('validation_timeout')
       })
     })
   })

--- a/src/routes/user.ts
+++ b/src/routes/user.ts
@@ -9,6 +9,9 @@ import { validateAccountTypes } from '../entities/User/utils'
 import { UserService } from '../services/user'
 import { validateAddress } from '../utils/validations'
 
+// Push is a subscription held elsewhere, so it is neither linked by signature nor unlinked here.
+const LINKABLE_ACCOUNTS = new Set([AccountType.Forum, AccountType.Discord])
+
 export default routes((route) => {
   const withAuth = auth()
   route.get('/user/validate', withAuth, handleAPI(getValidationMessage))
@@ -24,9 +27,17 @@ export default routes((route) => {
 
 async function getValidationMessage(req: WithAuth) {
   const address = req.auth!
-  const account = typeof req.query.account === 'string' ? req.query.account : undefined
+  // The account type is part of the message that gets signed, so a message issued without one can
+  // never validate against either flow. Refuse instead of handing back an unusable message.
+  if (Array.isArray(req.query.account)) {
+    throw new RequestError('Only one account can be validated at a time', RequestError.BadRequest)
+  }
+  const accounts = validateAccountTypes(req.query.account)
+  if (!LINKABLE_ACCOUNTS.has(accounts[0])) {
+    throw new RequestError(`Account type ${accounts[0]} cannot be validated this way`, RequestError.BadRequest)
+  }
 
-  return UserService.getValidationMessage(address, account)
+  return UserService.getValidationMessage(address, accounts[0])
 }
 
 async function validateForumUser(req: WithAuth) {
@@ -69,8 +80,6 @@ async function getProfile(req: Request): Promise<UserProfile> {
   return await UserService.getProfile(address)
 }
 
-const UNLINKABLE_ACCOUNTS = new Set([AccountType.Forum, AccountType.Discord])
-
 async function unlinkAccount(req: WithAuth) {
   const address = req.auth!
   const { accountType } = req.body
@@ -84,7 +93,7 @@ async function unlinkAccount(req: WithAuth) {
   // Not every account type can be unlinked: the query behind this only clears the forum and discord
   // columns, and push is a subscription held elsewhere. Refuse here rather than let it reach a
   // switch that has no case for it.
-  if (!UNLINKABLE_ACCOUNTS.has(accounts[0])) {
+  if (!LINKABLE_ACCOUNTS.has(accounts[0])) {
     throw new RequestError(`Account type ${accounts[0]} cannot be unlinked`, RequestError.BadRequest)
   }
   return await UserService.unlinkAccount(address, accounts[0])

--- a/src/services/DiscourseService.comments.test.ts
+++ b/src/services/DiscourseService.comments.test.ts
@@ -1,0 +1,184 @@
+import { Wallet } from 'ethers'
+
+import { Discourse } from '../clients/Discourse'
+import UserModel from '../entities/User/model'
+import { AccountType } from '../entities/User/types'
+import { DiscoursePostInTopic } from '../shared/types/discourse'
+import logger from '../utils/logger'
+
+import { DiscourseService, IncompleteDiscourseCommentsError } from './DiscourseService'
+import { UserService } from './user'
+
+jest.mock('../entities/User/model', () => ({
+  __esModule: true,
+  default: {
+    createDiscordConnection: jest.fn(),
+    createForumConnection: jest.fn(),
+    getAddressesByForumId: jest.fn(),
+  },
+}))
+
+const TOPIC_ID = 123
+const BATCH_SIZE = 20
+
+function createPost(id: number): DiscoursePostInTopic {
+  return {
+    id,
+    username: `user-${id}`,
+    user_id: id,
+    avatar_template: '/avatar/{size}.png',
+    created_at: new Date().toISOString(),
+    cooked: `comment-${id}`,
+  } as DiscoursePostInTopic
+}
+
+describe('DiscourseService.getPostComments', () => {
+  let getTopic: jest.Mock
+  let getPosts: jest.Mock
+  let initialPosts: DiscoursePostInTopic[]
+  let remainingPost: DiscoursePostInTopic
+
+  beforeEach(() => {
+    initialPosts = Array.from({ length: BATCH_SIZE }, (_, index) => createPost(index + 1))
+    remainingPost = createPost(BATCH_SIZE + 1)
+    getTopic = jest.fn().mockResolvedValue({
+      post_stream: {
+        stream: [...initialPosts.map((post) => post.id), remainingPost.id],
+        posts: initialPosts,
+      },
+    })
+    getPosts = jest.fn()
+    jest.spyOn(Discourse, 'get').mockReturnValue({ getTopic, getPosts } as never)
+    jest.spyOn(logger, 'error').mockImplementation(() => undefined)
+    ;(UserModel.getAddressesByForumId as jest.Mock).mockResolvedValue([])
+  })
+
+  afterEach(() => {
+    const validations = (
+      UserService as unknown as {
+        VALIDATIONS_IN_PROGRESS: Record<string, { message_timeout: NodeJS.Timeout }>
+      }
+    ).VALIDATIONS_IN_PROGRESS
+    Object.keys(validations).forEach((key) => {
+      clearTimeout(validations[key].message_timeout)
+      delete validations[key]
+    })
+    jest.restoreAllMocks()
+    jest.clearAllMocks()
+  })
+
+  describe('when a pagination request fails', () => {
+    beforeEach(() => {
+      getPosts.mockRejectedValue(new Error('Discourse unavailable'))
+    })
+
+    describe('and complete comments are required', () => {
+      let thrown: Error
+
+      beforeEach(async () => {
+        thrown = (await DiscourseService.getPostComments(TOPIC_ID, { requireComplete: true }).catch(
+          (error: Error) => error
+        )) as Error
+      })
+
+      it('should reject the partial comment set', () => {
+        expect(thrown).toBeInstanceOf(IncompleteDiscourseCommentsError)
+      })
+
+      it('should not resolve forum addresses for partial comments', () => {
+        expect(UserModel.getAddressesByForumId).not.toHaveBeenCalled()
+      })
+    })
+
+    describe('and best-effort comments are allowed', () => {
+      let totalComments: number
+
+      beforeEach(async () => {
+        const result = await DiscourseService.getPostComments(TOPIC_ID)
+        totalComments = result.totalComments
+      })
+
+      it('should return the comments fetched before the failure', () => {
+        expect(totalComments).toBe(BATCH_SIZE)
+      })
+    })
+  })
+
+  describe('when the initial topic response omits a streamed post', () => {
+    let thrown: Error
+
+    beforeEach(async () => {
+      getTopic.mockResolvedValue({
+        post_stream: {
+          stream: initialPosts.map((post) => post.id),
+          posts: initialPosts.slice(0, BATCH_SIZE - 1),
+        },
+      })
+      thrown = (await DiscourseService.getPostComments(TOPIC_ID, { requireComplete: true }).catch(
+        (error: Error) => error
+      )) as Error
+    })
+
+    it('should reject the incomplete response', () => {
+      expect(thrown).toBeInstanceOf(IncompleteDiscourseCommentsError)
+    })
+  })
+
+  describe('when a pagination response omits a requested post', () => {
+    let thrown: Error
+
+    beforeEach(async () => {
+      getPosts.mockResolvedValue({ post_stream: { posts: [] } })
+      thrown = (await DiscourseService.getPostComments(TOPIC_ID, { requireComplete: true }).catch(
+        (error: Error) => error
+      )) as Error
+    })
+
+    it('should reject the incomplete response', () => {
+      expect(thrown).toBeInstanceOf(IncompleteDiscourseCommentsError)
+    })
+  })
+
+  describe('when every requested post is returned', () => {
+    let totalComments: number
+
+    beforeEach(async () => {
+      getPosts.mockResolvedValue({ post_stream: { posts: [remainingPost] } })
+      const result = await DiscourseService.getPostComments(TOPIC_ID, { requireComplete: true })
+      totalComments = result.totalComments
+    })
+
+    it('should return the complete comment set', () => {
+      expect(totalComments).toBe(BATCH_SIZE + 1)
+    })
+  })
+
+  describe('when matching signed comments belong to accounts in different pages', () => {
+    let thrown: Error
+
+    beforeEach(async () => {
+      const signer = Wallet.createRandom()
+      const message = UserService.getValidationMessage(signer.address, AccountType.Forum)
+      const posted = `${message}\n\n${await signer.signMessage(message)}`
+      initialPosts[0] = { ...initialPosts[0], cooked: posted, user_id: 100 }
+      remainingPost = { ...remainingPost, cooked: posted, user_id: 200 }
+      getTopic.mockResolvedValue({
+        post_stream: {
+          stream: [...initialPosts.map((post) => post.id), remainingPost.id],
+          posts: initialPosts,
+        },
+      })
+      getPosts.mockResolvedValue({ post_stream: { posts: [remainingPost] } })
+
+      thrown = (await UserService.validateForumUser(signer.address).catch((error: Error) => error)) as Error
+    })
+
+    it('should reject the cross-page match as ambiguous', () => {
+      expect(thrown.message).toBe('Multiple forum accounts posted the same valid verification message')
+    })
+
+    it('should not link either forum account', () => {
+      expect(UserModel.createForumConnection).not.toHaveBeenCalled()
+    })
+  })
+})

--- a/src/services/DiscourseService.comments.test.ts
+++ b/src/services/DiscourseService.comments.test.ts
@@ -104,6 +104,38 @@ describe('DiscourseService.getPostComments', () => {
     })
   })
 
+  describe('when the initial topic request fails', () => {
+    beforeEach(() => {
+      getTopic.mockRejectedValue(new Error('Discourse unavailable'))
+    })
+
+    describe('and complete comments are required', () => {
+      let thrown: Error
+
+      beforeEach(async () => {
+        thrown = (await DiscourseService.getPostComments(TOPIC_ID, { requireComplete: true }).catch(
+          (error: Error) => error
+        )) as Error
+      })
+
+      it('should reject with an incomplete-source error', () => {
+        expect(thrown).toBeInstanceOf(IncompleteDiscourseCommentsError)
+      })
+    })
+
+    describe('and best-effort comments are allowed', () => {
+      let thrown: Error
+
+      beforeEach(async () => {
+        thrown = (await DiscourseService.getPostComments(TOPIC_ID).catch((error: Error) => error)) as Error
+      })
+
+      it('should preserve the upstream failure', () => {
+        expect(thrown.message).toBe('Discourse unavailable')
+      })
+    })
+  })
+
   describe('when the initial topic response omits a streamed post', () => {
     let thrown: Error
 

--- a/src/services/DiscourseService.ts
+++ b/src/services/DiscourseService.ts
@@ -23,6 +23,17 @@ import { ErrorService } from './ErrorService'
 import { ProposalInCreation } from './ProposalService'
 import { SnapshotService } from './SnapshotService'
 
+type GetPostCommentsOptions = {
+  requireComplete?: boolean
+}
+
+export class IncompleteDiscourseCommentsError extends Error {
+  constructor(discourseTopicId: number) {
+    super(`Could not fetch every comment for Discourse topic ${discourseTopicId}`)
+    this.name = 'IncompleteDiscourseCommentsError'
+  }
+}
+
 export class DiscourseService {
   private static async createPostWithRetry(post: DiscourseNewPost, retries = 3): Promise<DiscoursePost> {
     try {
@@ -141,10 +152,17 @@ export class DiscourseService {
     })
   }
 
-  static async getPostComments(discourseTopicId: number) {
+  static async getPostComments(discourseTopicId: number, { requireComplete = false }: GetPostCommentsOptions = {}) {
     const DISCOURSE_BATCH_SIZE = 20
     const topic = await Discourse.get().getTopic(discourseTopicId)
     let allComments: DiscoursePostInTopic[] = topic.post_stream.posts //first 20
+    if (requireComplete) {
+      const returnedPostIds = new Set(allComments.map((comment) => comment.id))
+      const initialPostIds = topic.post_stream.stream.slice(0, DISCOURSE_BATCH_SIZE)
+      if (initialPostIds.some((postId) => !returnedPostIds.has(postId))) {
+        throw new IncompleteDiscourseCommentsError(discourseTopicId)
+      }
+    }
     let skip = DISCOURSE_BATCH_SIZE
     if (topic.post_stream.stream.length > DISCOURSE_BATCH_SIZE) {
       let hasNext = true
@@ -154,6 +172,12 @@ export class DiscourseService {
           if (postIds.length === 0) break
           const newPostsResponse = await Discourse.get().getPosts(discourseTopicId, postIds)
           const newComments = newPostsResponse.post_stream.posts
+          if (requireComplete) {
+            const returnedPostIds = new Set(newComments.map((comment) => comment.id))
+            if (postIds.some((postId) => !returnedPostIds.has(postId))) {
+              throw new IncompleteDiscourseCommentsError(discourseTopicId)
+            }
+          }
           allComments = [...allComments, ...newComments]
           if (newComments.length < DISCOURSE_BATCH_SIZE) {
             hasNext = false
@@ -162,7 +186,13 @@ export class DiscourseService {
           }
         }
       } catch (error) {
-        console.error(`Error while fetching discourse posts in batches: `, error)
+        logger.error('Error while fetching Discourse posts in batches', {
+          discourseTopicId,
+          error: `${error}`,
+        })
+        if (requireComplete) {
+          throw new IncompleteDiscourseCommentsError(discourseTopicId)
+        }
       }
     }
 

--- a/src/services/DiscourseService.ts
+++ b/src/services/DiscourseService.ts
@@ -154,7 +154,18 @@ export class DiscourseService {
 
   static async getPostComments(discourseTopicId: number, { requireComplete = false }: GetPostCommentsOptions = {}) {
     const DISCOURSE_BATCH_SIZE = 20
-    const topic = await Discourse.get().getTopic(discourseTopicId)
+    const topic = await Discourse.get()
+      .getTopic(discourseTopicId)
+      .catch((error) => {
+        logger.error('Error while fetching the initial Discourse topic', {
+          discourseTopicId,
+          error: `${error}`,
+        })
+        if (requireComplete) {
+          throw new IncompleteDiscourseCommentsError(discourseTopicId)
+        }
+        throw error
+      })
     let allComments: DiscoursePostInTopic[] = topic.post_stream.posts //first 20
     if (requireComplete) {
       const returnedPostIds = new Set(allComments.map((comment) => comment.id))

--- a/src/services/discord.init.test.ts
+++ b/src/services/discord.init.test.ts
@@ -1,0 +1,70 @@
+const login = jest.fn()
+const on = jest.fn()
+
+jest.mock('discord.js', () => {
+  const actual = jest.requireActual('discord.js')
+  return {
+    ...actual,
+    Client: jest.fn().mockImplementation(() => ({ on, login })),
+  }
+})
+
+jest.mock('../constants', () => ({
+  ...jest.requireActual('../constants'),
+  DISCORD_SERVICE_ENABLED: true,
+}))
+
+// Both read into module constants at import time.
+process.env.DISCORD_TOKEN = 'test-token'
+
+// eslint-disable-next-line @typescript-eslint/no-var-requires
+const { DiscordService } = require('./discord')
+
+describe('DiscordService.init', () => {
+  let consoleError: jest.SpyInstance
+
+  beforeEach(() => {
+    jest.clearAllMocks()
+    consoleError = jest.spyOn(console, 'error').mockImplementation(() => undefined)
+  })
+
+  afterEach(() => {
+    jest.restoreAllMocks()
+  })
+
+  // Nothing in the process handles unhandled rejections, so an uncaught login failure would
+  // terminate the whole server rather than leaving discord disabled.
+  describe('when logging in fails', () => {
+    let loginError: Error
+
+    beforeEach(async () => {
+      loginError = new Error('An invalid token was provided')
+      login.mockRejectedValueOnce(loginError)
+      DiscordService.init()
+      // Let the rejection settle; an unhandled one would surface here rather than at exit.
+      await new Promise((resolve) => setImmediate(resolve))
+    })
+
+    it('should report the failure instead of leaving the rejection unhandled', () => {
+      expect(consoleError).toHaveBeenCalledWith('Discord client login failed', loginError)
+    })
+  })
+
+  describe('when the client is constructed', () => {
+    beforeEach(() => {
+      login.mockResolvedValueOnce(undefined)
+      DiscordService.init()
+    })
+
+    it('should listen for the error event the client actually emits', () => {
+      expect(on).toHaveBeenCalledWith('error', expect.any(Function))
+    })
+
+    it('should report what that listener receives', () => {
+      const clientError = new Error('gateway exploded')
+      const listener = on.mock.calls.find(([event]) => event === 'error')?.[1]
+      listener(clientError)
+      expect(consoleError).toHaveBeenCalledWith('Error in Discord client', clientError)
+    })
+  })
+})

--- a/src/services/discord.ts
+++ b/src/services/discord.ts
@@ -6,6 +6,7 @@ import { ProposalWithOutcome } from '../entities/Proposal/outcome'
 import { ProposalStatus, ProposalType } from '../entities/Proposal/types'
 import { isGovernanceProcessProposal, proposalUrl } from '../entities/Proposal/utils'
 import { getPublicUpdates, getUpdateNumber, getUpdateUrl } from '../entities/Updates/utils'
+import { MESSAGE_TIMEOUT_TIME } from '../entities/User/constants'
 import UserModel from '../entities/User/model'
 import { getEnumDisplayName, inBackground } from '../helpers'
 import { ErrorService } from '../services/ErrorService'
@@ -25,6 +26,11 @@ const DCL_LOGO = 'https://decentraland.org/images/decentraland.png'
 const DEFAULT_AVATAR = 'https://decentraland.org/images/male.png'
 const BLANK = '\u200B'
 const PREVIEW_MAX_LENGTH = 140
+// Discord caps one fetch at 100; five pages covers any burst the channel's rate limits allow.
+const VERIFICATION_FETCH_PAGE_SIZE = 100
+const VERIFICATION_FETCH_MAX_PAGES = 5
+// Short enough that a message posted now is still picked up well inside the ten second poll.
+const VERIFICATION_FETCH_CACHE_TTL = 3000
 
 type Field = {
   name: string
@@ -69,6 +75,9 @@ function getChoices(choices: string[]): Field[] {
 
 export class DiscordService {
   private static client: Client
+  private static verificationMessagesCache?: { messages: Discord.Message<true>[]; expiresAt: number }
+  private static verificationMessagesRequest?: Promise<Discord.Message<true>[]>
+
   static init() {
     if (!DISCORD_SERVICE_ENABLED) {
       console.log('Discord service disabled')
@@ -86,17 +95,43 @@ export class DiscordService {
         Discord.GatewayIntentBits.MessageContent,
       ],
     })
-    this.client.on('unhandledRejection', (error) => {
-      if (isProdEnv()) {
-        ErrorService.report('Unhandled rejection in Discord client', {
-          error,
-          category: ErrorCategory.Discord,
-        })
-      } else {
-        console.error('Unhandled rejection in Discord client', error)
-      }
+    // 'error' is the client's own failure event. The previous listener was registered for
+    // 'unhandledRejection', which discord.js never emits, so nothing here was ever reported.
+    this.client.on('error', (error) => {
+      this.reportError('Error in Discord client', error)
     })
-    this.client.login(TOKEN)
+
+    // Never leave this rejection unhandled: nothing in the process catches it, so a rejected login
+    // (revoked or malformed token) would terminate the whole server rather than disable Discord.
+    this.client.login(TOKEN).catch((error) => {
+      this.reportError('Discord client login failed', error)
+    })
+  }
+
+  private static reportError(message: string, error: unknown) {
+    if (isProdEnv()) {
+      ErrorService.report(message, { error: `${error}`, category: ErrorCategory.Discord })
+    } else {
+      console.error(message, error)
+    }
+  }
+
+  // channels.cache is only populated for channels the gateway has already delivered, so a cold
+  // start or a reconnect turns a cache read into a silent failure. Fetch falls back to the api.
+  private static async fetchTextChannel(channelId: string) {
+    if (!channelId) {
+      throw new Error('Discord channel ID not set')
+    }
+
+    const channel = await this.client.channels.fetch(channelId)
+    if (!channel) {
+      throw new Error(`Discord channel not found: ${channelId}`)
+    }
+    if (channel.type !== Discord.ChannelType.GuildText) {
+      throw new Error(`Discord channel type is not supported: ${channel.type}`)
+    }
+
+    return channel
   }
 
   private static get channel() {
@@ -331,28 +366,92 @@ export class DiscordService {
     }
   }
 
-  static async getProfileVerificationMessages() {
-    if (DISCORD_SERVICE_ENABLED) {
-      try {
-        const channel = this.client.channels.cache.get(PROFILE_VERIFICATION_CHANNEL_ID)
-        if (!channel) {
-          throw new Error(`Discord channel not found: ${PROFILE_VERIFICATION_CHANNEL_ID}`)
-        }
-        if (channel?.type !== Discord.ChannelType.GuildText) {
-          throw new Error(`Discord channel type is not supported: ${channel?.type}`)
-        }
-        const messages = (await channel.messages.fetch({ limit: 10 })).filter((message) => !message.author.bot)
-        return messages.map((message) => message)
-      } catch (error) {
-        if (isProdEnv()) {
-          ErrorService.report('Error getting profile verification messages', {
-            error,
-            category: ErrorCategory.Discord,
-          })
-        } else {
-          console.error('Error getting profile verification message', error)
-        }
+  static async getProfileVerificationMessages(): Promise<Discord.Message<true>[]> {
+    if (!DISCORD_SERVICE_ENABLED) {
+      return []
+    }
+
+    if (this.verificationMessagesCache && this.verificationMessagesCache.expiresAt > Date.now()) {
+      return this.verificationMessagesCache.messages
+    }
+
+    if (this.verificationMessagesRequest) {
+      return await this.verificationMessagesRequest
+    }
+
+    const request = this.fetchProfileVerificationMessages()
+    this.verificationMessagesRequest = request
+    try {
+      return await request
+    } finally {
+      if (this.verificationMessagesRequest === request) {
+        this.verificationMessagesRequest = undefined
       }
+    }
+  }
+
+  private static async fetchProfileVerificationMessages(): Promise<Discord.Message<true>[]> {
+    try {
+      const channel = await this.fetchTextChannel(PROFILE_VERIFICATION_CHANNEL_ID)
+
+      // Bounded by the validation window, not by a message count: posting after a pending
+      // verification message must not push it out of view and hide it from the ambiguity check.
+      const oldestRelevantTimestamp = Date.now() - MESSAGE_TIMEOUT_TIME
+      const messages: Discord.Message<true>[] = []
+      let before: Snowflake | undefined
+
+      // Paged rather than unbounded, so a flooded channel cannot turn one poll into an unbounded
+      // number of api calls.
+      let readWholeWindow = false
+      for (let page = 0; page < VERIFICATION_FETCH_MAX_PAGES; page++) {
+        const batch = await channel.messages.fetch({ limit: VERIFICATION_FETCH_PAGE_SIZE, before })
+        if (batch.size === 0) {
+          readWholeWindow = true
+          break
+        }
+
+        messages.push(...batch.values())
+
+        // A short page means there is nothing older left to read, so the window is covered even
+        // if its oldest message is still inside it.
+        if (batch.size < VERIFICATION_FETCH_PAGE_SIZE) {
+          readWholeWindow = true
+          break
+        }
+
+        const oldestInBatch = batch.last()
+        if (!oldestInBatch || oldestInBatch.createdTimestamp <= oldestRelevantTimestamp) {
+          readWholeWindow = true
+          break
+        }
+        before = oldestInBatch.id
+      }
+
+      // Out of pages with the window still not covered. A partial read is taken from the newest
+      // end, so it can hold a copy of a verification message while hiding the older original it
+      // was copied from — exactly what the ambiguity check needs to see. Answer with nothing
+      // rather than with a subset. Callers keep polling, so a link still succeeds once the
+      // channel settles. The refusal is cached like any other answer, otherwise a channel kept
+      // above the budget would make every poll spend the whole page budget again.
+      if (!readWholeWindow) {
+        this.reportError(
+          'Verification channel window did not fit the fetch budget',
+          new Error(`more than ${VERIFICATION_FETCH_PAGE_SIZE * VERIFICATION_FETCH_MAX_PAGES} messages in the window`)
+        )
+        this.verificationMessagesCache = { messages: [], expiresAt: Date.now() + VERIFICATION_FETCH_CACHE_TTL }
+        return []
+      }
+
+      const relevant = messages.filter(
+        (message) => !message.author.bot && message.createdTimestamp > oldestRelevantTimestamp
+      )
+      this.verificationMessagesCache = {
+        messages: relevant,
+        expiresAt: Date.now() + VERIFICATION_FETCH_CACHE_TTL,
+      }
+      return relevant
+    } catch (error) {
+      this.reportError('Error getting profile verification messages', error)
     }
     return []
   }
@@ -360,23 +459,13 @@ export class DiscordService {
   static async deleteVerificationMessage(messageId: string) {
     if (DISCORD_SERVICE_ENABLED) {
       try {
-        const channel = this.client.channels.cache.get(PROFILE_VERIFICATION_CHANNEL_ID)
-        if (!channel) {
-          throw new Error(`Discord channel not found: ${PROFILE_VERIFICATION_CHANNEL_ID}`)
-        }
-        if (channel?.type !== Discord.ChannelType.GuildText) {
-          throw new Error(`Discord channel type is not supported: ${channel?.type}`)
-        }
+        const channel = await this.fetchTextChannel(PROFILE_VERIFICATION_CHANNEL_ID)
+        // Dropped before the delete, so a failed delete does not leave a window cached as if the
+        // message were still there in a state we no longer know.
+        this.verificationMessagesCache = undefined
         await channel.messages.delete(messageId)
       } catch (error) {
-        if (isProdEnv()) {
-          ErrorService.report('Error deleting profile verification message', {
-            error,
-            category: ErrorCategory.Discord,
-          })
-        } else {
-          console.error('Error deleting profile verification message', error)
-        }
+        this.reportError('Error deleting profile verification message', error)
       }
     }
   }

--- a/src/services/discord.ts
+++ b/src/services/discord.ts
@@ -30,7 +30,7 @@ const PREVIEW_MAX_LENGTH = 140
 const VERIFICATION_FETCH_PAGE_SIZE = 100
 const VERIFICATION_FETCH_MAX_PAGES = 5
 // Short enough that a message posted now is still picked up well inside the ten second poll.
-const VERIFICATION_FETCH_CACHE_TTL = 3000
+const VERIFICATION_FETCH_FAILURE_CACHE_TTL = 3000
 
 type Field = {
   name: string
@@ -82,11 +82,7 @@ export class IncompleteDiscordVerificationReadError extends Error {
 
 export class DiscordService {
   private static client: Client
-  private static verificationMessagesCache?: {
-    messages: Discord.Message<true>[]
-    expiresAt: number
-    complete: boolean
-  }
+  private static verificationMessagesFailureCacheExpiresAt?: number
   private static verificationMessagesRequest?: Promise<Discord.Message<true>[]>
 
   static init() {
@@ -382,11 +378,8 @@ export class DiscordService {
       throw new IncompleteDiscordVerificationReadError()
     }
 
-    if (this.verificationMessagesCache && this.verificationMessagesCache.expiresAt > Date.now()) {
-      if (!this.verificationMessagesCache.complete) {
-        throw new IncompleteDiscordVerificationReadError()
-      }
-      return this.verificationMessagesCache.messages
+    if (this.verificationMessagesFailureCacheExpiresAt && this.verificationMessagesFailureCacheExpiresAt > Date.now()) {
+      throw new IncompleteDiscordVerificationReadError()
     }
 
     if (this.verificationMessagesRequest) {
@@ -451,33 +444,20 @@ export class DiscordService {
           'Verification channel window did not fit the fetch budget',
           new Error(`more than ${VERIFICATION_FETCH_PAGE_SIZE * VERIFICATION_FETCH_MAX_PAGES} messages in the window`)
         )
-        this.verificationMessagesCache = {
-          messages: [],
-          expiresAt: Date.now() + VERIFICATION_FETCH_CACHE_TTL,
-          complete: false,
-        }
+        this.verificationMessagesFailureCacheExpiresAt = Date.now() + VERIFICATION_FETCH_FAILURE_CACHE_TTL
         throw new IncompleteDiscordVerificationReadError()
       }
 
       const relevant = messages.filter(
         (message) => !message.author.bot && message.createdTimestamp > oldestRelevantTimestamp
       )
-      this.verificationMessagesCache = {
-        messages: relevant,
-        expiresAt: Date.now() + VERIFICATION_FETCH_CACHE_TTL,
-        complete: true,
-      }
       return relevant
     } catch (error) {
       if (error instanceof IncompleteDiscordVerificationReadError) {
         throw error
       }
       this.reportError('Error getting profile verification messages', error)
-      this.verificationMessagesCache = {
-        messages: [],
-        expiresAt: Date.now() + VERIFICATION_FETCH_CACHE_TTL,
-        complete: false,
-      }
+      this.verificationMessagesFailureCacheExpiresAt = Date.now() + VERIFICATION_FETCH_FAILURE_CACHE_TTL
       throw new IncompleteDiscordVerificationReadError()
     }
   }
@@ -486,9 +466,9 @@ export class DiscordService {
     if (DISCORD_SERVICE_ENABLED) {
       try {
         const channel = await this.fetchTextChannel(PROFILE_VERIFICATION_CHANNEL_ID)
-        // Dropped before the delete, so a failed delete does not leave a window cached as if the
-        // message were still there in a state we no longer know.
-        this.verificationMessagesCache = undefined
+        // A channel mutation can bring a previously oversized window back inside the read budget,
+        // so allow the next validation attempt to retry immediately.
+        this.verificationMessagesFailureCacheExpiresAt = undefined
         await channel.messages.delete(messageId)
       } catch (error) {
         this.reportError('Error deleting profile verification message', error)

--- a/src/services/discord.ts
+++ b/src/services/discord.ts
@@ -73,9 +73,20 @@ function getChoices(choices: string[]): Field[] {
   }))
 }
 
+export class IncompleteDiscordVerificationReadError extends Error {
+  constructor() {
+    super('Could not read the complete Discord verification message window')
+    this.name = 'IncompleteDiscordVerificationReadError'
+  }
+}
+
 export class DiscordService {
   private static client: Client
-  private static verificationMessagesCache?: { messages: Discord.Message<true>[]; expiresAt: number }
+  private static verificationMessagesCache?: {
+    messages: Discord.Message<true>[]
+    expiresAt: number
+    complete: boolean
+  }
   private static verificationMessagesRequest?: Promise<Discord.Message<true>[]>
 
   static init() {
@@ -368,10 +379,13 @@ export class DiscordService {
 
   static async getProfileVerificationMessages(): Promise<Discord.Message<true>[]> {
     if (!DISCORD_SERVICE_ENABLED) {
-      return []
+      throw new IncompleteDiscordVerificationReadError()
     }
 
     if (this.verificationMessagesCache && this.verificationMessagesCache.expiresAt > Date.now()) {
+      if (!this.verificationMessagesCache.complete) {
+        throw new IncompleteDiscordVerificationReadError()
+      }
       return this.verificationMessagesCache.messages
     }
 
@@ -429,17 +443,20 @@ export class DiscordService {
 
       // Out of pages with the window still not covered. A partial read is taken from the newest
       // end, so it can hold a copy of a verification message while hiding the older original it
-      // was copied from — exactly what the ambiguity check needs to see. Answer with nothing
-      // rather than with a subset. Callers keep polling, so a link still succeeds once the
-      // channel settles. The refusal is cached like any other answer, otherwise a channel kept
-      // above the budget would make every poll spend the whole page budget again.
+      // was copied from — exactly what the ambiguity check needs to see. Surface a retryable
+      // incomplete-source failure rather than returning a subset. The refusal is cached so a
+      // channel kept above the budget does not make every poll spend the whole page budget again.
       if (!readWholeWindow) {
         this.reportError(
           'Verification channel window did not fit the fetch budget',
           new Error(`more than ${VERIFICATION_FETCH_PAGE_SIZE * VERIFICATION_FETCH_MAX_PAGES} messages in the window`)
         )
-        this.verificationMessagesCache = { messages: [], expiresAt: Date.now() + VERIFICATION_FETCH_CACHE_TTL }
-        return []
+        this.verificationMessagesCache = {
+          messages: [],
+          expiresAt: Date.now() + VERIFICATION_FETCH_CACHE_TTL,
+          complete: false,
+        }
+        throw new IncompleteDiscordVerificationReadError()
       }
 
       const relevant = messages.filter(
@@ -448,12 +465,21 @@ export class DiscordService {
       this.verificationMessagesCache = {
         messages: relevant,
         expiresAt: Date.now() + VERIFICATION_FETCH_CACHE_TTL,
+        complete: true,
       }
       return relevant
     } catch (error) {
+      if (error instanceof IncompleteDiscordVerificationReadError) {
+        throw error
+      }
       this.reportError('Error getting profile verification messages', error)
+      this.verificationMessagesCache = {
+        messages: [],
+        expiresAt: Date.now() + VERIFICATION_FETCH_CACHE_TTL,
+        complete: false,
+      }
+      throw new IncompleteDiscordVerificationReadError()
     }
-    return []
   }
 
   static async deleteVerificationMessage(messageId: string) {

--- a/src/services/discord.verificationMessages.test.ts
+++ b/src/services/discord.verificationMessages.test.ts
@@ -59,10 +59,10 @@ function stubChannel(fetch: jest.Mock) {
 
 function clearVerificationCache() {
   const service = DiscordService as unknown as {
-    verificationMessagesCache?: unknown
+    verificationMessagesFailureCacheExpiresAt?: number
     verificationMessagesRequest?: unknown
   }
-  service.verificationMessagesCache = undefined
+  service.verificationMessagesFailureCacheExpiresAt = undefined
   service.verificationMessagesRequest = undefined
 }
 
@@ -202,6 +202,31 @@ describe('DiscordService.getProfileVerificationMessages', () => {
     })
   })
 
+  describe('when a message is posted after a successful read completes', () => {
+    let fetch: jest.Mock
+    let secondResult: FakeMessage[]
+
+    beforeEach(async () => {
+      const original = createMessage('original', now - 2000)
+      const copy = createMessage('copy', now - 1000)
+      let visibleMessages = [original]
+      fetch = jest.fn(async () => new Collection(visibleMessages.map((message) => [message.id, message])))
+      stubChannel(fetch)
+
+      await DiscordService.getProfileVerificationMessages()
+      visibleMessages = [copy, original]
+      secondResult = await DiscordService.getProfileVerificationMessages()
+    })
+
+    it('should fetch a fresh snapshot after the completed request', () => {
+      expect(fetch).toHaveBeenCalledTimes(2)
+    })
+
+    it('should include the newly posted message for ambiguity detection', () => {
+      expect(secondResult.map((message) => message.id)).toEqual(['copy', 'original'])
+    })
+  })
+
   describe('when messages predate the validation window', () => {
     let returned: FakeMessage[]
 
@@ -309,7 +334,7 @@ describe('DiscordService.getProfileVerificationMessages', () => {
       expect(deleteMessage).toHaveBeenCalledWith('original')
     })
 
-    it('should drop the cached window so the deleted message is not matched again', async () => {
+    it('should read a fresh window after deletion', async () => {
       fetch.mockClear()
       await DiscordService.getProfileVerificationMessages()
       expect(fetch).toHaveBeenCalled()

--- a/src/services/discord.verificationMessages.test.ts
+++ b/src/services/discord.verificationMessages.test.ts
@@ -1,0 +1,360 @@
+import { Collection } from 'discord.js'
+
+import { MESSAGE_TIMEOUT_TIME } from '../entities/User/constants'
+
+import Discord = require('discord.js')
+
+jest.mock('../constants', () => ({
+  ...jest.requireActual('../constants'),
+  DISCORD_SERVICE_ENABLED: true,
+}))
+
+// Set before the require: the service reads the channel id into a module constant at import time.
+process.env.DISCORD_PROFILE_VERIFICATION_CHANNEL_ID = 'verification-channel'
+
+// Imported after the mock so the service picks up the enabled flag.
+// eslint-disable-next-line @typescript-eslint/no-var-requires
+const { DiscordService } = require('./discord')
+
+type FakeMessage = {
+  id: string
+  content: string
+  createdTimestamp: number
+  author: { id: string; bot: boolean }
+}
+
+function createMessage(id: string, createdTimestamp: number, overrides: Partial<FakeMessage> = {}): FakeMessage {
+  return {
+    id,
+    content: `content-${id}`,
+    createdTimestamp,
+    author: { id: `author-${id}`, bot: false },
+    ...overrides,
+  }
+}
+
+// Mirrors channel.messages.fetch: newest first, honouring limit and the before cursor.
+function createFetchMock(newestFirst: FakeMessage[]) {
+  return jest.fn(async ({ limit, before }: { limit: number; before?: string }) => {
+    let pool = newestFirst
+    if (before) {
+      const cursor = pool.findIndex((message) => message.id === before)
+      // Rather than silently restarting from the newest message, which would hide a broken cursor
+      // behind a test that still passes.
+      if (cursor < 0) {
+        throw new Error(`before cursor not found: ${before}`)
+      }
+      pool = pool.slice(cursor + 1)
+    }
+    return new Collection(pool.slice(0, limit).map((message) => [message.id, message]))
+  })
+}
+
+function stubChannel(fetch: jest.Mock) {
+  const channel = { type: Discord.ChannelType.GuildText, messages: { fetch } }
+  ;(DiscordService as unknown as { client: unknown }).client = {
+    channels: { fetch: jest.fn().mockResolvedValue(channel) },
+  }
+}
+
+function clearVerificationCache() {
+  const service = DiscordService as unknown as {
+    verificationMessagesCache?: unknown
+    verificationMessagesRequest?: unknown
+  }
+  service.verificationMessagesCache = undefined
+  service.verificationMessagesRequest = undefined
+}
+
+describe('DiscordService.getProfileVerificationMessages', () => {
+  let now: number
+
+  beforeEach(() => {
+    clearVerificationCache()
+    now = Date.now()
+  })
+
+  afterEach(() => {
+    jest.restoreAllMocks()
+  })
+
+  describe('when a verification message is followed by more messages than a single legacy page held', () => {
+    let fetch: jest.Mock
+    let returned: FakeMessage[]
+
+    beforeEach(async () => {
+      // Regression case: the copy plus nine fillers used to push the original out of view.
+      const original = createMessage('original', now - 4000)
+      const copy = createMessage('copy', now - 3000)
+      const fillers = Array.from({ length: 9 }, (_, index) => createMessage(`filler-${index}`, now - 2000 + index))
+      fetch = createFetchMock([...fillers.reverse(), copy, original])
+      stubChannel(fetch)
+      returned = await DiscordService.getProfileVerificationMessages()
+    })
+
+    it('should still return the original verification message', () => {
+      expect(returned.map((message) => message.id)).toContain('original')
+    })
+
+    it('should return the copy alongside it so the ambiguity check can see both', () => {
+      expect(returned.map((message) => message.id)).toEqual(expect.arrayContaining(['original', 'copy']))
+    })
+  })
+
+  describe('when the messages inside the validation window span more than one page', () => {
+    let fetch: jest.Mock
+    let returned: FakeMessage[]
+
+    beforeEach(async () => {
+      const messages = Array.from({ length: 150 }, (_, index) => createMessage(`m-${index}`, now - 1000 - index))
+      fetch = createFetchMock(messages)
+      stubChannel(fetch)
+      returned = await DiscordService.getProfileVerificationMessages()
+    })
+
+    it('should page past the first fetch to cover the whole window', () => {
+      expect(returned).toHaveLength(150)
+    })
+
+    it('should stop on the short page rather than spend a fetch proving the channel is empty', () => {
+      expect(fetch).toHaveBeenCalledTimes(2)
+    })
+  })
+
+  // Nothing older exists, so the window is covered even though its oldest message is still inside
+  // it. A full final page cannot show that, so the budget is only usable up to a short page.
+  describe('and the last page inside the budget is short', () => {
+    let returned: FakeMessage[]
+
+    beforeEach(async () => {
+      const messages = Array.from({ length: 499 }, (_, index) => createMessage(`m-${index}`, now - 1000))
+      stubChannel(createFetchMock(messages))
+      returned = await DiscordService.getProfileVerificationMessages()
+    })
+
+    it('should return them rather than refuse', () => {
+      expect(returned).toHaveLength(499)
+    })
+  })
+
+  // The ordinary production path: a full page whose oldest message already predates the window.
+  describe('when a full page reaches past the start of the window', () => {
+    let fetch: jest.Mock
+    let returned: FakeMessage[]
+
+    beforeEach(async () => {
+      const inWindow = Array.from({ length: 150 }, (_, index) => createMessage(`recent-${index}`, now - 1000 - index))
+      const expired = Array.from({ length: 100 }, (_, index) =>
+        createMessage(`expired-${index}`, now - MESSAGE_TIMEOUT_TIME - 1000 - index)
+      )
+      fetch = createFetchMock([...inWindow, ...expired])
+      stubChannel(fetch)
+      returned = await DiscordService.getProfileVerificationMessages()
+    })
+
+    it('should stop there rather than keep paging', () => {
+      expect(fetch).toHaveBeenCalledTimes(2)
+    })
+
+    it('should return only the messages inside the window', () => {
+      expect(returned).toHaveLength(150)
+    })
+  })
+
+  describe('when the channel is empty', () => {
+    let returned: FakeMessage[]
+
+    beforeEach(async () => {
+      stubChannel(createFetchMock([]))
+      returned = await DiscordService.getProfileVerificationMessages()
+    })
+
+    it('should return nothing', () => {
+      expect(returned).toEqual([])
+    })
+  })
+
+  describe('when another caller asks for messages while a fetch is still in flight', () => {
+    let fetch: jest.Mock
+    let firstResult: FakeMessage[]
+    let secondResult: FakeMessage[]
+
+    beforeEach(async () => {
+      let resolveFetch: ((messages: Collection<string, FakeMessage>) => void) | undefined
+      const pendingFetch = new Promise<Collection<string, FakeMessage>>((resolve) => {
+        resolveFetch = resolve
+      })
+      fetch = jest.fn().mockReturnValue(pendingFetch)
+      stubChannel(fetch)
+
+      const first = DiscordService.getProfileVerificationMessages()
+      const second = DiscordService.getProfileVerificationMessages()
+      resolveFetch?.(new Collection([['original', createMessage('original', now - 1000)]]))
+      ;[firstResult, secondResult] = await Promise.all([first, second])
+    })
+
+    it('should coalesce both callers into one Discord fetch', () => {
+      expect(fetch).toHaveBeenCalledTimes(1)
+    })
+
+    it('should return the same fetched window to both callers', () => {
+      expect([firstResult[0].id, secondResult[0].id]).toEqual(['original', 'original'])
+    })
+  })
+
+  describe('when messages predate the validation window', () => {
+    let returned: FakeMessage[]
+
+    beforeEach(async () => {
+      const inWindow = createMessage('recent', now - 1000)
+      const expired = createMessage('expired', now - MESSAGE_TIMEOUT_TIME - 1000)
+      stubChannel(createFetchMock([inWindow, expired]))
+      returned = await DiscordService.getProfileVerificationMessages()
+    })
+
+    it('should return only the message inside the window', () => {
+      expect(returned.map((message) => message.id)).toEqual(['recent'])
+    })
+  })
+
+  describe('when the channel contains bot messages', () => {
+    let returned: FakeMessage[]
+
+    beforeEach(async () => {
+      const fromBot = createMessage('bot', now - 1000, { author: { id: 'author-bot', bot: true } })
+      const fromUser = createMessage('user', now - 2000)
+      stubChannel(createFetchMock([fromBot, fromUser]))
+      returned = await DiscordService.getProfileVerificationMessages()
+    })
+
+    it('should exclude the bot message', () => {
+      expect(returned.map((message) => message.id)).toEqual(['user'])
+    })
+  })
+
+  // A partial read is taken from the newest end, so it can hold a copy while hiding the original.
+  describe('when the window holds more messages than the fetch budget covers', () => {
+    let fetch: jest.Mock
+    let returned: FakeMessage[]
+
+    beforeEach(async () => {
+      const messages = Array.from({ length: 2000 }, (_, index) => createMessage(`m-${index}`, now - 1000))
+      fetch = createFetchMock(messages)
+      stubChannel(fetch)
+      returned = await DiscordService.getProfileVerificationMessages()
+    })
+
+    it('should stop at the page cap instead of paging without bound', () => {
+      expect(fetch).toHaveBeenCalledTimes(5)
+    })
+
+    it('should return nothing rather than a subset that could hide the original', () => {
+      expect(returned).toEqual([])
+    })
+
+    it('should not spend the page budget again on the next poll inside the cache window', async () => {
+      fetch.mockClear()
+      await DiscordService.getProfileVerificationMessages()
+      expect(fetch).not.toHaveBeenCalled()
+    })
+  })
+
+  describe('when the channel cannot be resolved', () => {
+    let returned: FakeMessage[]
+
+    beforeEach(async () => {
+      ;(DiscordService as unknown as { client: unknown }).client = {
+        channels: { fetch: jest.fn().mockResolvedValue(null) },
+      }
+      returned = await DiscordService.getProfileVerificationMessages()
+    })
+
+    it('should return nothing rather than throw', () => {
+      expect(returned).toEqual([])
+    })
+  })
+
+  describe('when the configured channel is not a text channel', () => {
+    let returned: FakeMessage[]
+
+    beforeEach(async () => {
+      ;(DiscordService as unknown as { client: unknown }).client = {
+        channels: { fetch: jest.fn().mockResolvedValue({ type: Discord.ChannelType.GuildVoice, messages: {} }) },
+      }
+      returned = await DiscordService.getProfileVerificationMessages()
+    })
+
+    it('should return nothing rather than read it', () => {
+      expect(returned).toEqual([])
+    })
+  })
+
+  describe('when a verification message is deleted', () => {
+    let deleteMessage: jest.Mock
+    let fetch: jest.Mock
+
+    beforeEach(async () => {
+      fetch = createFetchMock([createMessage('original', now - 1000)])
+      deleteMessage = jest.fn().mockResolvedValue(undefined)
+      const channel = { type: Discord.ChannelType.GuildText, messages: { fetch, delete: deleteMessage } }
+      ;(DiscordService as unknown as { client: unknown }).client = {
+        channels: { fetch: jest.fn().mockResolvedValue(channel) },
+      }
+
+      await DiscordService.getProfileVerificationMessages()
+      await DiscordService.deleteVerificationMessage('original')
+    })
+
+    it('should delete the matched message', () => {
+      expect(deleteMessage).toHaveBeenCalledWith('original')
+    })
+
+    it('should drop the cached window so the deleted message is not matched again', async () => {
+      fetch.mockClear()
+      await DiscordService.getProfileVerificationMessages()
+      expect(fetch).toHaveBeenCalled()
+    })
+  })
+
+  // The link has already been written by this point, so a failed delete must not turn a completed
+  // verification into an error.
+  describe('when deleting the message fails', () => {
+    let thrown: Error | undefined
+
+    beforeEach(async () => {
+      const channel = {
+        type: Discord.ChannelType.GuildText,
+        messages: { fetch: createFetchMock([]), delete: jest.fn().mockRejectedValue(new Error('missing access')) },
+      }
+      ;(DiscordService as unknown as { client: unknown }).client = {
+        channels: { fetch: jest.fn().mockResolvedValue(channel) },
+      }
+      thrown = await DiscordService.deleteVerificationMessage('original').then(
+        () => undefined,
+        (error: Error) => error
+      )
+    })
+
+    it('should not propagate the failure', () => {
+      expect(thrown).toBeUndefined()
+    })
+  })
+
+  describe('and the channel settles back inside the fetch budget', () => {
+    let returned: FakeMessage[]
+
+    beforeEach(async () => {
+      const flooded = Array.from({ length: 2000 }, (_, index) => createMessage(`m-${index}`, now - 1000))
+      stubChannel(createFetchMock(flooded))
+      await DiscordService.getProfileVerificationMessages()
+
+      clearVerificationCache()
+      stubChannel(createFetchMock([createMessage('original', now - 1000), createMessage('old', now - 400000)]))
+      returned = await DiscordService.getProfileVerificationMessages()
+    })
+
+    it('should read the window again rather than stay poisoned by the partial read', () => {
+      expect(returned.map((message) => message.id)).toEqual(['original'])
+    })
+  })
+})

--- a/src/services/discord.verificationMessages.test.ts
+++ b/src/services/discord.verificationMessages.test.ts
@@ -14,7 +14,7 @@ process.env.DISCORD_PROFILE_VERIFICATION_CHANNEL_ID = 'verification-channel'
 
 // Imported after the mock so the service picks up the enabled flag.
 // eslint-disable-next-line @typescript-eslint/no-var-requires
-const { DiscordService } = require('./discord')
+const { DiscordService, IncompleteDiscordVerificationReadError } = require('./discord')
 
 type FakeMessage = {
   id: string
@@ -235,57 +235,57 @@ describe('DiscordService.getProfileVerificationMessages', () => {
   // A partial read is taken from the newest end, so it can hold a copy while hiding the original.
   describe('when the window holds more messages than the fetch budget covers', () => {
     let fetch: jest.Mock
-    let returned: FakeMessage[]
+    let thrown: Error
 
     beforeEach(async () => {
       const messages = Array.from({ length: 2000 }, (_, index) => createMessage(`m-${index}`, now - 1000))
       fetch = createFetchMock(messages)
       stubChannel(fetch)
-      returned = await DiscordService.getProfileVerificationMessages()
+      thrown = (await DiscordService.getProfileVerificationMessages().catch((error: Error) => error)) as Error
     })
 
     it('should stop at the page cap instead of paging without bound', () => {
       expect(fetch).toHaveBeenCalledTimes(5)
     })
 
-    it('should return nothing rather than a subset that could hide the original', () => {
-      expect(returned).toEqual([])
+    it('should reject the incomplete read rather than return a subset', () => {
+      expect(thrown).toBeInstanceOf(IncompleteDiscordVerificationReadError)
     })
 
-    it('should not spend the page budget again on the next poll inside the cache window', async () => {
+    it('should cache the incomplete result inside the cache window', async () => {
       fetch.mockClear()
-      await DiscordService.getProfileVerificationMessages()
+      await DiscordService.getProfileVerificationMessages().catch(() => undefined)
       expect(fetch).not.toHaveBeenCalled()
     })
   })
 
   describe('when the channel cannot be resolved', () => {
-    let returned: FakeMessage[]
+    let thrown: Error
 
     beforeEach(async () => {
       ;(DiscordService as unknown as { client: unknown }).client = {
         channels: { fetch: jest.fn().mockResolvedValue(null) },
       }
-      returned = await DiscordService.getProfileVerificationMessages()
+      thrown = (await DiscordService.getProfileVerificationMessages().catch((error: Error) => error)) as Error
     })
 
-    it('should return nothing rather than throw', () => {
-      expect(returned).toEqual([])
+    it('should reject with an incomplete-source error', () => {
+      expect(thrown).toBeInstanceOf(IncompleteDiscordVerificationReadError)
     })
   })
 
   describe('when the configured channel is not a text channel', () => {
-    let returned: FakeMessage[]
+    let thrown: Error
 
     beforeEach(async () => {
       ;(DiscordService as unknown as { client: unknown }).client = {
         channels: { fetch: jest.fn().mockResolvedValue({ type: Discord.ChannelType.GuildVoice, messages: {} }) },
       }
-      returned = await DiscordService.getProfileVerificationMessages()
+      thrown = (await DiscordService.getProfileVerificationMessages().catch((error: Error) => error)) as Error
     })
 
-    it('should return nothing rather than read it', () => {
-      expect(returned).toEqual([])
+    it('should reject with an incomplete-source error', () => {
+      expect(thrown).toBeInstanceOf(IncompleteDiscordVerificationReadError)
     })
   })
 
@@ -346,7 +346,7 @@ describe('DiscordService.getProfileVerificationMessages', () => {
     beforeEach(async () => {
       const flooded = Array.from({ length: 2000 }, (_, index) => createMessage(`m-${index}`, now - 1000))
       stubChannel(createFetchMock(flooded))
-      await DiscordService.getProfileVerificationMessages()
+      await DiscordService.getProfileVerificationMessages().catch(() => undefined)
 
       clearVerificationCache()
       stubChannel(createFetchMock([createMessage('original', now - 1000), createMessage('old', now - 400000)]))

--- a/src/services/user.discordLinking.test.ts
+++ b/src/services/user.discordLinking.test.ts
@@ -201,4 +201,46 @@ describe('linking a discord account to a dao address', () => {
       expect(thrown.message).toBe('That Discord account is already linked to another address')
     })
   })
+
+  describe('when deleting the verification message fails after linking', () => {
+    let result: { valid: boolean }
+
+    beforeEach(async () => {
+      jest.spyOn(DiscordService, 'deleteVerificationMessage').mockRejectedValueOnce(new Error('Discord unavailable'))
+      stubChannelWith([
+        { id: 'v', content: posted, createdTimestamp: now, author: { id: SIGNER_DISCORD_ID, bot: false } },
+      ])
+      result = await UserService.validateDiscordUser(signer.address)
+    })
+
+    it('should still report the persisted link as valid', () => {
+      expect(result.valid).toBe(true)
+    })
+
+    it('should keep the persisted Discord connection', () => {
+      expect(createDiscordConnection).toHaveBeenCalledWith(signer.address, SIGNER_DISCORD_ID)
+    })
+  })
+
+  describe('when enqueueing the confirmation message fails after linking', () => {
+    let result: { valid: boolean }
+
+    beforeEach(async () => {
+      jest.spyOn(DiscordService, 'sendDirectMessage').mockImplementationOnce(() => {
+        throw new Error('Discord unavailable')
+      })
+      stubChannelWith([
+        { id: 'v', content: posted, createdTimestamp: now, author: { id: SIGNER_DISCORD_ID, bot: false } },
+      ])
+      result = await UserService.validateDiscordUser(signer.address)
+    })
+
+    it('should still report the persisted link as valid', () => {
+      expect(result.valid).toBe(true)
+    })
+
+    it('should keep the persisted Discord connection', () => {
+      expect(createDiscordConnection).toHaveBeenCalledWith(signer.address, SIGNER_DISCORD_ID)
+    })
+  })
 })

--- a/src/services/user.discordLinking.test.ts
+++ b/src/services/user.discordLinking.test.ts
@@ -1,0 +1,204 @@
+import { Collection } from 'discord.js'
+import { Wallet } from 'ethers'
+
+import Discord = require('discord.js')
+
+jest.mock('../constants', () => ({
+  ...jest.requireActual('../constants'),
+  DISCORD_SERVICE_ENABLED: true,
+}))
+
+jest.mock('../entities/User/model', () => ({
+  __esModule: true,
+  default: {
+    createDiscordConnection: jest.fn(),
+    createForumConnection: jest.fn(),
+  },
+}))
+
+// Set before the requires: the service reads the channel id into a module constant at import time.
+process.env.DISCORD_PROFILE_VERIFICATION_CHANNEL_ID = 'verification-channel'
+
+// Required after the mocks so both pick up the stubbed module graph.
+/* eslint-disable @typescript-eslint/no-var-requires */
+const UserModel = require('../entities/User/model').default
+const { DiscordService } = require('./discord')
+const { UserService } = require('./user')
+/* eslint-enable @typescript-eslint/no-var-requires */
+
+const SIGNER_DISCORD_ID = '111111111111111111'
+const REPOSTER_DISCORD_ID = '999999999999999999'
+
+type FakeMessage = {
+  id: string
+  content: string
+  createdTimestamp: number
+  author: { id: string; bot: boolean }
+}
+
+function stubChannelWith(newestFirst: FakeMessage[]) {
+  const fetch = jest.fn(async ({ limit, before }: { limit: number; before?: string }) => {
+    let pool = newestFirst
+    if (before) {
+      pool = pool.slice(pool.findIndex((message) => message.id === before) + 1)
+    }
+    return new Collection(pool.slice(0, limit).map((message) => [message.id, message]))
+  })
+  const channel = { type: Discord.ChannelType.GuildText, messages: { fetch } }
+  ;(DiscordService as unknown as { client: unknown }).client = {
+    channels: { fetch: jest.fn().mockResolvedValue(channel) },
+  }
+  // The service caches the window for a few seconds; drop it so each case reads its own stub.
+  ;(DiscordService as unknown as { verificationMessagesCache?: unknown }).verificationMessagesCache = undefined
+}
+
+describe('linking a discord account to a dao address', () => {
+  let signer: Wallet
+  let posted: string
+  let now: number
+  let createDiscordConnection: jest.Mock
+
+  beforeEach(async () => {
+    jest.clearAllMocks()
+    jest.spyOn(DiscordService, 'deleteVerificationMessage').mockResolvedValue(undefined as never)
+    jest.spyOn(DiscordService, 'sendDirectMessage').mockReturnValue(undefined as never)
+    createDiscordConnection = UserModel.createDiscordConnection as jest.Mock
+
+    now = Date.now()
+    signer = Wallet.createRandom()
+    // The real route: GET /user/validate issues the message and opens the validation window.
+    const message = UserService.getValidationMessage(signer.address, 'discord')
+    const signature = await signer.signMessage(message)
+    posted = `${message}\n\n${signature}`
+  })
+
+  afterEach(() => {
+    const inProgress = (
+      UserService as unknown as {
+        VALIDATIONS_IN_PROGRESS: Record<string, { message_timeout: NodeJS.Timeout }>
+      }
+    ).VALIDATIONS_IN_PROGRESS
+    Object.keys(inProgress).forEach((address) => {
+      clearTimeout(inProgress[address].message_timeout)
+      delete inProgress[address]
+    })
+    jest.restoreAllMocks()
+  })
+
+  describe('when only the genuine signer posted their verification message', () => {
+    let result: { valid: boolean }
+
+    beforeEach(async () => {
+      stubChannelWith([
+        { id: 'v', content: posted, createdTimestamp: now, author: { id: SIGNER_DISCORD_ID, bot: false } },
+      ])
+      result = await UserService.validateDiscordUser(signer.address)
+    })
+
+    it('should report the validation as valid', () => {
+      expect(result.valid).toBe(true)
+    })
+
+    it('should link the discord account of the genuine signer', () => {
+      expect(createDiscordConnection).toHaveBeenCalledWith(signer.address, SIGNER_DISCORD_ID)
+    })
+  })
+
+  describe('when another account reposts the verification message verbatim', () => {
+    let thrown: Error
+
+    beforeEach(async () => {
+      stubChannelWith([
+        { id: 'a', content: posted, createdTimestamp: now + 1200, author: { id: REPOSTER_DISCORD_ID, bot: false } },
+        { id: 'v', content: posted, createdTimestamp: now, author: { id: SIGNER_DISCORD_ID, bot: false } },
+      ])
+      thrown = (await UserService.validateDiscordUser(signer.address).catch((error: Error) => error)) as Error
+    })
+
+    it('should refuse the ambiguous match', () => {
+      expect(thrown.message).toBe('Multiple Discord accounts posted the same valid verification message')
+    })
+
+    it('should not link any discord account', () => {
+      expect(createDiscordConnection).not.toHaveBeenCalled()
+    })
+  })
+
+  describe('and the reposting account floods the channel to hide the original message', () => {
+    let thrown: Error
+
+    beforeEach(async () => {
+      const fillers: FakeMessage[] = Array.from({ length: 40 }, (_, index) => ({
+        id: `filler-${index}`,
+        content: `gm ${index}`,
+        createdTimestamp: now + 2000 + index,
+        author: { id: REPOSTER_DISCORD_ID, bot: false },
+      }))
+      stubChannelWith([
+        ...fillers.reverse(),
+        { id: 'a', content: posted, createdTimestamp: now + 1200, author: { id: REPOSTER_DISCORD_ID, bot: false } },
+        { id: 'v', content: posted, createdTimestamp: now, author: { id: SIGNER_DISCORD_ID, bot: false } },
+      ])
+      thrown = (await UserService.validateDiscordUser(signer.address).catch((error: Error) => error)) as Error
+    })
+
+    it('should still reach the original message and refuse the ambiguous match', () => {
+      expect(thrown.message).toBe('Multiple Discord accounts posted the same valid verification message')
+    })
+
+    it('should not link the reposting account to the signer address', () => {
+      expect(createDiscordConnection).not.toHaveBeenCalledWith(signer.address, REPOSTER_DISCORD_ID)
+    })
+  })
+
+  describe('and an unsigned copy is posted before the genuine message', () => {
+    beforeEach(async () => {
+      stubChannelWith([
+        { id: 'v', content: posted, createdTimestamp: now, author: { id: SIGNER_DISCORD_ID, bot: false } },
+        {
+          id: 'a',
+          content: posted.replace(/0x[a-fA-F\d]{130}/, '0xnotasignature'),
+          createdTimestamp: now - 5000,
+          author: { id: REPOSTER_DISCORD_ID, bot: false },
+        },
+      ])
+      await UserService.validateDiscordUser(signer.address)
+    })
+
+    it('should ignore the unsigned copy and link the genuine signer', () => {
+      expect(createDiscordConnection).toHaveBeenCalledWith(signer.address, SIGNER_DISCORD_ID)
+    })
+  })
+
+  // Discord keeps createdTimestamp on the snowflake when a message is edited, so a decoy posted
+  // before the signer can be rewritten afterwards to carry their content while still looking older.
+  describe('and the reposting account edits a message it posted before the genuine one', () => {
+    beforeEach(async () => {
+      stubChannelWith([
+        { id: 'v', content: posted, createdTimestamp: now, author: { id: SIGNER_DISCORD_ID, bot: false } },
+        { id: 'a', content: posted, createdTimestamp: now - 3000, author: { id: REPOSTER_DISCORD_ID, bot: false } },
+      ])
+      await UserService.validateDiscordUser(signer.address).catch(() => undefined)
+    })
+
+    it('should not link the reposting account to the signer address', () => {
+      expect(createDiscordConnection).not.toHaveBeenCalledWith(signer.address, REPOSTER_DISCORD_ID)
+    })
+  })
+
+  describe('when the discord account is already linked to another address', () => {
+    let thrown: Error
+
+    beforeEach(async () => {
+      createDiscordConnection.mockRejectedValueOnce(Object.assign(new Error('duplicate key'), { code: '23505' }))
+      stubChannelWith([
+        { id: 'v', content: posted, createdTimestamp: now, author: { id: SIGNER_DISCORD_ID, bot: false } },
+      ])
+      thrown = (await UserService.validateDiscordUser(signer.address).catch((error: Error) => error)) as Error
+    })
+
+    it('should explain the conflict rather than surface the driver error', () => {
+      expect(thrown.message).toBe('That Discord account is already linked to another address')
+    })
+  })
+})

--- a/src/services/user.discordLinking.test.ts
+++ b/src/services/user.discordLinking.test.ts
@@ -1,3 +1,4 @@
+import RequestError from 'decentraland-gatsby/dist/entities/Route/error'
 import { Collection } from 'discord.js'
 import { Wallet } from 'ethers'
 
@@ -22,7 +23,8 @@ process.env.DISCORD_PROFILE_VERIFICATION_CHANNEL_ID = 'verification-channel'
 // Required after the mocks so both pick up the stubbed module graph.
 /* eslint-disable @typescript-eslint/no-var-requires */
 const UserModel = require('../entities/User/model').default
-const { DiscordService } = require('./discord')
+const { DiscordService, IncompleteDiscordVerificationReadError } = require('./discord')
+const { ErrorService } = require('./ErrorService')
 const { UserService } = require('./user')
 /* eslint-enable @typescript-eslint/no-var-requires */
 
@@ -199,6 +201,57 @@ describe('linking a discord account to a dao address', () => {
 
     it('should explain the conflict rather than surface the driver error', () => {
       expect(thrown.message).toBe('That Discord account is already linked to another address')
+    })
+  })
+
+  describe('when the Discord verification source cannot be read completely', () => {
+    let thrown: RequestError
+
+    beforeEach(async () => {
+      jest
+        .spyOn(DiscordService, 'getProfileVerificationMessages')
+        .mockRejectedValueOnce(new IncompleteDiscordVerificationReadError())
+      thrown = (await UserService.validateDiscordUser(signer.address).catch(
+        (error: RequestError) => error
+      )) as RequestError
+    })
+
+    it('should expose a retryable service-unavailable status', () => {
+      expect(thrown.statusCode).toBe(503)
+    })
+
+    it('should identify the incomplete validation source', () => {
+      expect(thrown.code).toBe('validation_source_incomplete')
+    })
+
+    it('should not link a Discord account', () => {
+      expect(createDiscordConnection).not.toHaveBeenCalled()
+    })
+  })
+
+  describe('when an unexpected Discord validation error occurs', () => {
+    let thrown: RequestError
+    let report: jest.SpyInstance
+
+    beforeEach(async () => {
+      report = jest.spyOn(ErrorService, 'report').mockImplementation(() => undefined)
+      jest
+        .spyOn(DiscordService, 'getProfileVerificationMessages')
+        .mockRejectedValueOnce(new Error('secret upstream detail'))
+      thrown = (await UserService.validateDiscordUser(signer.address).catch(
+        (error: RequestError) => error
+      )) as RequestError
+    })
+
+    it('should return a generic client-facing message', () => {
+      expect(thrown.message).toBe("Couldn't validate the user")
+    })
+
+    it('should report the original error for diagnosis', () => {
+      expect(report).toHaveBeenCalledWith(
+        'Unexpected profile validation failure',
+        expect.objectContaining({ error: 'Error: secret upstream detail' })
+      )
     })
   })
 

--- a/src/services/user.discordLinking.test.ts
+++ b/src/services/user.discordLinking.test.ts
@@ -50,8 +50,10 @@ function stubChannelWith(newestFirst: FakeMessage[]) {
   ;(DiscordService as unknown as { client: unknown }).client = {
     channels: { fetch: jest.fn().mockResolvedValue(channel) },
   }
-  // The service caches the window for a few seconds; drop it so each case reads its own stub.
-  ;(DiscordService as unknown as { verificationMessagesCache?: unknown }).verificationMessagesCache = undefined
+  // Drop any throttled failure so each case reads its own stub.
+  ;(
+    DiscordService as unknown as { verificationMessagesFailureCacheExpiresAt?: number }
+  ).verificationMessagesFailureCacheExpiresAt = undefined
 }
 
 describe('linking a discord account to a dao address', () => {

--- a/src/services/user.forumLinking.test.ts
+++ b/src/services/user.forumLinking.test.ts
@@ -1,3 +1,4 @@
+import RequestError from 'decentraland-gatsby/dist/entities/Route/error'
 import { Wallet } from 'ethers'
 
 import { ProposalComment } from '../entities/Proposal/types'
@@ -15,7 +16,7 @@ jest.mock('../entities/User/model', () => ({
 // Required after the mock so the service picks up the stubbed model.
 /* eslint-disable @typescript-eslint/no-var-requires */
 const UserModel = require('../entities/User/model').default
-const { DiscourseService } = require('./DiscourseService')
+const { DiscourseService, IncompleteDiscourseCommentsError } = require('./DiscourseService')
 const { UserService } = require('./user')
 /* eslint-enable @typescript-eslint/no-var-requires */
 
@@ -33,7 +34,7 @@ function comment(userForumId: number | undefined, cooked: string, createdAt: Dat
 }
 
 function stubComments(comments: ProposalComment[]) {
-  jest
+  return jest
     .spyOn(DiscourseService, 'getPostComments')
     .mockResolvedValue({ totalComments: comments.length, comments } as never)
 }
@@ -69,10 +70,15 @@ describe('linking a forum account to a dao address', () => {
 
   describe('when only the genuine signer posted their verification comment', () => {
     let result: { valid: boolean }
+    let getPostComments: jest.SpyInstance
 
     beforeEach(async () => {
-      stubComments([comment(SIGNER_FORUM_ID, posted, now)])
+      getPostComments = stubComments([comment(SIGNER_FORUM_ID, posted, now)])
       result = await UserService.validateForumUser(signer.address)
+    })
+
+    it('should require a complete forum comment set', () => {
+      expect(getPostComments).toHaveBeenCalledWith(expect.any(Number), { requireComplete: true })
     })
 
     it('should report the validation as valid', () => {
@@ -100,6 +106,31 @@ describe('linking a forum account to a dao address', () => {
     })
 
     it('should not link any forum account', () => {
+      expect(createForumConnection).not.toHaveBeenCalled()
+    })
+  })
+
+  describe('when the complete forum history cannot be fetched', () => {
+    let thrown: RequestError
+
+    beforeEach(async () => {
+      jest
+        .spyOn(DiscourseService, 'getPostComments')
+        .mockRejectedValue(new IncompleteDiscourseCommentsError(123) as never)
+      thrown = (await UserService.validateForumUser(signer.address).catch(
+        (error: RequestError) => error
+      )) as RequestError
+    })
+
+    it('should expose a retryable service-unavailable status', () => {
+      expect(thrown.statusCode).toBe(503)
+    })
+
+    it('should identify the incomplete validation source', () => {
+      expect(thrown.code).toBe('validation_source_incomplete')
+    })
+
+    it('should not link a forum account', () => {
       expect(createForumConnection).not.toHaveBeenCalled()
     })
   })

--- a/src/services/user.forumLinking.test.ts
+++ b/src/services/user.forumLinking.test.ts
@@ -1,0 +1,175 @@
+import { Wallet } from 'ethers'
+
+import { ProposalComment } from '../entities/Proposal/types'
+import { AccountType } from '../entities/User/types'
+import { formatValidationMessage } from '../entities/User/utils'
+
+jest.mock('../entities/User/model', () => ({
+  __esModule: true,
+  default: {
+    createDiscordConnection: jest.fn(),
+    createForumConnection: jest.fn(),
+  },
+}))
+
+// Required after the mock so the service picks up the stubbed model.
+/* eslint-disable @typescript-eslint/no-var-requires */
+const UserModel = require('../entities/User/model').default
+const { DiscourseService } = require('./DiscourseService')
+const { UserService } = require('./user')
+/* eslint-enable @typescript-eslint/no-var-requires */
+
+const SIGNER_FORUM_ID = 200
+const OTHER_FORUM_ID = 999
+
+function comment(userForumId: number | undefined, cooked: string, createdAt: Date): ProposalComment {
+  return {
+    user_forum_id: userForumId as number,
+    username: `user-${userForumId}`,
+    avatar_url: 'https://forum.test.url/avatar.png',
+    created_at: createdAt.toISOString(),
+    cooked,
+  }
+}
+
+function stubComments(comments: ProposalComment[]) {
+  jest
+    .spyOn(DiscourseService, 'getPostComments')
+    .mockResolvedValue({ totalComments: comments.length, comments } as never)
+}
+
+describe('linking a forum account to a dao address', () => {
+  let signer: Wallet
+  let posted: string
+  let now: Date
+  let createForumConnection: jest.Mock
+
+  beforeEach(async () => {
+    jest.clearAllMocks()
+    createForumConnection = UserModel.createForumConnection as jest.Mock
+
+    now = new Date()
+    signer = Wallet.createRandom()
+    const message = UserService.getValidationMessage(signer.address, AccountType.Forum)
+    posted = `${message}\n\n${await signer.signMessage(message)}`
+  })
+
+  afterEach(() => {
+    const inProgress = (
+      UserService as unknown as {
+        VALIDATIONS_IN_PROGRESS: Record<string, { message_timeout: NodeJS.Timeout }>
+      }
+    ).VALIDATIONS_IN_PROGRESS
+    Object.keys(inProgress).forEach((key) => {
+      clearTimeout(inProgress[key].message_timeout)
+      delete inProgress[key]
+    })
+    jest.restoreAllMocks()
+  })
+
+  describe('when only the genuine signer posted their verification comment', () => {
+    let result: { valid: boolean }
+
+    beforeEach(async () => {
+      stubComments([comment(SIGNER_FORUM_ID, posted, now)])
+      result = await UserService.validateForumUser(signer.address)
+    })
+
+    it('should report the validation as valid', () => {
+      expect(result.valid).toBe(true)
+    })
+
+    it('should link the forum account of the genuine signer', () => {
+      expect(createForumConnection).toHaveBeenCalledWith(signer.address, String(SIGNER_FORUM_ID))
+    })
+  })
+
+  describe('when another forum account reposts the verification comment verbatim', () => {
+    let thrown: Error
+
+    beforeEach(async () => {
+      stubComments([
+        comment(SIGNER_FORUM_ID, posted, now),
+        comment(OTHER_FORUM_ID, posted, new Date(now.getTime() + 1200)),
+      ])
+      thrown = (await UserService.validateForumUser(signer.address).catch((error: Error) => error)) as Error
+    })
+
+    it('should refuse the ambiguous match', () => {
+      expect(thrown.message).toBe('Multiple forum accounts posted the same valid verification message')
+    })
+
+    it('should not link any forum account', () => {
+      expect(createForumConnection).not.toHaveBeenCalled()
+    })
+  })
+
+  // A message signed for the discord flow must not satisfy the forum one.
+  describe('when the comment carries a signature made for another account type', () => {
+    let result: { valid: boolean }
+
+    beforeEach(async () => {
+      const discordMessage = formatValidationMessage(signer.address, now.toISOString(), AccountType.Discord)
+      const signature = await signer.signMessage(discordMessage)
+      stubComments([comment(SIGNER_FORUM_ID, `${discordMessage}\n\n${signature}`, now)])
+      result = await UserService.validateForumUser(signer.address)
+    })
+
+    it('should not link the account', () => {
+      expect(result.valid).toBe(false)
+    })
+  })
+
+  // Comments arrive as Discourse's rendered `cooked` html, not as the plain text the user typed, so
+  // the address, timestamp and signature all have to survive that rendering to be matched.
+  describe('when the comment arrives as rendered discourse html', () => {
+    let result: { valid: boolean }
+
+    beforeEach(async () => {
+      const message = UserService.getValidationMessage(signer.address, AccountType.Forum)
+      const signature = await signer.signMessage(message)
+      const [statement, date] = message.split('\n\n')
+      const cooked =
+        `<p>${statement}<br>\n${date}</p>\n<p>${signature}</p>\n` +
+        `<p><a href="https://forum.test.url/t/1234" rel="noopener nofollow ugc">the thread</a></p>`
+      stubComments([comment(SIGNER_FORUM_ID, cooked, now)])
+      result = await UserService.validateForumUser(signer.address)
+    })
+
+    it('should still link the account', () => {
+      expect(result.valid).toBe(true)
+    })
+
+    it('should link the author of that comment', () => {
+      expect(createForumConnection).toHaveBeenCalledWith(signer.address, String(SIGNER_FORUM_ID))
+    })
+  })
+
+  describe('when a matching comment has no forum author id', () => {
+    let result: { valid: boolean }
+
+    beforeEach(async () => {
+      stubComments([comment(undefined, posted, now)])
+      result = await UserService.validateForumUser(signer.address)
+    })
+
+    it('should ignore it rather than link an unattributable comment', () => {
+      expect(createForumConnection).not.toHaveBeenCalled()
+      expect(result.valid).toBe(false)
+    })
+  })
+
+  describe('when the forum account is already linked to another address', () => {
+    let thrown: Error
+
+    beforeEach(async () => {
+      createForumConnection.mockRejectedValueOnce(Object.assign(new Error('duplicate key'), { code: '23505' }))
+      stubComments([comment(SIGNER_FORUM_ID, posted, now)])
+      thrown = (await UserService.validateForumUser(signer.address).catch((error: Error) => error)) as Error
+    })
+
+    it('should explain the conflict rather than surface the driver error', () => {
+      expect(thrown.message).toBe('That Forum account is already linked to another address')
+    })
+  })
+})

--- a/src/services/user.ts
+++ b/src/services/user.ts
@@ -1,11 +1,14 @@
 import { ChainId } from '@dcl/schemas/dist/dapps/chain-id'
+import RequestError from 'decentraland-gatsby/dist/entities/Route/error'
+import capitalize from 'lodash/capitalize'
 
 import { PUSH_CHANNEL_ID } from '../constants'
 import { isSameAddress } from '../entities/Snapshot/utils'
 import { GATSBY_DISCOURSE_CONNECT_THREAD, MESSAGE_TIMEOUT_TIME } from '../entities/User/constants'
 import UserModel from '../entities/User/model'
 import { AccountType, UserAttributes, UserProfile, ValidationComment, ValidationMessage } from '../entities/User/types'
-import { formatValidationMessage, getValidationComment, toAccountType, validateComment } from '../entities/User/utils'
+import { AmbiguousValidationError, formatValidationMessage, getValidationComment } from '../entities/User/utils'
+import { ErrorCategory } from '../utils/errorCategories'
 import { isProdEnv } from '../utils/governanceEnvs'
 import { getCaipAddress, getPushNotificationsEnv } from '../utils/notifications'
 
@@ -18,27 +21,39 @@ import PushAPI = require('@pushprotocol/restapi')
 export class UserService {
   private static VALIDATIONS_IN_PROGRESS: Record<string, ValidationMessage> = {}
 
-  private static clearValidationInProgress(user: string) {
-    const validation = this.VALIDATIONS_IN_PROGRESS[user]
+  // Keyed by account as well as address so opening one flow does not cancel the other.
+  private static validationKey(address: string, account: AccountType) {
+    return `${address.toLowerCase()}:${account}`
+  }
+
+  private static clearValidationInProgress(address: string, account: AccountType) {
+    const key = this.validationKey(address, account)
+    const validation = this.VALIDATIONS_IN_PROGRESS[key]
     if (validation) {
       clearTimeout(validation.message_timeout)
-      delete this.VALIDATIONS_IN_PROGRESS[user]
+      delete this.VALIDATIONS_IN_PROGRESS[key]
     }
   }
 
-  static getValidationMessage(address: string, account?: string) {
+  static getValidationMessage(address: string, account: AccountType) {
+    // Discard any window already open for this pair, otherwise its timer fires later and expires
+    // the window opened here instead of the one it was scheduled for.
+    this.clearValidationInProgress(address, account)
+
     const timestamp = new Date().toISOString()
+    const key = this.validationKey(address, account)
     const message_timeout = setTimeout(() => {
-      delete this.VALIDATIONS_IN_PROGRESS[address]
+      delete this.VALIDATIONS_IN_PROGRESS[key]
     }, MESSAGE_TIMEOUT_TIME)
 
-    this.VALIDATIONS_IN_PROGRESS[address] = {
+    this.VALIDATIONS_IN_PROGRESS[key] = {
       address,
       timestamp,
+      account,
       message_timeout,
     }
 
-    return formatValidationMessage(address, timestamp, toAccountType(account))
+    return formatValidationMessage(address, timestamp, account)
   }
 
   static async validateForumUser(user: string) {
@@ -46,7 +61,9 @@ export class UserService {
       const comments = await DiscourseService.getPostComments(Number(GATSBY_DISCOURSE_CONNECT_THREAD))
       const formattedComments = comments.comments.map<ValidationComment>((comment) => ({
         id: '',
-        userId: String(comment.user_forum_id),
+        // Left empty rather than stringified when absent, so 'undefined' does not become an author
+        // id that several unattributable comments appear to share.
+        userId: comment.user_forum_id != null ? String(comment.user_forum_id) : '',
         content: comment.cooked,
         timestamp: new Date(comment.created_at).getTime(),
       }))
@@ -56,27 +73,39 @@ export class UserService {
         valid: !!validationComment,
       }
     } catch (error) {
+      // Preserve a deliberate client-facing failure instead of remapping it to a 500.
+      if (error instanceof RequestError) {
+        throw error
+      }
+      // Someone posted a valid copy of another account's verification message. Nothing was linked,
+      // but it blocks the genuine attempt, so it should be visible rather than a generic failure.
+      if (error instanceof AmbiguousValidationError) {
+        ErrorService.report('Multiple valid verification messages matched one address', {
+          address: user,
+          account: AccountType.Forum,
+          category: ErrorCategory.Discourse,
+        })
+        throw new RequestError('Multiple forum accounts posted the same valid verification message', 409, {
+          code: 'ambiguous_validation',
+        })
+      }
       throw new Error("Couldn't validate the user. " + error)
     }
   }
 
   static async checkForumValidationMessage(user: string, validationComments: ValidationComment[]) {
-    const messageProperties = this.VALIDATIONS_IN_PROGRESS[user]
+    const messageProperties = this.VALIDATIONS_IN_PROGRESS[this.validationKey(user, AccountType.Forum)]
     if (!messageProperties) {
       throw new Error('Validation timed out')
     }
 
     const { address, timestamp } = messageProperties
 
-    const validationComment = getValidationComment(validationComments, address, timestamp)
+    const validationComment = getValidationComment(validationComments, address, timestamp, AccountType.Forum)
 
     if (validationComment) {
-      if (!isSameAddress(address, user) || !validateComment(validationComment, address, timestamp, AccountType.Forum)) {
-        throw new Error('Validation failed')
-      }
-
-      await UserModel.createForumConnection(user, validationComment.userId)
-      this.clearValidationInProgress(user)
+      await this.createConnection(AccountType.Forum, user, validationComment.userId)
+      this.clearValidationInProgress(user, AccountType.Forum)
     }
 
     return validationComment
@@ -106,30 +135,61 @@ export class UserService {
         valid: !!validationComment,
       }
     } catch (error) {
+      // Preserve a deliberate client-facing failure instead of remapping it to a 500.
+      if (error instanceof RequestError) {
+        throw error
+      }
+      // Someone posted a valid copy of another account's verification message. Nothing was linked,
+      // but it blocks the genuine attempt, so it should be visible rather than a generic failure.
+      if (error instanceof AmbiguousValidationError) {
+        ErrorService.report('Multiple valid verification messages matched one address', {
+          address: user,
+          account: AccountType.Discord,
+          category: ErrorCategory.Discord,
+        })
+        throw new RequestError('Multiple Discord accounts posted the same valid verification message', 409, {
+          code: 'ambiguous_validation',
+        })
+      }
       throw new Error("Couldn't validate the user. " + error)
     }
   }
+
   static async checkDiscordValidationMessage(user: string, validationComments: ValidationComment[]) {
-    const messageProperties = this.VALIDATIONS_IN_PROGRESS[user]
+    const messageProperties = this.VALIDATIONS_IN_PROGRESS[this.validationKey(user, AccountType.Discord)]
     if (!messageProperties) {
       throw new Error('Validation timed out')
     }
     const { address, timestamp } = messageProperties
 
-    const validationComment = getValidationComment(validationComments, address, timestamp)
+    const validationComment = getValidationComment(validationComments, address, timestamp, AccountType.Discord)
 
     if (validationComment) {
-      if (
-        !isSameAddress(address, user) ||
-        !validateComment(validationComment, address, timestamp, AccountType.Discord)
-      ) {
-        throw new Error('Validation failed')
-      }
-      await UserModel.createDiscordConnection(user, validationComment.userId)
-      this.clearValidationInProgress(user)
+      await this.createConnection(AccountType.Discord, user, validationComment.userId)
+      this.clearValidationInProgress(user, AccountType.Discord)
     }
 
     return validationComment
+  }
+
+  // forum_id and discord_id are unique across addresses, so an account already linked elsewhere
+  // reaches the insert and fails there. Answer with the reason instead of a driver error.
+  private static async createConnection(account: AccountType, address: string, accountId: string) {
+    try {
+      if (account === AccountType.Discord) {
+        await UserModel.createDiscordConnection(address, accountId)
+      } else {
+        await UserModel.createForumConnection(address, accountId)
+      }
+    } catch (error) {
+      if ((error as { code?: string })?.code === '23505') {
+        throw new RequestError(
+          `That ${capitalize(account)} account is already linked to another address`,
+          RequestError.BadRequest
+        )
+      }
+      throw error
+    }
   }
 
   static async updateDiscordActiveStatus(address: string, is_discord_notifications_active: boolean) {

--- a/src/services/user.ts
+++ b/src/services/user.ts
@@ -19,7 +19,7 @@ import { getCaipAddress, getPushNotificationsEnv } from '../utils/notifications'
 
 import { DiscourseService, IncompleteDiscourseCommentsError } from './DiscourseService'
 import { ErrorService } from './ErrorService'
-import { DiscordService } from './discord'
+import { DiscordService, IncompleteDiscordVerificationReadError } from './discord'
 
 import PushAPI = require('@pushprotocol/restapi')
 
@@ -169,8 +169,9 @@ export class UserService {
       throw new RequestError(error.message, 408, { code: 'validation_timeout' })
     }
 
-    if (error instanceof IncompleteDiscourseCommentsError) {
-      throw new RequestError('Could not read the complete forum verification history; please retry', 503, {
+    if (error instanceof IncompleteDiscourseCommentsError || error instanceof IncompleteDiscordVerificationReadError) {
+      const source = account === AccountType.Forum ? 'forum' : 'Discord'
+      throw new RequestError(`Could not read the complete ${source} verification history; please retry`, 503, {
         code: 'validation_source_incomplete',
       })
     }
@@ -188,7 +189,13 @@ export class UserService {
       })
     }
 
-    throw new Error("Couldn't validate the user. " + error)
+    ErrorService.report('Unexpected profile validation failure', {
+      address: user,
+      account,
+      error: `${error}`,
+      category: account === AccountType.Forum ? ErrorCategory.Discourse : ErrorCategory.Discord,
+    })
+    throw new RequestError("Couldn't validate the user", RequestError.InternalServerError)
   }
 
   static async checkDiscordValidationMessage(user: string, validationComments: ValidationComment[]) {

--- a/src/services/user.ts
+++ b/src/services/user.ts
@@ -217,12 +217,19 @@ export class UserService {
 
   // forum_id and discord_id are unique across addresses, so an account already linked elsewhere
   // reaches the insert and fails there. Answer with the reason instead of a driver error.
-  private static async createConnection(account: AccountType, address: string, accountId: string) {
+  private static async createConnection(
+    account: AccountType.Forum | AccountType.Discord,
+    address: string,
+    accountId: string
+  ) {
     try {
-      if (account === AccountType.Discord) {
-        await UserModel.createDiscordConnection(address, accountId)
-      } else {
-        await UserModel.createForumConnection(address, accountId)
+      switch (account) {
+        case AccountType.Discord:
+          await UserModel.createDiscordConnection(address, accountId)
+          break
+        case AccountType.Forum:
+          await UserModel.createForumConnection(address, accountId)
+          break
       }
     } catch (error) {
       if ((error as { code?: string })?.code === '23505') {

--- a/src/services/user.ts
+++ b/src/services/user.ts
@@ -7,12 +7,17 @@ import { isSameAddress } from '../entities/Snapshot/utils'
 import { GATSBY_DISCOURSE_CONNECT_THREAD, MESSAGE_TIMEOUT_TIME } from '../entities/User/constants'
 import UserModel from '../entities/User/model'
 import { AccountType, UserAttributes, UserProfile, ValidationComment, ValidationMessage } from '../entities/User/types'
-import { AmbiguousValidationError, formatValidationMessage, getValidationComment } from '../entities/User/utils'
+import {
+  AmbiguousValidationError,
+  ValidationTimeoutError,
+  formatValidationMessage,
+  getValidationComment,
+} from '../entities/User/utils'
 import { ErrorCategory } from '../utils/errorCategories'
 import { isProdEnv } from '../utils/governanceEnvs'
 import { getCaipAddress, getPushNotificationsEnv } from '../utils/notifications'
 
-import { DiscourseService } from './DiscourseService'
+import { DiscourseService, IncompleteDiscourseCommentsError } from './DiscourseService'
 import { ErrorService } from './ErrorService'
 import { DiscordService } from './discord'
 
@@ -58,7 +63,9 @@ export class UserService {
 
   static async validateForumUser(user: string) {
     try {
-      const comments = await DiscourseService.getPostComments(Number(GATSBY_DISCOURSE_CONNECT_THREAD))
+      const comments = await DiscourseService.getPostComments(Number(GATSBY_DISCOURSE_CONNECT_THREAD), {
+        requireComplete: true,
+      })
       const formattedComments = comments.comments.map<ValidationComment>((comment) => ({
         id: '',
         // Left empty rather than stringified when absent, so 'undefined' does not become an author
@@ -73,30 +80,14 @@ export class UserService {
         valid: !!validationComment,
       }
     } catch (error) {
-      // Preserve a deliberate client-facing failure instead of remapping it to a 500.
-      if (error instanceof RequestError) {
-        throw error
-      }
-      // Someone posted a valid copy of another account's verification message. Nothing was linked,
-      // but it blocks the genuine attempt, so it should be visible rather than a generic failure.
-      if (error instanceof AmbiguousValidationError) {
-        ErrorService.report('Multiple valid verification messages matched one address', {
-          address: user,
-          account: AccountType.Forum,
-          category: ErrorCategory.Discourse,
-        })
-        throw new RequestError('Multiple forum accounts posted the same valid verification message', 409, {
-          code: 'ambiguous_validation',
-        })
-      }
-      throw new Error("Couldn't validate the user. " + error)
+      this.handleValidationError(error, user, AccountType.Forum)
     }
   }
 
   static async checkForumValidationMessage(user: string, validationComments: ValidationComment[]) {
     const messageProperties = this.VALIDATIONS_IN_PROGRESS[this.validationKey(user, AccountType.Forum)]
     if (!messageProperties) {
-      throw new Error('Validation timed out')
+      throw new ValidationTimeoutError()
     }
 
     const { address, timestamp } = messageProperties
@@ -112,6 +103,7 @@ export class UserService {
   }
 
   static async validateDiscordUser(user: string) {
+    let validationComment: ValidationComment | undefined
     try {
       const messages = await DiscordService.getProfileVerificationMessages()
       const formattedMessages = messages.map<ValidationComment>((message) => ({
@@ -121,44 +113,88 @@ export class UserService {
         timestamp: message.createdTimestamp,
       }))
 
-      const validationComment = await this.checkDiscordValidationMessage(user, formattedMessages)
-      if (validationComment) {
-        await DiscordService.deleteVerificationMessage(validationComment.id)
-        DiscordService.sendDirectMessage(validationComment.userId, {
-          title: 'Profile verification completed ✅',
-          action: `You have been verified as ${user}\n\nFrom now on you will receive important notifications for you through this channel.`,
-          fields: [],
-        })
-      }
-
-      return {
-        valid: !!validationComment,
-      }
+      validationComment = await this.checkDiscordValidationMessage(user, formattedMessages)
     } catch (error) {
-      // Preserve a deliberate client-facing failure instead of remapping it to a 500.
-      if (error instanceof RequestError) {
-        throw error
-      }
-      // Someone posted a valid copy of another account's verification message. Nothing was linked,
-      // but it blocks the genuine attempt, so it should be visible rather than a generic failure.
-      if (error instanceof AmbiguousValidationError) {
-        ErrorService.report('Multiple valid verification messages matched one address', {
-          address: user,
-          account: AccountType.Discord,
-          category: ErrorCategory.Discord,
-        })
-        throw new RequestError('Multiple Discord accounts posted the same valid verification message', 409, {
-          code: 'ambiguous_validation',
-        })
-      }
-      throw new Error("Couldn't validate the user. " + error)
+      this.handleValidationError(error, user, AccountType.Discord)
     }
+
+    if (validationComment) {
+      await this.runDiscordPostLinkActions(user, validationComment)
+    }
+
+    return {
+      valid: !!validationComment,
+    }
+  }
+
+  private static async runDiscordPostLinkActions(user: string, validationComment: ValidationComment): Promise<void> {
+    try {
+      await DiscordService.deleteVerificationMessage(validationComment.id)
+    } catch (error) {
+      ErrorService.report('Could not delete a completed Discord verification message', {
+        address: user,
+        messageId: validationComment.id,
+        error: `${error}`,
+        category: ErrorCategory.Discord,
+      })
+    }
+
+    try {
+      DiscordService.sendDirectMessage(validationComment.userId, {
+        title: 'Profile verification completed ✅',
+        action: `You have been verified as ${user}\n\nFrom now on you will receive important notifications for you through this channel.`,
+        fields: [],
+      })
+    } catch (error) {
+      ErrorService.report('Could not enqueue the Discord verification confirmation', {
+        address: user,
+        discordUserId: validationComment.userId,
+        error: `${error}`,
+        category: ErrorCategory.Discord,
+      })
+    }
+  }
+
+  private static handleValidationError(
+    error: unknown,
+    user: string,
+    account: AccountType.Forum | AccountType.Discord
+  ): never {
+    // Preserve deliberate client-facing failures instead of remapping them to a 500.
+    if (error instanceof RequestError) {
+      throw error
+    }
+
+    if (error instanceof ValidationTimeoutError) {
+      throw new RequestError(error.message, 408, { code: 'validation_timeout' })
+    }
+
+    if (error instanceof IncompleteDiscourseCommentsError) {
+      throw new RequestError('Could not read the complete forum verification history; please retry', 503, {
+        code: 'validation_source_incomplete',
+      })
+    }
+
+    // A valid copy posted by another account blocks the genuine attempt without linking anything.
+    if (error instanceof AmbiguousValidationError) {
+      ErrorService.report('Multiple valid verification messages matched one address', {
+        address: user,
+        account,
+        category: account === AccountType.Forum ? ErrorCategory.Discourse : ErrorCategory.Discord,
+      })
+      const accountName = account === AccountType.Forum ? 'forum' : 'Discord'
+      throw new RequestError(`Multiple ${accountName} accounts posted the same valid verification message`, 409, {
+        code: 'ambiguous_validation',
+      })
+    }
+
+    throw new Error("Couldn't validate the user. " + error)
   }
 
   static async checkDiscordValidationMessage(user: string, validationComments: ValidationComment[]) {
     const messageProperties = this.VALIDATIONS_IN_PROGRESS[this.validationKey(user, AccountType.Discord)]
     if (!messageProperties) {
-      throw new Error('Validation timed out')
+      throw new ValidationTimeoutError()
     }
     const { address, timestamp } = messageProperties
 

--- a/src/services/user.validationWindow.test.ts
+++ b/src/services/user.validationWindow.test.ts
@@ -1,0 +1,96 @@
+import { MESSAGE_TIMEOUT_TIME } from '../entities/User/constants'
+import { AccountType } from '../entities/User/types'
+
+jest.mock('../entities/User/model', () => ({
+  __esModule: true,
+  default: { createDiscordConnection: jest.fn(), createForumConnection: jest.fn() },
+}))
+
+// eslint-disable-next-line @typescript-eslint/no-var-requires
+const { UserService } = require('./user')
+
+const ADDRESS = '0x2AC89522CB415AC333E64F52a1a5693218cEBD58'
+
+function openWindows(): Record<string, { message_timeout: NodeJS.Timeout }> {
+  return (UserService as unknown as { VALIDATIONS_IN_PROGRESS: Record<string, { message_timeout: NodeJS.Timeout }> })
+    .VALIDATIONS_IN_PROGRESS
+}
+
+describe('the validation window', () => {
+  beforeEach(() => {
+    jest.useFakeTimers()
+  })
+
+  afterEach(() => {
+    Object.keys(openWindows()).forEach((key) => {
+      clearTimeout(openWindows()[key].message_timeout)
+      delete openWindows()[key]
+    })
+    jest.useRealTimers()
+  })
+
+  describe('when it is left to expire', () => {
+    beforeEach(() => {
+      UserService.getValidationMessage(ADDRESS, AccountType.Discord)
+      jest.advanceTimersByTime(MESSAGE_TIMEOUT_TIME)
+    })
+
+    it('should no longer be open', () => {
+      expect(Object.keys(openWindows())).toHaveLength(0)
+    })
+  })
+
+  // The timer from the first request used to survive and expire the second request's window.
+  describe('when a second message is requested before the first window expires', () => {
+    beforeEach(() => {
+      UserService.getValidationMessage(ADDRESS, AccountType.Discord)
+      jest.advanceTimersByTime(60 * 1000)
+      UserService.getValidationMessage(ADDRESS, AccountType.Discord)
+      jest.advanceTimersByTime(MESSAGE_TIMEOUT_TIME - 60 * 1000)
+    })
+
+    it('should keep the second window open for its own full duration', () => {
+      expect(Object.keys(openWindows())).toHaveLength(1)
+    })
+
+    it('should close it once its own timeout elapses', () => {
+      jest.advanceTimersByTime(60 * 1000)
+      expect(Object.keys(openWindows())).toHaveLength(0)
+    })
+  })
+
+  describe('when a window is opened for each account type', () => {
+    beforeEach(() => {
+      UserService.getValidationMessage(ADDRESS, AccountType.Discord)
+      UserService.getValidationMessage(ADDRESS, AccountType.Forum)
+    })
+
+    it('should keep both rather than let one replace the other', () => {
+      expect(Object.keys(openWindows())).toHaveLength(2)
+    })
+  })
+
+  describe('when a discord validation is checked with no window open', () => {
+    let thrown: Error
+
+    beforeEach(async () => {
+      thrown = (await UserService.checkDiscordValidationMessage(ADDRESS, []).catch((error: Error) => error)) as Error
+    })
+
+    it('should report the validation as timed out', () => {
+      expect(thrown.message).toBe('Validation timed out')
+    })
+  })
+
+  describe('when a forum validation is checked with no window open', () => {
+    let thrown: Error
+
+    beforeEach(async () => {
+      thrown = (await UserService.checkForumValidationMessage(ADDRESS, []).catch((error: Error) => error)) as Error
+    })
+
+    it('should report the validation as timed out', () => {
+      expect(thrown.message).toBe('Validation timed out')
+    })
+  })
+})

--- a/test/integration/userAccounts.test.ts
+++ b/test/integration/userAccounts.test.ts
@@ -109,9 +109,52 @@ describe('the user account queries', () => {
         expect(outcome).toBeInstanceOf(Error)
       })
 
+      // UserService maps this code to a 400 explaining the account is taken. Asserted against a real
+      // Postgres because the unit test supplies the code itself, so it cannot prove the driver does.
+      it('should refuse it with a unique violation', () => {
+        expect((outcome as { code?: string }).code).toBe('23505')
+      })
+
       it('should leave the first wallet holding it', async () => {
         const [found] = await UserModel.getAddressesByForumId([FORUM_ID])
         expect(found?.address).toBe(ADDRESS.toLowerCase())
+      })
+    })
+  })
+
+  describe('createDiscordConnection', () => {
+    describe('when the wallet links a discord account twice', () => {
+      beforeEach(async () => {
+        await UserModel.createDiscordConnection(ADDRESS, DISCORD_ID)
+        await UserModel.createDiscordConnection(ADDRESS, 'discord-user-2')
+      })
+
+      it('should replace the link rather than fail on the existing row', async () => {
+        const [found] = await UserModel.getDiscordIds([ADDRESS])
+        expect(found?.discord_id).toBe('discord-user-2')
+      })
+    })
+
+    // A discord account belongs to one wallet, enforced by a unique constraint rather than by code.
+    describe('when a second wallet claims the same discord account', () => {
+      let outcome: unknown
+
+      beforeEach(async () => {
+        await UserModel.createDiscordConnection(ADDRESS, DISCORD_ID)
+        outcome = await UserModel.createDiscordConnection(OTHER_ADDRESS, DISCORD_ID).catch((error) => error)
+      })
+
+      it('should refuse the second claim', () => {
+        expect(outcome).toBeInstanceOf(Error)
+      })
+
+      it('should refuse it with a unique violation', () => {
+        expect((outcome as { code?: string }).code).toBe('23505')
+      })
+
+      it('should leave the first wallet holding it', async () => {
+        const [found] = await UserModel.getDiscordIds([ADDRESS])
+        expect(found?.discord_id).toBe(DISCORD_ID)
       })
     })
   })


### PR DESCRIPTION
Improvements to the forum/discord account link flow and the Discord client around it.

## Reading the verification channel

- Bounded by the **validation window** rather than by a fixed message count, paging until the window is covered. Previously a single `limit: 10` fetch decided what the check could see, so ordinary channel traffic could push a pending verification message out of view — the user then polled for the full five minutes with nothing happening and no error anywhere.
- When a busy channel does not fit the page budget, it answers with nothing rather than from a partial read. A partial read is taken from the newest end, so it cannot show whether a message has been duplicated.
- One read is shared between concurrent polls for a few seconds, so each poll no longer spends the bot's API budget on an identical fetch against a rate limit shared with notifications and announcements.
- Resolves the channel with `channels.fetch` instead of `channels.cache`. The cache is only populated for channels the gateway has already delivered, so a cold start or a reconnect silently returned no messages.

## Selecting the verification comment

- The signature is checked while selecting candidates rather than after, so a comment carrying only the address and timestamp — both public once the genuine comment is posted — is simply not a candidate.
- Candidate **accounts** are counted rather than candidate comments, so posting the same verification message twice no longer looks ambiguous and still links. Two posts from one account resolve to the same link.
- Comments with no author id are not candidates, and the forum author id is left empty rather than stringified when absent, so `'undefined'` cannot become an author id that several comments appear to share.
- A malformed signature is a rejected candidate instead of letting the recovery error surface as a 500.

## Discord client

- The login rejection is caught. Nothing in the process handles unhandled rejections and Node exits non-zero on one, so a revoked or malformed token terminated the whole server instead of leaving Discord disabled.
- The client error listener was registered for `unhandledRejection`, which discord.js never emits — it compiled only via the inherited `EventEmitter` overload, so every client error it was written to report had been dropped. It now listens for `error`.

## Validation window and errors

- Keyed by account as well as address, so opening one flow no longer cancels the other.
- A window already open for a pair is discarded when a new one is issued. The earlier request's timer used to survive and expire the window opened after it, so retrying could get a window that closed early.
- An account already linked to another address answers with a 400 explaining the conflict instead of the driver error, and a deliberate client-facing failure is no longer remapped to a 500.
- `GET /user/validate` requires an account type. It is part of the message that gets signed, so a message issued without one could never validate against either flow.
- Push no longer has a placeholder column name in the `isValidated` column map, so its guard can report it; a tautological address comparison is gone.

## Tests

New unit suites for the channel read, the validation window, the discord and forum link paths, and the Discord client init. Integration assertions that an account collision really is Postgres `23505` — the code the 400 above depends on, which until now only existed in a hand-built mock.

- unit: 65 suites, 1050 passed
- integration: 16 suites, 246 passed

## Deploy note

Safe to merge before the UI change: the deployed UI already always sends the account type, so the stricter `GET /user/validate` does not break it.
