### PR TITLE
fix: derive update authorship from the authenticated caller

### DIFF
--- a/src/routes/update.test.ts
+++ b/src/routes/update.test.ts
@@ -9,6 +9,7 @@ import { createTestApp } from './testApp'
 import update from './update'
 
 const AUTHOR = '0x2AC89522CB415AC333E64F52a1a5693218cEBD58'
+const COAUTHOR = '0x4Fc4dE7CD3F8f04F2c9d61A0b1b0A08D5F0e6b3A'
 const STRANGER = '0x56d0B5eD3D525332F00C9BC938f93598ab16AAA7'
 const PROJECT_ID = '00000000-0000-0000-0000-000000000002'
 const UPDATE_ID = '00000000-0000-0000-0000-000000000003'
@@ -123,6 +124,19 @@ describe('the project update routes', () => {
         expect(create).toHaveBeenCalledTimes(1)
       })
     })
+
+    describe('when the body claims a different author', () => {
+      beforeEach(async () => {
+        await supertest(app)
+          .post('/api/updates')
+          .set('x-test-auth', COAUTHOR)
+          .send({ project_id: PROJECT_ID, ...VALID_BODY, author: AUTHOR })
+      })
+
+      it('should store the authenticated caller instead', () => {
+        expect(create).toHaveBeenCalledWith(expect.objectContaining({ author: COAUTHOR }), expect.anything(), COAUTHOR)
+      })
+    })
   })
 
   describe('PATCH /api/updates/:update_id', () => {
@@ -202,6 +216,58 @@ describe('the project update routes', () => {
 
       it('should apply the edit', () => {
         expect(updateProjectUpdate).toHaveBeenCalledTimes(1)
+      })
+    })
+
+    describe('when a coauthor edits an update someone else wrote', () => {
+      beforeEach(async () => {
+        ;(UpdateService.getById as jest.Mock).mockResolvedValue({
+          id: UPDATE_ID,
+          project_id: PROJECT_ID,
+          author: AUTHOR,
+          completion_date: new Date(),
+        })
+        response = await supertest(app)
+          .patch(`/api/updates/${UPDATE_ID}`)
+          .set('x-test-auth', COAUTHOR)
+          .send({ ...VALID_PATCH_BODY, author: STRANGER })
+      })
+
+      it('should allow the edit', () => {
+        expect(response.status).toBe(201)
+      })
+
+      it('should keep the stored author rather than the one in the body', () => {
+        expect(updateProjectUpdate).toHaveBeenCalledWith(
+          expect.anything(),
+          expect.anything(),
+          expect.objectContaining({ author: AUTHOR }),
+          COAUTHOR
+        )
+      })
+    })
+
+    describe('when a coauthor completes a pending update that has no author yet', () => {
+      beforeEach(async () => {
+        ;(UpdateService.getById as jest.Mock).mockResolvedValue({
+          id: UPDATE_ID,
+          project_id: PROJECT_ID,
+          author: null,
+          completion_date: null,
+        })
+        await supertest(app)
+          .patch(`/api/updates/${UPDATE_ID}`)
+          .set('x-test-auth', COAUTHOR)
+          .send({ ...VALID_PATCH_BODY, author: AUTHOR })
+      })
+
+      it('should record the caller as the author', () => {
+        expect(updateProjectUpdate).toHaveBeenCalledWith(
+          expect.anything(),
+          expect.anything(),
+          expect.objectContaining({ author: COAUTHOR }),
+          COAUTHOR
+        )
       })
     })
   })

--- a/src/routes/update.ts
+++ b/src/routes/update.ts
@@ -6,6 +6,7 @@ import validate from 'decentraland-gatsby/dist/entities/Route/validate'
 import schema from 'decentraland-gatsby/dist/entities/Schema'
 import { Request } from 'express'
 import isNaN from 'lodash/isNaN'
+import omit from 'lodash/omit'
 import toNumber from 'lodash/toNumber'
 
 import {
@@ -105,10 +106,11 @@ async function getProjectUpdateComments(req: Request<{ update_id: string }>) {
 const generalSectionValidator = schema.compile(GeneralUpdateSectionSchema)
 async function updateProjectUpdate(req: WithAuth<Request<{ update_id: string }>>) {
   const id = req.params.update_id
-  const { author, financial_records, ...body } = req.body
+  const { financial_records, ...body } = req.body
+  // a body author is dropped: authorship comes from the authenticated caller
   const { health, introduction, highlights, blockers, next_steps, additional_notes } = validate<UpdateGeneralSection>(
     generalSectionValidator,
-    body
+    omit(body, 'author')
   )
   const parsedResult = FinancialUpdateSectionSchema.safeParse({ financial_records })
   if (!parsedResult.success) {
@@ -130,7 +132,8 @@ async function updateProjectUpdate(req: WithAuth<Request<{ update_id: string }>>
     update,
     project,
     {
-      author,
+      // pending updates generated from a vesting have no author yet, so whoever completes one claims it
+      author: update.author || user,
       health,
       introduction,
       highlights,
@@ -200,10 +203,11 @@ async function validateFinancialRecords(
 
 async function createProjectUpdate(req: WithAuth) {
   const user = req.auth!
-  const { project_id, author, financial_records, ...body } = req.body
+  const { project_id, financial_records, ...body } = req.body
+  // a body author is dropped: authorship comes from the authenticated caller
   const { health, introduction, highlights, blockers, next_steps, additional_notes } = validate<UpdateGeneralSection>(
     schema.compile(GeneralUpdateSectionSchema),
-    body
+    omit(body, 'author')
   )
   try {
     const project = await ProjectService.getUpdatedProject(project_id)
@@ -212,7 +216,7 @@ async function createProjectUpdate(req: WithAuth) {
     const financialRecords = await validateFinancialRecords(project, financial_records)
     return await UpdateService.create(
       {
-        author,
+        author: user,
         health,
         introduction,
         highlights,


### PR DESCRIPTION
## Summary

`POST /api/updates` and `PATCH /api/updates/:id` took `author` from the request body and stored it verbatim. Both routes authorize with `validateIsAuthorOrCoauthor(req.auth, project.id)`, which proves the caller may edit the project but says nothing about whose name ends up on the update. An approved coauthor could therefore publish content under another wallet's identity. Because `author` was stripped out before `validate(...)` ran, it was never checked for being an address either — any string went through.

Authorship now comes from `req.auth`. On edit the stored author is preserved rather than replaced.

This came in via an Immunefi report. We closed it as out of scope — the actor must already be an approved coauthor, a role that can already edit and delete any update on the project by design, and `author` is a display field no backend authorization reads. Still worth fixing.

## What could break

`PATCH` is also the completion path for the pending updates generated from a vesting, which start with a null author. Replacing the body value with `update.author` alone would have left those permanently authorless, so the fallback is `update.author || user`. Covered by a test.

Clients may still send `author`; it is now dropped via `omit` rather than rejected, so no 400s on the extra field. governance-ui already sends the connected account, so behavior there is unchanged.

## How to test

`npx jest src/routes/update.test.ts` — three new cases: a forged `author` on POST, a coauthor editing someone else's update, and a coauthor completing an authorless pending update.