### PR TITLE
fix: bump decentraland-gatsby to 8.4.8 for canonical signer validation

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -20,7 +20,7 @@
         "dayjs-precise-range": "^1.0.1",
         "dcl-catalyst-client": "^22.0.0",
         "decentraland-dapps": "^28.0.0",
-        "decentraland-gatsby": "^8.4.6",
+        "decentraland-gatsby": "^8.4.8",
         "discord.js": "^14.7.1",
         "dotenv": "^16.0.0",
         "ethers": "^5.7.1",
@@ -941,6 +941,7 @@
       "version": "7.22.15",
       "resolved": "https://registry.npmjs.org/@babel/core/-/core-7.22.15.tgz",
       "integrity": "sha512-PtZqMmgRrvj8ruoEOIwVA3yoF91O+Hgw9o7DAUTNBA6Mo2jpu31clx9a7Nz/9JznqetTR6zwfC4L3LAjKQXUwA==",
+      "peer": true,
       "dependencies": {
         "@ampproject/remapping": "^2.2.0",
         "@babel/code-frame": "^7.22.13",
@@ -3083,6 +3084,7 @@
       "resolved": "https://registry.npmjs.org/@solana/kit/-/kit-5.5.1.tgz",
       "integrity": "sha512-irKUGiV2yRoyf+4eGQ/ZeCRxa43yjFEL1DUI5B0DkcfZw3cr0VJtVJnrG8OtVF01vT0OUfYOcUn6zJW5TROHvQ==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@solana/accounts": "5.5.1",
         "@solana/addresses": "5.5.1",
@@ -3168,6 +3170,7 @@
       "resolved": "https://registry.npmjs.org/axios/-/axios-1.16.0.tgz",
       "integrity": "sha512-6hp5CwvTPlN2A31g5dxnwAX0orzM7pmCRDLnZSX772mv8WDqICwFjowHuPs04Mc8deIld1+ejhtaMn5vp6b+1w==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "follow-redirects": "^1.16.0",
         "form-data": "^4.0.5",
@@ -3234,6 +3237,7 @@
       "resolved": "https://registry.npmjs.org/zod/-/zod-3.25.76.tgz",
       "integrity": "sha512-gzUt/qt81nXsFGKIFcC3YnfEAx5NkunCfnDlvuBSSFS02bcXu4Lmea0AFIUwbLWxWPx3d9p8S5QoaujKcNQxcQ==",
       "license": "MIT",
+      "peer": true,
       "funding": {
         "url": "https://github.com/sponsors/colinhacks"
       }
@@ -3327,7 +3331,6 @@
       "resolved": "https://registry.npmjs.org/@date-fns/upgrade/-/upgrade-1.0.3.tgz",
       "integrity": "sha512-0BLzKmXwWw3Zh3cZzW4xScmwGijXCAulaFdikqNiSnK8PAgYYSWWxOP/kuJFpKaoIT5KzstVGyHsjA7t/QXi1Q==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "date-fns": "^2.1"
       }
@@ -3337,7 +3340,6 @@
       "resolved": "https://registry.npmjs.org/date-fns/-/date-fns-2.30.0.tgz",
       "integrity": "sha512-fnULvOpxnC5/Vg3NCiWelDsLiUc9bRwAPs/+LfTLNvetFCtCTN+yQz15C/fs4AwX1R9K5GLtLfn8QW+dWisaAw==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@babel/runtime": "^7.21.0"
       },
@@ -3377,9 +3379,9 @@
       }
     },
     "node_modules/@dcl/crypto-middleware": {
-      "version": "4.1.0",
-      "resolved": "https://registry.npmjs.org/@dcl/crypto-middleware/-/crypto-middleware-4.1.0.tgz",
-      "integrity": "sha512-F9MVyxnLFaLJSyo5o6MtsGTDiQ1r4VqCKuFkaEPcq2JFyI6W4ftIRaKIj7hLb65PP/ywm3FkQrizSJ+6MhWpZw==",
+      "version": "5.1.0",
+      "resolved": "https://registry.npmjs.org/@dcl/crypto-middleware/-/crypto-middleware-5.1.0.tgz",
+      "integrity": "sha512-aiG/aInYDgL5Er+KStaIqjOmGGLlmIHSRlcAK5Jzyn+wiPU/kYiQIpMDyaIsrZ0om9HOi0M6lnqcR7ZVNpj4bA==",
       "license": "Apache-2.0",
       "dependencies": {
         "@dcl/core-commons": "^0.10.0",
@@ -3387,18 +3389,6 @@
       },
       "engines": {
         "node": ">=22.0.0"
-      },
-      "peerDependencies": {
-        "express": "^4.0.0 || ^5.0.0",
-        "koa": "^2.0.0"
-      },
-      "peerDependenciesMeta": {
-        "express": {
-          "optional": true
-        },
-        "koa": {
-          "optional": true
-        }
       }
     },
     "node_modules/@dcl/crypto/node_modules/@noble/curves": {
@@ -3487,7 +3477,6 @@
       "resolved": "https://registry.npmjs.org/@dcl/hooks/-/hooks-1.4.0.tgz",
       "integrity": "sha512-GFt8SAvL8sb42YE7eNYWOlICKJVMyPM0J+YKivwrrQujNiPX14wed4eugIRDte71KZvzVlg9ohfRqEdj6VhYjA==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@formatjs/intl": "^3.1.8",
         "@segment/analytics-next": "^1.79.0",
@@ -3505,7 +3494,6 @@
       "resolved": "https://registry.npmjs.org/@formatjs/ecma402-abstract/-/ecma402-abstract-2.3.6.tgz",
       "integrity": "sha512-HJnTFeRM2kVFVr5gr5kH1XP6K0JcJtE7Lzvtr3FS/so5f1kpsqqqxy5JF+FRaO6H2qmcMfAUIox7AJteieRtVw==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@formatjs/fast-memoize": "2.2.7",
         "@formatjs/intl-localematcher": "0.6.2",
@@ -3518,7 +3506,6 @@
       "resolved": "https://registry.npmjs.org/@formatjs/fast-memoize/-/fast-memoize-2.2.7.tgz",
       "integrity": "sha512-Yabmi9nSvyOMrlSeGGWDiH7rf3a7sIwplbvo/dlz9WCIjzIQAfy1RMf4S0X3yG724n5Ghu2GmEl5NJIV6O9sZQ==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "tslib": "^2.8.0"
       }
@@ -3528,7 +3515,6 @@
       "resolved": "https://registry.npmjs.org/@formatjs/icu-messageformat-parser/-/icu-messageformat-parser-2.11.4.tgz",
       "integrity": "sha512-7kR78cRrPNB4fjGFZg3Rmj5aah8rQj9KPzuLsmcSn4ipLXQvC04keycTI1F7kJYDwIXtT2+7IDEto842CfZBtw==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@formatjs/ecma402-abstract": "2.3.6",
         "@formatjs/icu-skeleton-parser": "1.8.16",
@@ -3540,7 +3526,6 @@
       "resolved": "https://registry.npmjs.org/@formatjs/icu-skeleton-parser/-/icu-skeleton-parser-1.8.16.tgz",
       "integrity": "sha512-H13E9Xl+PxBd8D5/6TVUluSpxGNvFSlN/b3coUp0e0JpuWXXnQDiavIpY3NnvSp4xhEMoXyyBvVfdFX8jglOHQ==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@formatjs/ecma402-abstract": "2.3.6",
         "tslib": "^2.8.0"
@@ -3551,7 +3536,6 @@
       "resolved": "https://registry.npmjs.org/@formatjs/intl/-/intl-3.1.8.tgz",
       "integrity": "sha512-LWXgwI5zTMatvR8w8kCNh/priDTOF/ZssokMBHJ7ZWXFoYLVOYo0EJERD9Eajv+xsfQO1QkuAt77KWQ1OI4mOQ==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@formatjs/ecma402-abstract": "2.3.6",
         "@formatjs/fast-memoize": "2.2.7",
@@ -3573,7 +3557,6 @@
       "resolved": "https://registry.npmjs.org/@formatjs/intl-localematcher/-/intl-localematcher-0.6.2.tgz",
       "integrity": "sha512-XOMO2Hupl0wdd172Y06h6kLpBz6Dv+J4okPLl4LPtzbr8f66WbIoy4ev98EBuZ6ZK4h5ydTN6XneT4QVpD7cdA==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "tslib": "^2.8.0"
       }
@@ -3583,7 +3566,6 @@
       "resolved": "https://registry.npmjs.org/intl-messageformat/-/intl-messageformat-10.7.18.tgz",
       "integrity": "sha512-m3Ofv/X/tV8Y3tHXLohcuVuhWKo7BBq62cqY15etqmLxg2DZ34AGGgQDeR+SCta2+zICb1NX83af0GJmbQ1++g==",
       "license": "BSD-3-Clause",
-      "peer": true,
       "dependencies": {
         "@formatjs/ecma402-abstract": "2.3.6",
         "@formatjs/fast-memoize": "2.2.7",
@@ -3595,8 +3577,7 @@
       "version": "2.8.1",
       "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.8.1.tgz",
       "integrity": "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==",
-      "license": "0BSD",
-      "peer": true
+      "license": "0BSD"
     },
     "node_modules/@dcl/http-server": {
       "version": "2.1.0",
@@ -3631,6 +3612,7 @@
       "resolved": "https://registry.npmjs.org/@dcl/schemas/-/schemas-26.5.0.tgz",
       "integrity": "sha512-R7/IXI3g4SFGsVKtsLzwUk7romfV9vxWtI0A7pbwlNEyfPtIVgdIqpgHAXD06vDTAyrEZAWMyzhHxcBEoIXniQ==",
       "license": "Apache-2.0",
+      "peer": true,
       "dependencies": {
         "ajv": "^8.11.0",
         "ajv-errors": "^3.0.0",
@@ -3642,6 +3624,7 @@
       "version": "8.12.0",
       "resolved": "https://registry.npmjs.org/ajv/-/ajv-8.12.0.tgz",
       "integrity": "sha512-sRu1kpcO9yLtYxBKvqfTeh9KzZEwO3STyX1HT+4CaDzC6HpTGYhIhPIzj9XuKU7KYDwnaeh5hcOwjy1QuJzBPA==",
+      "peer": true,
       "dependencies": {
         "fast-deep-equal": "^3.1.1",
         "json-schema-traverse": "^1.0.0",
@@ -3690,7 +3673,8 @@
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/@dcl/ui-env/-/ui-env-2.0.0.tgz",
       "integrity": "sha512-Is+LqRhVU4BzxzCvWC5xbnYAF9dEiFUDOU3nuHpRyd19QCDrCm9HFt+cV+Q7RaNzXeHEsTqqPJ+Iej9aB70bmQ==",
-      "license": "ISC"
+      "license": "ISC",
+      "peer": true
     },
     "node_modules/@discordjs/builders": {
       "version": "1.4.0",
@@ -3955,6 +3939,7 @@
       "resolved": "https://registry.npmjs.org/@emotion/react/-/react-11.14.0.tgz",
       "integrity": "sha512-O000MLDBDdk/EohJPFUqvnp4qnHeYkVP5B0xEG0D/L7cOKP9kefu2DXn8dj74cQfsEzUqh+sr1RzFqiL1o+PpA==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@babel/runtime": "^7.18.3",
         "@emotion/babel-plugin": "^11.13.5",
@@ -5133,7 +5118,6 @@
       "resolved": "https://registry.npmjs.org/@fluentui/react-component-event-listener/-/react-component-event-listener-0.63.1.tgz",
       "integrity": "sha512-gSMdOh6tI3IJKZFqxfQwbTpskpME0CvxdxGM2tdglmf6ZPVDi0L4+KKIm+2dN8nzb8Ya1A8ZT+Ddq0KmZtwVQg==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@babel/runtime": "^7.10.4"
       },
@@ -5147,7 +5131,6 @@
       "resolved": "https://registry.npmjs.org/@fluentui/react-component-ref/-/react-component-ref-0.63.1.tgz",
       "integrity": "sha512-8MkXX4+R3i80msdbD4rFpEB4WWq2UDvGwG386g3ckIWbekdvN9z2kWAd9OXhRGqB7QeOsoAGWocp6gAMCivRlw==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@babel/runtime": "^7.10.4",
         "react-is": "^16.6.3"
@@ -5319,6 +5302,7 @@
       "version": "1.3.9",
       "resolved": "https://registry.npmjs.org/@gatsbyjs/reach-router/-/reach-router-1.3.9.tgz",
       "integrity": "sha512-/354IaUSM54xb7K/TxpLBJB94iEAJ3P82JD38T8bLnIDWF+uw8+W/82DKnQ7y24FJcKxtVmG43aiDLG88KSuYQ==",
+      "peer": true,
       "dependencies": {
         "invariant": "^2.2.3",
         "prop-types": "^15.6.1",
@@ -5769,7 +5753,6 @@
       "resolved": "https://registry.npmjs.org/@hey-api/codegen-core/-/codegen-core-0.9.1.tgz",
       "integrity": "sha512-s97jL1dgTMuiMHv2BZ1X4Tgd99Mf9GOvGdNqNcGwIMmnR+PgYNoraj4Zvp134MKsNCap/m7k0r0vKKnl56pj4w==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@hey-api/types": "0.1.4",
         "ansi-colors": "4.1.3",
@@ -5788,7 +5771,6 @@
       "resolved": "https://registry.npmjs.org/@hey-api/json-schema-ref-parser/-/json-schema-ref-parser-1.4.4.tgz",
       "integrity": "sha512-otmd+zCxbYVBIp/mlMTnGkvlNYLkVKgs3VOIq0kSnenhB1+fRwLPQIeSwyWM6E51oXhUedkYjVsVpkVexeuJOA==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@jsdevtools/ono": "7.1.3",
         "@types/json-schema": "7.0.15",
@@ -5805,8 +5787,7 @@
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/argparse/-/argparse-2.0.1.tgz",
       "integrity": "sha512-8+9WqebbFzpX9OR+Wa6O29asIogeRMzcGtAINdpMHHyAg10f05aSFVBbcEqGf/PXw1EjAZ+q2/bEBg3DvurK3Q==",
-      "license": "Python-2.0",
-      "peer": true
+      "license": "Python-2.0"
     },
     "node_modules/@hey-api/json-schema-ref-parser/node_modules/js-yaml": {
       "version": "4.2.0",
@@ -5823,7 +5804,6 @@
         }
       ],
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "argparse": "^2.0.1"
       },
@@ -5836,7 +5816,6 @@
       "resolved": "https://registry.npmjs.org/@hey-api/openapi-ts/-/openapi-ts-0.99.0.tgz",
       "integrity": "sha512-SePU/5oEWWkvUBYmvzdYRctseoLuskyhs4ET0RvLIcmzc8yLQoA2R+KtBIQ8bPsoSUB0m4E5SmBnl6aGSA0szQ==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@hey-api/codegen-core": "0.9.1",
         "@hey-api/json-schema-ref-parser": "1.4.4",
@@ -5867,7 +5846,6 @@
       "resolved": "https://registry.npmjs.org/commander/-/commander-15.0.0.tgz",
       "integrity": "sha512-z67u4ZhzCL/Tydu1lJARtEZYWbWaN7oYLHbsuzocr6y4N6WZAagG3RQ4FW61V1/0+jImpj293XfrcYnd1qxtPg==",
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=22.12.0"
       }
@@ -5877,7 +5855,6 @@
       "resolved": "https://registry.npmjs.org/@hey-api/shared/-/shared-0.5.0.tgz",
       "integrity": "sha512-JN/j4Ebh4cJGYIQ5cwWuqe7GeSUyQoz7oC51WqyhKOcrejK6DKZMDkshc5d1eKTRuRL+rjozuRcoUaZZn2DGPw==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@hey-api/codegen-core": "0.9.1",
         "@hey-api/json-schema-ref-parser": "1.4.4",
@@ -5900,7 +5877,6 @@
       "resolved": "https://registry.npmjs.org/define-lazy-prop/-/define-lazy-prop-3.0.0.tgz",
       "integrity": "sha512-N+MeXYoqr3pOgn8xfyRPREN7gHakLYjhsHhWGT3fWAiL4IkAt0iDw14QiiEm2bE30c5XX5q0FtAA3CK5f9/BUg==",
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=12"
       },
@@ -5913,7 +5889,6 @@
       "resolved": "https://registry.npmjs.org/open/-/open-11.0.0.tgz",
       "integrity": "sha512-smsWv2LzFjP03xmvFoJ331ss6h+jixfA4UUV/Bsiyuu4YJPfN+FIQGOIiv4w9/+MoHkfkJ22UIaQWRVFRfH6Vw==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "default-browser": "^5.4.0",
         "define-lazy-prop": "^3.0.0",
@@ -5934,7 +5909,6 @@
       "resolved": "https://registry.npmjs.org/@hey-api/spec-types/-/spec-types-0.2.0.tgz",
       "integrity": "sha512-ibQ8Is7evMavzr8GNyJCcTg975d8DpaMUyLmOrQ85UBdy1l6t1KuRAwgChAbesJsIlNV6gjmlXruWyegDX18Fg==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@hey-api/types": "0.1.4"
       },
@@ -5946,8 +5920,7 @@
       "version": "0.1.4",
       "resolved": "https://registry.npmjs.org/@hey-api/types/-/types-0.1.4.tgz",
       "integrity": "sha512-thWfawrDIP7wSI9ioT13I5soaaqB5vAPIiZmgD8PbeEVKNrkonc0N/Sjj97ezl7oQgusZmaNphGdMKipPO6IBg==",
-      "license": "MIT",
-      "peer": true
+      "license": "MIT"
     },
     "node_modules/@humanwhocodes/config-array": {
       "version": "0.9.5",
@@ -6071,9 +6044,6 @@
       "cpu": [
         "arm"
       ],
-      "libc": [
-        "glibc"
-      ],
       "license": "LGPL-3.0-or-later",
       "optional": true,
       "os": [
@@ -6089,9 +6059,6 @@
       "integrity": "sha512-9B+taZ8DlyyqzZQnoeIvDVR/2F4EbMepXMc/NdVbkzsJbzkUjhXv/70GQJ7tdLA4YJgNP25zukcxpX2/SueNrA==",
       "cpu": [
         "arm64"
-      ],
-      "libc": [
-        "glibc"
       ],
       "license": "LGPL-3.0-or-later",
       "optional": true,
@@ -6109,9 +6076,6 @@
       "cpu": [
         "s390x"
       ],
-      "libc": [
-        "glibc"
-      ],
       "license": "LGPL-3.0-or-later",
       "optional": true,
       "os": [
@@ -6127,9 +6091,6 @@
       "integrity": "sha512-MmWmQ3iPFZr0Iev+BAgVMb3ZyC4KeFc3jFxnNbEPas60e1cIfevbtuyf9nDGIzOaW9PdnDciJm+wFFaTlj5xYw==",
       "cpu": [
         "x64"
-      ],
-      "libc": [
-        "glibc"
       ],
       "license": "LGPL-3.0-or-later",
       "optional": true,
@@ -6147,9 +6108,6 @@
       "cpu": [
         "arm64"
       ],
-      "libc": [
-        "musl"
-      ],
       "license": "LGPL-3.0-or-later",
       "optional": true,
       "os": [
@@ -6166,9 +6124,6 @@
       "cpu": [
         "x64"
       ],
-      "libc": [
-        "musl"
-      ],
       "license": "LGPL-3.0-or-later",
       "optional": true,
       "os": [
@@ -6184,9 +6139,6 @@
       "integrity": "sha512-JTS1eldqZbJxjvKaAkxhZmBqPRGmxgu+qFKSInv8moZ2AmT5Yib3EQ1c6gp493HvrvV8QgdOXdyaIBrhvFhBMQ==",
       "cpu": [
         "arm"
-      ],
-      "libc": [
-        "glibc"
       ],
       "license": "Apache-2.0",
       "optional": true,
@@ -6210,9 +6162,6 @@
       "cpu": [
         "arm64"
       ],
-      "libc": [
-        "glibc"
-      ],
       "license": "Apache-2.0",
       "optional": true,
       "os": [
@@ -6234,9 +6183,6 @@
       "integrity": "sha512-y/5PCd+mP4CA/sPDKl2961b+C9d+vPAveS33s6Z3zfASk2j5upL6fXVPZi7ztePZ5CuH+1kW8JtvxgbuXHRa4Q==",
       "cpu": [
         "s390x"
-      ],
-      "libc": [
-        "glibc"
       ],
       "license": "Apache-2.0",
       "optional": true,
@@ -6260,9 +6206,6 @@
       "cpu": [
         "x64"
       ],
-      "libc": [
-        "glibc"
-      ],
       "license": "Apache-2.0",
       "optional": true,
       "os": [
@@ -6285,9 +6228,6 @@
       "cpu": [
         "arm64"
       ],
-      "libc": [
-        "musl"
-      ],
       "license": "Apache-2.0",
       "optional": true,
       "os": [
@@ -6309,9 +6249,6 @@
       "integrity": "sha512-WT+d/cgqKkkKySYmqoZ8y3pxx7lx9vVejxW/W4DOFMYVSkErR+w7mf2u8m/y4+xHe7yY9DAXQMWQhpnMuFfScw==",
       "cpu": [
         "x64"
-      ],
-      "libc": [
-        "musl"
       ],
       "license": "Apache-2.0",
       "optional": true,
@@ -6975,8 +6912,7 @@
       "version": "7.1.3",
       "resolved": "https://registry.npmjs.org/@jsdevtools/ono/-/ono-7.1.3.tgz",
       "integrity": "sha512-4JQNk+3mVzK3xh2rqd6RB4J46qUR19azEHBneZyTZM+c456qOrbbM/5xcR8huNCCcbVt7+UmizG6GuUvPvKUYg==",
-      "license": "MIT",
-      "peer": true
+      "license": "MIT"
     },
     "node_modules/@lezer/common": {
       "version": "0.15.12",
@@ -7126,7 +7062,6 @@
       "resolved": "https://registry.npmjs.org/@lukeed/csprng/-/csprng-1.1.0.tgz",
       "integrity": "sha512-Z7C/xXCiGWsg0KuKsHTKJxbWhpI3Vs5GwLfOean7MGyVFGqdRgBbAjOCh6u4bbjPc/8MJ2pZmK/0DLdCbivLDA==",
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=8"
       }
@@ -7136,7 +7071,6 @@
       "resolved": "https://registry.npmjs.org/@lukeed/ms/-/ms-2.0.2.tgz",
       "integrity": "sha512-9I2Zn6+NJLfaGoz9jN3lpwDgAYvfGeNYdbAIjJOqzs4Tpc+VU3Jqq4IofSUBKajiDS8k9fZIg18/z13mpk1bsA==",
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=8"
       }
@@ -7146,7 +7080,6 @@
       "resolved": "https://registry.npmjs.org/@lukeed/uuid/-/uuid-2.0.1.tgz",
       "integrity": "sha512-qC72D4+CDdjGqJvkFMMEAtancHUQ7/d/tAiHf64z8MopFDmcrtbcJuerDtFceuAfQJ2pDSfCKCtbqoGBNnwg0w==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@lukeed/csprng": "^1.1.0"
       },
@@ -7178,6 +7111,7 @@
       "resolved": "https://registry.npmjs.org/@magic-sdk/provider/-/provider-27.0.0.tgz",
       "integrity": "sha512-k2haK2zhYkqf+cbMF+/HKvqa8qPWqdZbW10qgN6AdqaOE750ceC3GDQCUwAfkzdofmWrRtFgW5jVAVCVz5WklQ==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@magic-sdk/types": "^23.0.0",
         "eventemitter3": "^4.0.4",
@@ -7191,7 +7125,8 @@
       "version": "23.0.0",
       "resolved": "https://registry.npmjs.org/@magic-sdk/types/-/types-23.0.0.tgz",
       "integrity": "sha512-NTjgGPJVYxoncSrHtDZLDiJzdSbxHV0jCy6J+YvT+LY7QUiGY3zzu+NhLqgLxE6KZODXERhSLYSimotcokZbmw==",
-      "license": "MIT"
+      "license": "MIT",
+      "peer": true
     },
     "node_modules/@metamask/eth-json-rpc-provider": {
       "version": "1.0.1",
@@ -7879,7 +7814,6 @@
       "integrity": "sha512-I/lGHztkCzvwlXpjD2+SNmvNQvB4227xBXhISPjEaJUXGImOQ9f3D2Yj/T3KasSI/h0MLWy74X0J6clhPmsRbQ==",
       "deprecated": "This package has been replaced by @base-ui/react",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@babel/runtime": "^7.23.9",
         "@floating-ui/react-dom": "^2.0.8",
@@ -7912,7 +7846,6 @@
       "resolved": "https://registry.npmjs.org/clsx/-/clsx-2.1.1.tgz",
       "integrity": "sha512-eYm0QWBtUrBWZWG0d386OGAw16Z995PiOVo2B7bjWSbHedGl5e0ZWaq65kOGgUSNesEIDkB9ISbTg/JK9dhCZA==",
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=6"
       }
@@ -7922,7 +7855,6 @@
       "resolved": "https://registry.npmjs.org/@mui/core-downloads-tracker/-/core-downloads-tracker-5.18.0.tgz",
       "integrity": "sha512-jbhwoQ1AY200PSSOrNXmrFCaSDSJWP7qk6urkTmIirvRXDROkqe+QwcLlUiw/PrREwsIF/vm3/dAXvjlMHF0RA==",
       "license": "MIT",
-      "peer": true,
       "funding": {
         "type": "opencollective",
         "url": "https://opencollective.com/mui-org"
@@ -7933,7 +7865,6 @@
       "resolved": "https://registry.npmjs.org/@mui/icons-material/-/icons-material-5.16.0.tgz",
       "integrity": "sha512-6ISoOhkp9w5gD0PEW9JklrcbyARDkFWNTBdwXZ1Oy5IGlyu9B0zG0hnUIe4H17IaF1Vgj6C8VI+v4tkSdK0veg==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@babel/runtime": "^7.23.9"
       },
@@ -8006,7 +7937,6 @@
       "resolved": "https://registry.npmjs.org/clsx/-/clsx-2.1.1.tgz",
       "integrity": "sha512-eYm0QWBtUrBWZWG0d386OGAw16Z995PiOVo2B7bjWSbHedGl5e0ZWaq65kOGgUSNesEIDkB9ISbTg/JK9dhCZA==",
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=6"
       }
@@ -8015,15 +7945,13 @@
       "version": "18.3.1",
       "resolved": "https://registry.npmjs.org/react-is/-/react-is-18.3.1.tgz",
       "integrity": "sha512-/LLMVyas0ljjAtoYiPqYiL8VWXzUUdThrmU5+n20DZv+a+ClRoevUzw5JxU+Ieh5/c87ytoTBV9G1FiKfNJdmg==",
-      "license": "MIT",
-      "peer": true
+      "license": "MIT"
     },
     "node_modules/@mui/private-theming": {
       "version": "5.17.1",
       "resolved": "https://registry.npmjs.org/@mui/private-theming/-/private-theming-5.17.1.tgz",
       "integrity": "sha512-XMxU0NTYcKqdsG8LRmSoxERPXwMbp16sIXPcLVgLGII/bVNagX0xaheWAwFv8+zDK7tI3ajllkuD3GZZE++ICQ==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@babel/runtime": "^7.23.9",
         "@mui/utils": "^5.17.1",
@@ -8051,7 +7979,6 @@
       "resolved": "https://registry.npmjs.org/@mui/styled-engine/-/styled-engine-5.18.0.tgz",
       "integrity": "sha512-BN/vKV/O6uaQh2z5rXV+MBlVrEkwoS/TK75rFQ2mjxA7+NBo8qtTAOA4UaM0XeJfn7kh2wZ+xQw2HAx0u+TiBg==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@babel/runtime": "^7.23.9",
         "@emotion/cache": "^11.13.5",
@@ -8085,7 +8012,6 @@
       "resolved": "https://registry.npmjs.org/@mui/system/-/system-5.18.0.tgz",
       "integrity": "sha512-ojZGVcRWqWhu557cdO3pWHloIGJdzVtxs3rk0F9L+x55LsUjcMUVkEhiF7E4TMxZoF9MmIHGGs0ZX3FDLAf0Xw==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@babel/runtime": "^7.23.9",
         "@mui/private-theming": "^5.17.1",
@@ -8126,7 +8052,6 @@
       "resolved": "https://registry.npmjs.org/@mui/types/-/types-7.2.24.tgz",
       "integrity": "sha512-3c8tRt/CbWZ+pEg7QpSwbdxOk36EfmhbKf6AGZsD1EcLDLTSZoxxJ86FVtcjxvjuhdyBiWKSTGZFaXCnidO2kw==",
       "license": "MIT",
-      "peer": true,
       "peerDependencies": {
         "@types/react": "^17.0.0 || ^18.0.0 || ^19.0.0"
       },
@@ -8141,7 +8066,6 @@
       "resolved": "https://registry.npmjs.org/clsx/-/clsx-2.1.1.tgz",
       "integrity": "sha512-eYm0QWBtUrBWZWG0d386OGAw16Z995PiOVo2B7bjWSbHedGl5e0ZWaq65kOGgUSNesEIDkB9ISbTg/JK9dhCZA==",
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=6"
       }
@@ -8151,7 +8075,6 @@
       "resolved": "https://registry.npmjs.org/@mui/types/-/types-7.4.12.tgz",
       "integrity": "sha512-iKNAF2u9PzSIj40CjvKJWxFXJo122jXVdrmdh0hMYd+FR+NuJMkr/L88XwWLCRiJ5P1j+uyac25+Kp6YC4hu6w==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@babel/runtime": "^7.28.6"
       },
@@ -8169,7 +8092,6 @@
       "resolved": "https://registry.npmjs.org/@mui/utils/-/utils-5.17.1.tgz",
       "integrity": "sha512-jEZ8FTqInt2WzxDV8bhImWBqeQRD99c/id/fq83H0ER9tFl+sfZlaAoCdznGvbSQQ9ividMxqSV2c7cC1vBcQg==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@babel/runtime": "^7.23.9",
         "@mui/types": "~7.2.15",
@@ -8200,7 +8122,6 @@
       "resolved": "https://registry.npmjs.org/@mui/types/-/types-7.2.24.tgz",
       "integrity": "sha512-3c8tRt/CbWZ+pEg7QpSwbdxOk36EfmhbKf6AGZsD1EcLDLTSZoxxJ86FVtcjxvjuhdyBiWKSTGZFaXCnidO2kw==",
       "license": "MIT",
-      "peer": true,
       "peerDependencies": {
         "@types/react": "^17.0.0 || ^18.0.0 || ^19.0.0"
       },
@@ -8215,7 +8136,6 @@
       "resolved": "https://registry.npmjs.org/clsx/-/clsx-2.1.1.tgz",
       "integrity": "sha512-eYm0QWBtUrBWZWG0d386OGAw16Z995PiOVo2B7bjWSbHedGl5e0ZWaq65kOGgUSNesEIDkB9ISbTg/JK9dhCZA==",
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=6"
       }
@@ -8224,8 +8144,7 @@
       "version": "19.2.7",
       "resolved": "https://registry.npmjs.org/react-is/-/react-is-19.2.7.tgz",
       "integrity": "sha512-kZFnouyVv7eP/Phmrlo9FK+zcAdriZJvzxXHF1Sl1P377WSGe2G/JxVolhTrB/jeV47lKImhNUsijjHAAbcl/A==",
-      "license": "MIT",
-      "peer": true
+      "license": "MIT"
     },
     "node_modules/@multiformats/murmur3": {
       "version": "1.1.3",
@@ -8241,6 +8160,7 @@
       "resolved": "https://registry.npmjs.org/@noble/ciphers/-/ciphers-1.3.0.tgz",
       "integrity": "sha512-2I0gnIVPtfnMw9ee9h1dJG7tp81+8Ob3OJb3Mv37rx5L40/b0i7djjCVvGOVqc9AEIQyvyu1i6ypKdFw8R8gQw==",
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": "^14.21.3 || >=16"
       },
@@ -8496,6 +8416,7 @@
       "version": "2.6.2",
       "resolved": "https://registry.npmjs.org/@parcel/core/-/core-2.6.2.tgz",
       "integrity": "sha512-JlKS3Ux0ngmdooSBbzQLShHJdsapF9E7TGMo1hFaHRquZip/DaqzvysYrgMJlDuCoLArciq5ei7ZKzGeK9zexA==",
+      "peer": true,
       "dependencies": {
         "@mischnic/json-sourcemap": "^0.1.0",
         "@parcel/cache": "2.6.2",
@@ -9817,6 +9738,7 @@
       "resolved": "https://registry.npmjs.org/ws/-/ws-8.13.0.tgz",
       "integrity": "sha512-x9vcZYTrFPC7aSIbj7sRCYo7L/Xb8Iy+pW0ng0wt2vCJv7M9HOMy0UoN3rr+IFC7hb7vXoqS+P9ktyLLLhO+LA==",
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=10.0.0"
       },
@@ -10332,7 +10254,6 @@
       "resolved": "https://registry.npmjs.org/@redux-saga/core/-/core-1.5.0.tgz",
       "integrity": "sha512-oMWpQntvVikLhr+wZsvGDzkjW79HphBgEb6Hncz8OkM0azsT3uUnP1Her/W5QZhcDG+tWmjDhah8uDbPSRLs/Q==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@babel/runtime": "^7.28.4",
         "@redux-saga/deferred": "^1.3.1",
@@ -10350,15 +10271,13 @@
       "version": "1.3.1",
       "resolved": "https://registry.npmjs.org/@redux-saga/deferred/-/deferred-1.3.1.tgz",
       "integrity": "sha512-0YZ4DUivWojXBqLB/TmuRRpDDz7tyq1I0AuDV7qi01XlLhM5m51W7+xYtIckH5U2cMlv9eAuicsfRAi1XHpXIg==",
-      "license": "MIT",
-      "peer": true
+      "license": "MIT"
     },
     "node_modules/@redux-saga/delay-p": {
       "version": "1.3.1",
       "resolved": "https://registry.npmjs.org/@redux-saga/delay-p/-/delay-p-1.3.1.tgz",
       "integrity": "sha512-597I7L5MXbD/1i3EmcaOOjL/5suxJD7p5tnbV1PiWnE28c2cYiIHqmSMK2s7us2/UrhOL2KTNBiD0qBg6KnImg==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@redux-saga/symbols": "^1.2.1"
       }
@@ -10368,7 +10287,6 @@
       "resolved": "https://registry.npmjs.org/@redux-saga/is/-/is-1.2.1.tgz",
       "integrity": "sha512-x3aWtX3GmQfEvn8dh0ovPbsXgK9JjpiR24wKztpGbZP8JZUWWvUgKrvnWZ/T/4iphOBftyVc9VrIwhAnsM+OFA==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@redux-saga/symbols": "^1.2.1",
         "@redux-saga/types": "^1.3.1"
@@ -10378,15 +10296,13 @@
       "version": "1.2.1",
       "resolved": "https://registry.npmjs.org/@redux-saga/symbols/-/symbols-1.2.1.tgz",
       "integrity": "sha512-3dh+uDvpBXi7EUp/eO+N7eFM4xKaU4yuGBXc50KnZGzIrR/vlvkTFQsX13zsY8PB6sCFYAgROfPSRUj8331QSA==",
-      "license": "MIT",
-      "peer": true
+      "license": "MIT"
     },
     "node_modules/@redux-saga/types": {
       "version": "1.4.0",
       "resolved": "https://registry.npmjs.org/@redux-saga/types/-/types-1.4.0.tgz",
       "integrity": "sha512-fq3Vy0TRl0mEb+1CyTx5wPBY3jxDi7yD4GL1Kz4S6ud7/leGEgRq1NYJDIiVbHMRBJd5rU/BB0Z+akrXSR0DJg==",
-      "license": "MIT",
-      "peer": true
+      "license": "MIT"
     },
     "node_modules/@reown/appkit": {
       "version": "1.8.21",
@@ -10819,7 +10735,6 @@
       "resolved": "https://registry.npmjs.org/@segment/analytics-core/-/analytics-core-1.8.3.tgz",
       "integrity": "sha512-63X8e2DWb2ZnJ9S3H8iSOFnbeDXMkTGhA8kZG4eFAO07QBwBVyWo5BCpv6vmuOMEkv2le6t2FMg1p6ZeJQA/4A==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@lukeed/uuid": "^2.0.0",
         "@segment/analytics-generic-utils": "1.2.0",
@@ -10831,15 +10746,13 @@
       "version": "2.8.1",
       "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.8.1.tgz",
       "integrity": "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==",
-      "license": "0BSD",
-      "peer": true
+      "license": "0BSD"
     },
     "node_modules/@segment/analytics-generic-utils": {
       "version": "1.2.0",
       "resolved": "https://registry.npmjs.org/@segment/analytics-generic-utils/-/analytics-generic-utils-1.2.0.tgz",
       "integrity": "sha512-DfnW6mW3YQOLlDQQdR89k4EqfHb0g/3XvBXkovH1FstUN93eL1kfW9CsDcVQyH3bAC5ZsFyjA/o/1Q2j0QeoWw==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "tslib": "^2.4.1"
       }
@@ -10848,15 +10761,13 @@
       "version": "2.8.1",
       "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.8.1.tgz",
       "integrity": "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==",
-      "license": "0BSD",
-      "peer": true
+      "license": "0BSD"
     },
     "node_modules/@segment/analytics-next": {
       "version": "1.84.0",
       "resolved": "https://registry.npmjs.org/@segment/analytics-next/-/analytics-next-1.84.0.tgz",
       "integrity": "sha512-V5scoCrhiTpRPOuBwNVpvE4KvHwrjgQ5fs282R72KiAZ0HoxmjLgReZYjZogBf7qq/c6VmQG3nidwh8PQGcY1A==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@lukeed/uuid": "^2.0.0",
         "@segment/analytics-core": "1.8.3",
@@ -10875,15 +10786,13 @@
       "version": "2.8.1",
       "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.8.1.tgz",
       "integrity": "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==",
-      "license": "0BSD",
-      "peer": true
+      "license": "0BSD"
     },
     "node_modules/@segment/analytics-page-tools": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/@segment/analytics-page-tools/-/analytics-page-tools-1.0.0.tgz",
       "integrity": "sha512-o9OVB91qLB9qb0Bw1HfjmWm5AnrMNULRjx++4lBqLt8InKRX1urrRBparVlpj+yJA0sckN5ZcsfazRLuPgBYDQ==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "tslib": "^2.4.1"
       }
@@ -10892,15 +10801,13 @@
       "version": "2.8.1",
       "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.8.1.tgz",
       "integrity": "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==",
-      "license": "0BSD",
-      "peer": true
+      "license": "0BSD"
     },
     "node_modules/@segment/analytics.js-video-plugins": {
       "version": "0.2.1",
       "resolved": "https://registry.npmjs.org/@segment/analytics.js-video-plugins/-/analytics.js-video-plugins-0.2.1.tgz",
       "integrity": "sha512-lZwCyEXT4aaHBLNK433okEKdxGAuyrVmop4BpQqQSJuRz0DglPZgd9B/XjiiWs1UyOankg2aNYMN3VcS8t4eSQ==",
       "license": "ISC",
-      "peer": true,
       "dependencies": {
         "unfetch": "^3.1.1"
       }
@@ -10909,15 +10816,13 @@
       "version": "3.1.2",
       "resolved": "https://registry.npmjs.org/unfetch/-/unfetch-3.1.2.tgz",
       "integrity": "sha512-L0qrK7ZeAudGiKYw6nzFjnJ2D5WHblUBwmHIqtPS6oKUd+Hcpk7/hKsSmcHsTlpd1TbTNsiRBUKRq3bHLNIqIw==",
-      "license": "MIT",
-      "peer": true
+      "license": "MIT"
     },
     "node_modules/@segment/facade": {
       "version": "3.4.10",
       "resolved": "https://registry.npmjs.org/@segment/facade/-/facade-3.4.10.tgz",
       "integrity": "sha512-xVQBbB/lNvk/u8+ey0kC/+g8pT3l0gCT8O2y9Z+StMMn3KAFAQ9w8xfgef67tJybktOKKU7pQGRPolRM1i1pdA==",
       "license": "SEE LICENSE IN LICENSE",
-      "peer": true,
       "dependencies": {
         "@segment/isodate-traverse": "^1.1.1",
         "inherits": "^2.0.4",
@@ -10929,15 +10834,13 @@
       "version": "1.0.3",
       "resolved": "https://registry.npmjs.org/@segment/isodate/-/isodate-1.0.3.tgz",
       "integrity": "sha512-BtanDuvJqnACFkeeYje7pWULVv8RgZaqKHWwGFnL/g/TH/CcZjkIVTfGDp/MAxmilYHUkrX70SqwnYSTNEaN7A==",
-      "license": "SEE LICENSE IN LICENSE",
-      "peer": true
+      "license": "SEE LICENSE IN LICENSE"
     },
     "node_modules/@segment/isodate-traverse": {
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/@segment/isodate-traverse/-/isodate-traverse-1.1.1.tgz",
       "integrity": "sha512-+G6e1SgAUkcq0EDMi+SRLfT48TNlLPF3QnSgFGVs0V9F3o3fq/woQ2rHFlW20W0yy5NnCUH0QGU3Am2rZy/E3w==",
       "license": "SEE LICENSE IN LICENSE",
-      "peer": true,
       "dependencies": {
         "@segment/isodate": "^1.0.3"
       }
@@ -10956,7 +10859,6 @@
       "resolved": "https://registry.npmjs.org/@semantic-ui-react/event-stack/-/event-stack-3.1.3.tgz",
       "integrity": "sha512-FdTmJyWvJaYinHrKRsMLDrz4tTMGdFfds299Qory53hBugiDvGC0tEJf+cHsi5igDwWb/CLOgOiChInHwq8URQ==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "exenv": "^1.2.2",
         "prop-types": "^15.6.2"
@@ -10971,7 +10873,6 @@
       "resolved": "https://registry.npmjs.org/@sentry-internal/browser-utils/-/browser-utils-9.47.1.tgz",
       "integrity": "sha512-twv6YhrUlPkvKz4/iQDH4KHgcv9t4cMjmZPf4/dCSCXn4/GOjzjx2d74c1w+1KOdS7lcsQzI+MtbK6SeYLiGfQ==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@sentry/core": "9.47.1"
       },
@@ -10984,7 +10885,6 @@
       "resolved": "https://registry.npmjs.org/@sentry-internal/feedback/-/feedback-9.47.1.tgz",
       "integrity": "sha512-xJ4vKvIpAT8e+Sz80YrsNinPU0XV7jPxPjdZ4ex8R2mMvx7pM0gq8JiR/sIVmNiOE0WiUDr6VwLDE8j2APSRMA==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@sentry/core": "9.47.1"
       },
@@ -10997,7 +10897,6 @@
       "resolved": "https://registry.npmjs.org/@sentry-internal/replay/-/replay-9.47.1.tgz",
       "integrity": "sha512-O9ZEfySpstGtX1f73m3NbdbS2utwPikaFt6sgp74RG4ZX4LlXe99VAjKR464xKECpYsLmj2bYpiK4opURF0pBA==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@sentry-internal/browser-utils": "9.47.1",
         "@sentry/core": "9.47.1"
@@ -11011,7 +10910,6 @@
       "resolved": "https://registry.npmjs.org/@sentry-internal/replay-canvas/-/replay-canvas-9.47.1.tgz",
       "integrity": "sha512-r9nve+l5+elGB9NXSN1+PUgJy790tXN1e8lZNH2ziveoU91jW4yYYt34mHZ30fU9tOz58OpaRMj3H3GJ/jYZVA==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@sentry-internal/replay": "9.47.1",
         "@sentry/core": "9.47.1"
@@ -11042,7 +10940,6 @@
       "resolved": "https://registry.npmjs.org/@sentry/core/-/core-9.47.1.tgz",
       "integrity": "sha512-KX62+qIt4xgy8eHKHiikfhz2p5fOciXd0Cl+dNzhgPFq8klq4MGMNaf148GB3M/vBqP4nw/eFvRMAayFCgdRQw==",
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -12245,6 +12142,7 @@
       "resolved": "https://registry.npmjs.org/@solana/kit/-/kit-2.3.0.tgz",
       "integrity": "sha512-sb6PgwoW2LjE5oTFu4lhlS/cGt/NB3YrShEyx7JgWFWysfgLdJnhwWThgwy/4HjNsmtMrQGWVls0yVBHcMvlMQ==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@solana/accounts": "2.3.0",
         "@solana/addresses": "2.3.0",
@@ -14010,6 +13908,7 @@
       "resolved": "https://registry.npmjs.org/@solana/sysvars/-/sysvars-2.3.0.tgz",
       "integrity": "sha512-LvjADZrpZ+CnhlHqfI5cmsRzX9Rpyb1Ox2dMHnbsRNzeKAMhu9w4ZBIaeTdO322zsTr509G1B+k2ABD3whvUBA==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@solana/accounts": "2.3.0",
         "@solana/codecs": "2.3.0",
@@ -14557,6 +14456,7 @@
       "resolved": "https://registry.npmjs.org/@tanstack/react-query/-/react-query-5.81.5.tgz",
       "integrity": "sha512-lOf2KqRRiYWpQT86eeeftAGnjuTR35myTP8MXyvHa81VlomoAWNEd8x5vkcAfQefu0qtYCvyqLropFZqgI2EQw==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@tanstack/query-core": "5.81.5"
       },
@@ -14853,29 +14753,25 @@
       "version": "3.2.2",
       "resolved": "https://registry.npmjs.org/@types/d3-array/-/d3-array-3.2.2.tgz",
       "integrity": "sha512-hOLWVbm7uRza0BYXpIIW5pxfrKe0W+D5lrFiAEYR+pb6w3N2SwSMaJbXdUfSEv+dT4MfHBLtn5js0LAWaO6otw==",
-      "license": "MIT",
-      "peer": true
+      "license": "MIT"
     },
     "node_modules/@types/d3-color": {
       "version": "3.1.3",
       "resolved": "https://registry.npmjs.org/@types/d3-color/-/d3-color-3.1.3.tgz",
       "integrity": "sha512-iO90scth9WAbmgv7ogoq57O9YpKmFBbmoEoCHDB2xMBY0+/KVrqAaCDyCE16dUspeOvIxFFRI+0sEtqDqy2b4A==",
-      "license": "MIT",
-      "peer": true
+      "license": "MIT"
     },
     "node_modules/@types/d3-ease": {
       "version": "3.0.2",
       "resolved": "https://registry.npmjs.org/@types/d3-ease/-/d3-ease-3.0.2.tgz",
       "integrity": "sha512-NcV1JjO5oDzoK26oMzbILE6HW7uVXOHLQvHshBUW4UMdZGfiY6v5BeQwh9a9tCzv+CeefZQHJt5SRgK154RtiA==",
-      "license": "MIT",
-      "peer": true
+      "license": "MIT"
     },
     "node_modules/@types/d3-interpolate": {
       "version": "3.0.4",
       "resolved": "https://registry.npmjs.org/@types/d3-interpolate/-/d3-interpolate-3.0.4.tgz",
       "integrity": "sha512-mgLPETlrpVV1YRJIglr4Ez47g7Yxjl1lj7YKsiMCb27VJH9W8NVM6Bb9d8kkpG/uAQS5AmbA48q2IAolKKo1MA==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@types/d3-color": "*"
       }
@@ -14884,15 +14780,13 @@
       "version": "3.1.1",
       "resolved": "https://registry.npmjs.org/@types/d3-path/-/d3-path-3.1.1.tgz",
       "integrity": "sha512-VMZBYyQvbGmWyWVea0EHs/BwLgxc+MKi1zLDCONksozI4YJMcTt8ZEuIR4Sb1MMTE8MMW49v0IwI5+b7RmfWlg==",
-      "license": "MIT",
-      "peer": true
+      "license": "MIT"
     },
     "node_modules/@types/d3-scale": {
       "version": "4.0.9",
       "resolved": "https://registry.npmjs.org/@types/d3-scale/-/d3-scale-4.0.9.tgz",
       "integrity": "sha512-dLmtwB8zkAeO/juAMfnV+sItKjlsw2lKdZVVy6LRr0cBmegxSABiLEpGVmSJJ8O08i4+sGR6qQtb6WtuwJdvVw==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@types/d3-time": "*"
       }
@@ -14902,7 +14796,6 @@
       "resolved": "https://registry.npmjs.org/@types/d3-shape/-/d3-shape-3.1.8.tgz",
       "integrity": "sha512-lae0iWfcDeR7qt7rA88BNiqdvPS5pFVPpo5OfjElwNaT2yyekbM0C9vK+yqBqEmHr6lDkRnYNoTBYlAgJa7a4w==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@types/d3-path": "*"
       }
@@ -14911,15 +14804,13 @@
       "version": "3.0.4",
       "resolved": "https://registry.npmjs.org/@types/d3-time/-/d3-time-3.0.4.tgz",
       "integrity": "sha512-yuzZug1nkAAaBlBBikKZTgzCeA+k1uy4ZFwWANOfKw5z5LRhV0gNA7gNkKm7HoK+HRN0wX3EkxGk0fpbWhmB7g==",
-      "license": "MIT",
-      "peer": true
+      "license": "MIT"
     },
     "node_modules/@types/d3-timer": {
       "version": "3.0.2",
       "resolved": "https://registry.npmjs.org/@types/d3-timer/-/d3-timer-3.0.2.tgz",
       "integrity": "sha512-Ps3T8E8dZDam6fUyNiMkekK3XUsaUEik+idO9/YjPtfj2qruF8tFBXS7XhtE4iIXBLxhmLjP3SXpLhVf21I9Lw==",
-      "license": "MIT",
-      "peer": true
+      "license": "MIT"
     },
     "node_modules/@types/dayjs-precise-range": {
       "version": "1.0.5",
@@ -14962,6 +14853,7 @@
       "version": "4.17.13",
       "resolved": "https://registry.npmjs.org/@types/express/-/express-4.17.13.tgz",
       "integrity": "sha512-6bSZTPaTIACxn48l50SR+axgrqm6qXFIxrdAKaG6PaJk3+zuUr35hBlgT7vOmJcum+OEaIBLtHV/qloEAFITeA==",
+      "peer": true,
       "dependencies": {
         "@types/body-parser": "*",
         "@types/express-serve-static-core": "^4.17.18",
@@ -15154,7 +15046,8 @@
     "node_modules/@types/node": {
       "version": "18.15.13",
       "resolved": "https://registry.npmjs.org/@types/node/-/node-18.15.13.tgz",
-      "integrity": "sha512-N+0kuo9KgrUQ1Sn/ifDXsvg0TTleP7rIy4zOBGECxAljqvqfqpTfzx0Q1NUedOixRMBfe2Whhb056a42cWs26Q=="
+      "integrity": "sha512-N+0kuo9KgrUQ1Sn/ifDXsvg0TTleP7rIy4zOBGECxAljqvqfqpTfzx0Q1NUedOixRMBfe2Whhb056a42cWs26Q==",
+      "peer": true
     },
     "node_modules/@types/node-fetch": {
       "version": "2.6.4",
@@ -15227,6 +15120,7 @@
       "version": "17.0.2",
       "resolved": "https://registry.npmjs.org/@types/react/-/react-17.0.2.tgz",
       "integrity": "sha512-Xt40xQsrkdvjn1EyWe1Bc0dJLcil/9x2vAuW7ya+PuQip4UYUaXyhzWmAbwRsdMgwOFHpfp7/FFZebDU6Y8VHA==",
+      "peer": true,
       "dependencies": {
         "@types/prop-types": "*",
         "csstype": "^3.0.2"
@@ -15245,7 +15139,6 @@
       "resolved": "https://registry.npmjs.org/@types/react-transition-group/-/react-transition-group-4.4.12.tgz",
       "integrity": "sha512-8TV6R3h2j7a91c+1DXdJi3Syo69zzIZbz7Lg5tORM5LEJG7X/E6a1V3drRyBRZq7/utz7A+c4OgYLiLcYGHG6w==",
       "license": "MIT",
-      "peer": true,
       "peerDependencies": {
         "@types/react": "*"
       }
@@ -15391,8 +15284,7 @@
       "version": "0.0.3",
       "resolved": "https://registry.npmjs.org/@types/use-sync-external-store/-/use-sync-external-store-0.0.3.tgz",
       "integrity": "sha512-EwmlvuaxPNej9+T4v5AuBPJa2x2UOJVdjCtDHgcDqitUeOtjnJKJ+apYjVcAoBEMjKW1VVFGZLUb5+qqa09XFA==",
-      "license": "MIT",
-      "peer": true
+      "license": "MIT"
     },
     "node_modules/@types/validator": {
       "version": "13.7.2",
@@ -15564,6 +15456,7 @@
       "resolved": "https://registry.npmjs.org/@typescript-eslint/parser/-/parser-6.11.0.tgz",
       "integrity": "sha512-+whEdjk+d5do5nxfxx73oanLL9ghKO3EwM9kBCkUtWMRwWuPaFv9ScuqlYfQ6pAD6ZiJhky7TZ2ZYhrMsfMxVQ==",
       "dev": true,
+      "peer": true,
       "dependencies": {
         "@typescript-eslint/scope-manager": "6.11.0",
         "@typescript-eslint/types": "6.11.0",
@@ -16040,6 +15933,326 @@
         "url": "https://opencollective.com/typescript-eslint"
       }
     },
+    "node_modules/@typescript/typescript-aix-ppc64": {
+      "version": "7.0.2",
+      "resolved": "https://registry.npmjs.org/@typescript/typescript-aix-ppc64/-/typescript-aix-ppc64-7.0.2.tgz",
+      "integrity": "sha512-MTKKkWB7p/0E9xi1d1tHtZ5PiLkGEMIq88pK2CubZjOsLtYTLqhgIgi6zepFa+9GHZ6h05NMCkQxGKiPXMxXtQ==",
+      "cpu": [
+        "ppc64"
+      ],
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "aix"
+      ],
+      "engines": {
+        "node": ">=16.20.0"
+      }
+    },
+    "node_modules/@typescript/typescript-darwin-arm64": {
+      "version": "7.0.2",
+      "resolved": "https://registry.npmjs.org/@typescript/typescript-darwin-arm64/-/typescript-darwin-arm64-7.0.2.tgz",
+      "integrity": "sha512-gowzar9MwS/aRWp6f3a4KUqzRjAZjOsmGNCM6LcTgXum+dBfgsBVMN+AgvOCCbguXyick6LJhpBszxMebJ8syA==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">=16.20.0"
+      }
+    },
+    "node_modules/@typescript/typescript-darwin-x64": {
+      "version": "7.0.2",
+      "resolved": "https://registry.npmjs.org/@typescript/typescript-darwin-x64/-/typescript-darwin-x64-7.0.2.tgz",
+      "integrity": "sha512-SZ9xZInqApNlNGc9s0W1VSsktYSOe9cFqNOIqmN1Gs8SmkjKZYFt017G4VwPxASInODuAdbTW7sXiFUf893RgA==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">=16.20.0"
+      }
+    },
+    "node_modules/@typescript/typescript-freebsd-arm64": {
+      "version": "7.0.2",
+      "resolved": "https://registry.npmjs.org/@typescript/typescript-freebsd-arm64/-/typescript-freebsd-arm64-7.0.2.tgz",
+      "integrity": "sha512-W5NH4y/J0plIIS5b2xvTEkU7JFxyqdMAOgf+Ilhl0vHQXKO5dZoxd+C/jEtq56c4F3wk71RB4BMRQ2XdI+bwYQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "engines": {
+        "node": ">=16.20.0"
+      }
+    },
+    "node_modules/@typescript/typescript-freebsd-x64": {
+      "version": "7.0.2",
+      "resolved": "https://registry.npmjs.org/@typescript/typescript-freebsd-x64/-/typescript-freebsd-x64-7.0.2.tgz",
+      "integrity": "sha512-UMGDx5sTpzNw3WiPebH7l90IWfJggEd+egHt/q6p7/Cm3zqoV7VxkGXt+3DxPIw8CcmvAB0j3sVVfbhX+M4Tpw==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "engines": {
+        "node": ">=16.20.0"
+      }
+    },
+    "node_modules/@typescript/typescript-linux-arm": {
+      "version": "7.0.2",
+      "resolved": "https://registry.npmjs.org/@typescript/typescript-linux-arm/-/typescript-linux-arm-7.0.2.tgz",
+      "integrity": "sha512-gffT3xPz9sR7j/YJExkyPntrI0P2EP9XbOyWzth2/Gs0RstK+90RBcO0ncXoXy/beYll1SXw846Nf2zdnEz0QQ==",
+      "cpu": [
+        "arm"
+      ],
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=16.20.0"
+      }
+    },
+    "node_modules/@typescript/typescript-linux-arm64": {
+      "version": "7.0.2",
+      "resolved": "https://registry.npmjs.org/@typescript/typescript-linux-arm64/-/typescript-linux-arm64-7.0.2.tgz",
+      "integrity": "sha512-Qh4eU4/y3yDjnfjjyPYihMj5/ODIlmt+Bzu17OI+fiSRDW57QmU5SiN63exPRNJPKUzcc1INa1NXdrJ+MqHjUQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=16.20.0"
+      }
+    },
+    "node_modules/@typescript/typescript-linux-loong64": {
+      "version": "7.0.2",
+      "resolved": "https://registry.npmjs.org/@typescript/typescript-linux-loong64/-/typescript-linux-loong64-7.0.2.tgz",
+      "integrity": "sha512-uEHck9i8hoAzXPiYRib1O7miOnz23SxIeVl6F4LXox+qov1K35jHcEW6VHKvZI+pyvl7fZEP4MCU5LYvIq1GuQ==",
+      "cpu": [
+        "loong64"
+      ],
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=16.20.0"
+      }
+    },
+    "node_modules/@typescript/typescript-linux-mips64el": {
+      "version": "7.0.2",
+      "resolved": "https://registry.npmjs.org/@typescript/typescript-linux-mips64el/-/typescript-linux-mips64el-7.0.2.tgz",
+      "integrity": "sha512-R4KvAMnE43W5Qeqb0Ly56O3mWMWIAgsMyz36DCaycd5nbg/9kzm0liw3JocfRqyJY0KPmzFjbswozXyW0DnIYA==",
+      "cpu": [
+        "mips64el"
+      ],
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=16.20.0"
+      }
+    },
+    "node_modules/@typescript/typescript-linux-ppc64": {
+      "version": "7.0.2",
+      "resolved": "https://registry.npmjs.org/@typescript/typescript-linux-ppc64/-/typescript-linux-ppc64-7.0.2.tgz",
+      "integrity": "sha512-DORx5b3sd/4S7eayxm4FQv+A7CrkUIGRaHiwI8oiHTAI1fAPWhF4J0vAlkC8biAlHSVVwxMQ3tjZ2/DVbnQiiA==",
+      "cpu": [
+        "ppc64"
+      ],
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=16.20.0"
+      }
+    },
+    "node_modules/@typescript/typescript-linux-riscv64": {
+      "version": "7.0.2",
+      "resolved": "https://registry.npmjs.org/@typescript/typescript-linux-riscv64/-/typescript-linux-riscv64-7.0.2.tgz",
+      "integrity": "sha512-wf0jqEDOjrPRnKwYRyyJDRo11KMbvMFrU+q4zqKyChODBzvlkbhNQfKvLxQCcwTpdDaXSHZTVuh0JoCrKCUMHQ==",
+      "cpu": [
+        "riscv64"
+      ],
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=16.20.0"
+      }
+    },
+    "node_modules/@typescript/typescript-linux-s390x": {
+      "version": "7.0.2",
+      "resolved": "https://registry.npmjs.org/@typescript/typescript-linux-s390x/-/typescript-linux-s390x-7.0.2.tgz",
+      "integrity": "sha512-IkwJc3L7yhytWd/ewjyxNDfOmswCm9GWMJT/ue/dU4aZNbwZeYAetq42VyLmsmSjvoX7z74X6ZaYCtzAr0EuGw==",
+      "cpu": [
+        "s390x"
+      ],
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=16.20.0"
+      }
+    },
+    "node_modules/@typescript/typescript-linux-x64": {
+      "version": "7.0.2",
+      "resolved": "https://registry.npmjs.org/@typescript/typescript-linux-x64/-/typescript-linux-x64-7.0.2.tgz",
+      "integrity": "sha512-EYdf2cNg7rgCWJnxCdJ+F3V39O8ihb37eHAu1LK8oAFizgTQbPOK7zHHXbPt8rX24COqODXeI3sIf0fCXG7H/A==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=16.20.0"
+      }
+    },
+    "node_modules/@typescript/typescript-netbsd-arm64": {
+      "version": "7.0.2",
+      "resolved": "https://registry.npmjs.org/@typescript/typescript-netbsd-arm64/-/typescript-netbsd-arm64-7.0.2.tgz",
+      "integrity": "sha512-+polYF4MF04aPpO5FTkHran9yUQDSXqy5GiSDKpsll5jy3l3+g9QLhpf39T+ePtefhXLOGrLl0QIjkQP6VnelA==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "netbsd"
+      ],
+      "engines": {
+        "node": ">=16.20.0"
+      }
+    },
+    "node_modules/@typescript/typescript-netbsd-x64": {
+      "version": "7.0.2",
+      "resolved": "https://registry.npmjs.org/@typescript/typescript-netbsd-x64/-/typescript-netbsd-x64-7.0.2.tgz",
+      "integrity": "sha512-8YIT0EHM/3dq10ZOVF/A7pc/YSMtbcecct4rWtexrnSCHOPcpC2KTLXfTCR6vDpnSiY12heNb1GiN/wu+T/FyA==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "netbsd"
+      ],
+      "engines": {
+        "node": ">=16.20.0"
+      }
+    },
+    "node_modules/@typescript/typescript-openbsd-arm64": {
+      "version": "7.0.2",
+      "resolved": "https://registry.npmjs.org/@typescript/typescript-openbsd-arm64/-/typescript-openbsd-arm64-7.0.2.tgz",
+      "integrity": "sha512-APT8+ClYnuYm1u9+kgGXoMj2VzWzcymwh2gNSQVySHfkRDGOTVkoWLjCmOQSaO+PoqQ57B0flRp9SA+7GnnkzQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "openbsd"
+      ],
+      "engines": {
+        "node": ">=16.20.0"
+      }
+    },
+    "node_modules/@typescript/typescript-openbsd-x64": {
+      "version": "7.0.2",
+      "resolved": "https://registry.npmjs.org/@typescript/typescript-openbsd-x64/-/typescript-openbsd-x64-7.0.2.tgz",
+      "integrity": "sha512-yX7s+Q0Dln0Dt9tEzZsAjXXR/+ytBM7AlglaqyeMPxQszJ1JhlJdZ6jLA+IzldHtflX81em7lDao1xXu+aRRkg==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "openbsd"
+      ],
+      "engines": {
+        "node": ">=16.20.0"
+      }
+    },
+    "node_modules/@typescript/typescript-sunos-x64": {
+      "version": "7.0.2",
+      "resolved": "https://registry.npmjs.org/@typescript/typescript-sunos-x64/-/typescript-sunos-x64-7.0.2.tgz",
+      "integrity": "sha512-dLJDGaLZ1D4HPQn62u1n8mBDkJREwMsAkCdkwd4Ieqw+x3TUyTsqY0YiBCtE6H6OzzgGk3iuZ3vFWRS+E8/d1g==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "sunos"
+      ],
+      "engines": {
+        "node": ">=16.20.0"
+      }
+    },
+    "node_modules/@typescript/typescript-win32-arm64": {
+      "version": "7.0.2",
+      "resolved": "https://registry.npmjs.org/@typescript/typescript-win32-arm64/-/typescript-win32-arm64-7.0.2.tgz",
+      "integrity": "sha512-Gyl1Vy6OsWesLzmq+EP0Fb7b4Nid5232AvcA2SFcdYreldpNtYFFofPjnt62y9hQy7VTaZp65ICJjuAQRaVcIQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=16.20.0"
+      }
+    },
+    "node_modules/@typescript/typescript-win32-x64": {
+      "version": "7.0.2",
+      "resolved": "https://registry.npmjs.org/@typescript/typescript-win32-x64/-/typescript-win32-x64-7.0.2.tgz",
+      "integrity": "sha512-0BQ3HkAHHlKLSp1qRvf3SUhGpGsDuhB/jgFw75guyqbxJqEaS0Cw/VFO8i2nHglJUzQCRtMMR/IBAKE3ETMC4g==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=16.20.0"
+      }
+    },
     "node_modules/@vercel/webpack-asset-relocator-loader": {
       "version": "1.7.2",
       "resolved": "https://registry.npmjs.org/@vercel/webpack-asset-relocator-loader/-/webpack-asset-relocator-loader-1.7.2.tgz",
@@ -16102,6 +16315,7 @@
       "resolved": "https://registry.npmjs.org/@wagmi/core/-/core-2.22.1.tgz",
       "integrity": "sha512-cG/xwQWsBEcKgRTkQVhH29cbpbs/TdcUJVFXCyri3ZknxhMyGv0YEjTcrNpRgt2SaswL1KrvslSNYKKo+5YEAg==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "eventemitter3": "5.0.1",
         "mipd": "0.0.7",
@@ -16223,6 +16437,7 @@
       "integrity": "sha512-SSlIG6QEVxClgl1s0LMk4xr2wg4eT3Zn/Hb81IocyqNSGfXpjtawWxKxiC5/9Z95f1INyBD6MctJbL/R1oBwIw==",
       "deprecated": "Reliability and performance improvements. See: https://github.com/WalletConnect/walletconnect-monorepo/releases",
       "license": "Apache-2.0",
+      "peer": true,
       "dependencies": {
         "@reown/appkit": "1.7.8",
         "@walletconnect/jsonrpc-http-connection": "1.0.8",
@@ -16560,6 +16775,7 @@
       "resolved": "https://registry.npmjs.org/ws/-/ws-8.18.0.tgz",
       "integrity": "sha512-8VbfWfHLbbwu3+N6OKsOMpBdT4kXPDDB9cJk2bJ6mh9ucxdlnNvH1e+roYkKmN9Nxw2yjz7VzeO9oOz2zJ04Pw==",
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=10.0.0"
       },
@@ -16878,6 +17094,7 @@
       "resolved": "https://registry.npmjs.org/ws/-/ws-8.18.0.tgz",
       "integrity": "sha512-8VbfWfHLbbwu3+N6OKsOMpBdT4kXPDDB9cJk2bJ6mh9ucxdlnNvH1e+roYkKmN9Nxw2yjz7VzeO9oOz2zJ04Pw==",
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=10.0.0"
       },
@@ -17139,6 +17356,7 @@
       "resolved": "https://registry.npmjs.org/ws/-/ws-8.18.0.tgz",
       "integrity": "sha512-8VbfWfHLbbwu3+N6OKsOMpBdT4kXPDDB9cJk2bJ6mh9ucxdlnNvH1e+roYkKmN9Nxw2yjz7VzeO9oOz2zJ04Pw==",
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=10.0.0"
       },
@@ -17407,6 +17625,7 @@
       "resolved": "https://registry.npmjs.org/ws/-/ws-8.18.0.tgz",
       "integrity": "sha512-8VbfWfHLbbwu3+N6OKsOMpBdT4kXPDDB9cJk2bJ6mh9ucxdlnNvH1e+roYkKmN9Nxw2yjz7VzeO9oOz2zJ04Pw==",
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=10.0.0"
       },
@@ -18387,6 +18606,7 @@
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/abort-controller/-/abort-controller-3.0.0.tgz",
       "integrity": "sha512-h8lQ8tacZYnR3vNQTgibj+tODHI5/+l06Au2Pcriv/Gmet0eaj4TwWH41sO9wnHDiQsEj19q0drzdWdeAHtweg==",
+      "peer": true,
       "dependencies": {
         "event-target-shim": "^5.0.0"
       },
@@ -18415,6 +18635,7 @@
       "version": "8.11.3",
       "resolved": "https://registry.npmjs.org/acorn/-/acorn-8.11.3.tgz",
       "integrity": "sha512-Y9rRfJG5jcKOE0CLisYbojUjIrIEE7AGMzA/Sm4BslANhbS+cDMpgBdcPT91oJ7OuJ9hYJBx59RjbhxVnrF8Xg==",
+      "peer": true,
       "bin": {
         "acorn": "bin/acorn"
       },
@@ -18500,6 +18721,7 @@
       "version": "6.12.6",
       "resolved": "https://registry.npmjs.org/ajv/-/ajv-6.12.6.tgz",
       "integrity": "sha512-j3fVLgvTo527anyYyJOGTYJbG+vnnQYvE0m5mmkc1TK+nxAppkCLMIL0aZ4dblVCNoGShhm+kzE4ZUykBoMg4g==",
+      "peer": true,
       "dependencies": {
         "fast-deep-equal": "^3.1.1",
         "fast-json-stable-stringify": "^2.0.0",
@@ -19068,7 +19290,6 @@
       "integrity": "sha512-ifWaTHQ0ce+448CYop8AdrQiBsGrnC+bMgfyKFdi6EsPLTAWG+QfyDeM6OH+FmWnKvEq5NnBMLvlBUPKQZoDSg==",
       "deprecated": "babel-eslint is now @babel/eslint-parser. This package will no longer receive updates.",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@babel/code-frame": "^7.0.0",
         "@babel/parser": "^7.7.0",
@@ -19089,7 +19310,6 @@
       "resolved": "https://registry.npmjs.org/eslint-visitor-keys/-/eslint-visitor-keys-1.3.0.tgz",
       "integrity": "sha512-6J72N8UNa462wa/KFODt/PJ3IU60SDpC3QXC1Hjc1BXXpfL2C9R5+AU7jhe0F6GREqVMh4Juu+NY7xn+6dipUQ==",
       "license": "Apache-2.0",
-      "peer": true,
       "engines": {
         "node": ">=4"
       }
@@ -19404,8 +19624,7 @@
       "version": "0.5.2",
       "resolved": "https://registry.npmjs.org/balloon-css/-/balloon-css-0.5.2.tgz",
       "integrity": "sha512-zheJpzwyNrG4t39vusA67v3BYg1HTVXOF8cErPEHzWK88PEOFwgo6Ea9VHOgOWNMgeuOtFVtB73NE2NWl9uDyQ==",
-      "license": "MIT",
-      "peer": true
+      "license": "MIT"
     },
     "node_modules/base-x": {
       "version": "3.0.9",
@@ -19785,6 +20004,7 @@
         }
       ],
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "baseline-browser-mapping": "^2.10.38",
         "caniuse-lite": "^1.0.30001799",
@@ -19914,6 +20134,7 @@
       "integrity": "sha512-ZMANVnAixE6AWWnPzlW2KpUrxhm9woycYvPOo67jWHyFowASTEd9s+QN1EIMsSDtwhIxN4sWE1jotpuDUIgyIw==",
       "hasInstallScript": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "node-gyp-build": "^4.3.0"
       },
@@ -19960,7 +20181,6 @@
       "resolved": "https://registry.npmjs.org/c12/-/c12-3.3.4.tgz",
       "integrity": "sha512-cM0ApFQSBXuourJejzwv/AuPRvAxordTyParRVcHjjtXirtkzM0uK2L9TTn9s0cXZbG7E55jCivRQzoxYmRAlA==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "chokidar": "^5.0.0",
         "confbox": "^0.2.4",
@@ -19989,7 +20209,6 @@
       "resolved": "https://registry.npmjs.org/chokidar/-/chokidar-5.0.0.tgz",
       "integrity": "sha512-TQMmc3w+5AxjpL8iIiwebF73dRDF4fBIieAqGn9RGCWaEVwQ6Fb2cGe31Yns0RRIzii5goJ1Y7xbMwo1TxMplw==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "readdirp": "^5.0.0"
       },
@@ -20005,7 +20224,6 @@
       "resolved": "https://registry.npmjs.org/dotenv/-/dotenv-17.4.2.tgz",
       "integrity": "sha512-nI4U3TottKAcAD9LLud4Cb7b2QztQMUEfHbvhTH09bqXTxnSie8WnjPALV/WMCrJZ6UV/qHJ6L03OqO3LcdYZw==",
       "license": "BSD-2-Clause",
-      "peer": true,
       "engines": {
         "node": ">=12"
       },
@@ -20018,7 +20236,6 @@
       "resolved": "https://registry.npmjs.org/readdirp/-/readdirp-5.0.0.tgz",
       "integrity": "sha512-9u/XQ1pvrQtYyMpZe7DXKv2p5CNvyVwzUB6uhLAnQwHMSgKMBR62lc7AHljaeteeHXn11XTAaLLUVZYVZyuRBQ==",
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">= 20.19.0"
       },
@@ -20737,8 +20954,7 @@
       "version": "2.5.1",
       "resolved": "https://registry.npmjs.org/classnames/-/classnames-2.5.1.tgz",
       "integrity": "sha512-saHYOzhIQs6wy2sVxTM6bUDsQO4F50V9RQ22qBpEdCW+I+/Wmke2HOl6lS6dTpdxVhb88/I6+Hs+438c3lfUow==",
-      "license": "MIT",
-      "peer": true
+      "license": "MIT"
     },
     "node_modules/clean-css": {
       "version": "3.4.28",
@@ -21153,7 +21369,6 @@
       "resolved": "https://registry.npmjs.org/color-support/-/color-support-1.1.3.tgz",
       "integrity": "sha512-qiBjkpbMLO/HL68y+lh4q0/O1MZFj2RX6X/KmMa3+gJD3z+WwI1ZzDHysvqHGS3mP6mznPckpXmw1nI9cJjyRg==",
       "license": "ISC",
-      "peer": true,
       "bin": {
         "color-support": "bin.js"
       }
@@ -21330,8 +21545,7 @@
       "version": "0.2.4",
       "resolved": "https://registry.npmjs.org/confbox/-/confbox-0.2.4.tgz",
       "integrity": "sha512-ysOGlgTFbN2/Y6Cg3Iye8YKulHw+R2fNXHrgSmXISQdMnomY6eNDprVdW9R5xBguEqI954+S6709UyiO7B+6OQ==",
-      "license": "MIT",
-      "peer": true
+      "license": "MIT"
     },
     "node_modules/configstore": {
       "version": "5.0.1",
@@ -21445,6 +21659,7 @@
       "resolved": "https://registry.npmjs.org/core-js/-/core-js-3.32.2.tgz",
       "integrity": "sha512-pxXSw1mYZPDGvTQqEc5vgIb83jGQKFGYWY76z4a7weZXUolw3G+OvpZqSRcfYOoOVUQJYEPsWeQK8pKEnUtWxQ==",
       "hasInstallScript": true,
+      "peer": true,
       "funding": {
         "type": "opencollective",
         "url": "https://opencollective.com/core-js"
@@ -21600,6 +21815,7 @@
       "resolved": "https://registry.npmjs.org/cross-fetch/-/cross-fetch-4.1.0.tgz",
       "integrity": "sha512-uKm5PU+MHTootlWEY+mZ4vvXoCn4fLQxT9dSc1sXVMSFkINTJVN8cAQROpwcKm8bJ/c7rgZVIBWzH5T78sNZZw==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "node-fetch": "^2.7.0"
       }
@@ -21707,8 +21923,7 @@
       "version": "0.1.2",
       "resolved": "https://registry.npmjs.org/css-mediaquery/-/css-mediaquery-0.1.2.tgz",
       "integrity": "sha512-COtn4EROW5dBGlE/4PiKnh6rZpAPxDeFLaEEwt4i10jpDMFt2EhQGS79QmmrO+iKCHv0PU/HrOWEhijFd1x99Q==",
-      "license": "BSD",
-      "peer": true
+      "license": "BSD"
     },
     "node_modules/css-minimizer-webpack-plugin": {
       "version": "2.0.0",
@@ -22491,7 +22706,6 @@
       "resolved": "https://registry.npmjs.org/d3-array/-/d3-array-3.2.4.tgz",
       "integrity": "sha512-tdQAmyA18i4J7wprpYq8ClcxZy3SC31QMeByyCFyRt7BVHdREQZ5lpzoe5mFEYZUWe+oq8HBvk9JjpibyEV4Jg==",
       "license": "ISC",
-      "peer": true,
       "dependencies": {
         "internmap": "1 - 2"
       },
@@ -22504,7 +22718,6 @@
       "resolved": "https://registry.npmjs.org/d3-color/-/d3-color-3.1.0.tgz",
       "integrity": "sha512-zg/chbXyeBtMQ1LbD/WSoW2DpC3I0mpmPdW+ynRTj/x2DAWYrIY7qeZIHidozwV24m4iavr15lNwIwLxRmOxhA==",
       "license": "ISC",
-      "peer": true,
       "engines": {
         "node": ">=12"
       }
@@ -22514,7 +22727,6 @@
       "resolved": "https://registry.npmjs.org/d3-ease/-/d3-ease-3.0.1.tgz",
       "integrity": "sha512-wR/XK3D3XcLIZwpbvQwQ5fK+8Ykds1ip7A2Txe0yxncXSdq1L9skcG7blcedkOX+ZcgxGAmLX1FrRGbADwzi0w==",
       "license": "BSD-3-Clause",
-      "peer": true,
       "engines": {
         "node": ">=12"
       }
@@ -22524,7 +22736,6 @@
       "resolved": "https://registry.npmjs.org/d3-format/-/d3-format-3.1.2.tgz",
       "integrity": "sha512-AJDdYOdnyRDV5b6ArilzCPPwc1ejkHcoyFarqlPqT7zRYjhavcT3uSrqcMvsgh2CgoPbK3RCwyHaVyxYcP2Arg==",
       "license": "ISC",
-      "peer": true,
       "engines": {
         "node": ">=12"
       }
@@ -22534,7 +22745,6 @@
       "resolved": "https://registry.npmjs.org/d3-interpolate/-/d3-interpolate-3.0.1.tgz",
       "integrity": "sha512-3bYs1rOD33uo8aqJfKP3JWPAibgw8Zm2+L9vBKEHJ2Rg+viTR7o5Mmv5mZcieN+FRYaAOWX5SJATX6k1PWz72g==",
       "license": "ISC",
-      "peer": true,
       "dependencies": {
         "d3-color": "1 - 3"
       },
@@ -22547,7 +22757,6 @@
       "resolved": "https://registry.npmjs.org/d3-path/-/d3-path-3.1.0.tgz",
       "integrity": "sha512-p3KP5HCf/bvjBSSKuXid6Zqijx7wIfNW+J/maPs+iwR35at5JCbLUT0LzF1cnjbCHWhqzQTIN2Jpe8pRebIEFQ==",
       "license": "ISC",
-      "peer": true,
       "engines": {
         "node": ">=12"
       }
@@ -22557,7 +22766,6 @@
       "resolved": "https://registry.npmjs.org/d3-scale/-/d3-scale-4.0.2.tgz",
       "integrity": "sha512-GZW464g1SH7ag3Y7hXjf8RoUuAFIqklOAq3MRl4OaWabTFJY9PN/E1YklhXLh+OQ3fM9yS2nOkCoS+WLZ6kvxQ==",
       "license": "ISC",
-      "peer": true,
       "dependencies": {
         "d3-array": "2.10.0 - 3",
         "d3-format": "1 - 3",
@@ -22574,7 +22782,6 @@
       "resolved": "https://registry.npmjs.org/d3-shape/-/d3-shape-3.2.0.tgz",
       "integrity": "sha512-SaLBuwGm3MOViRq2ABk3eLoxwZELpH6zhl3FbAoJ7Vm1gofKx6El1Ib5z23NUEhF9AsGl7y+dzLe5Cw2AArGTA==",
       "license": "ISC",
-      "peer": true,
       "dependencies": {
         "d3-path": "^3.1.0"
       },
@@ -22587,7 +22794,6 @@
       "resolved": "https://registry.npmjs.org/d3-time/-/d3-time-3.1.0.tgz",
       "integrity": "sha512-VqKjzBLejbSMT4IgbmVgDjpkYrNWUYJnbCGo874u7MMKIWsILRX+OpX/gTk8MqjpT1A/c6HY2dCA77ZN0lkQ2Q==",
       "license": "ISC",
-      "peer": true,
       "dependencies": {
         "d3-array": "2 - 3"
       },
@@ -22600,7 +22806,6 @@
       "resolved": "https://registry.npmjs.org/d3-time-format/-/d3-time-format-4.1.0.tgz",
       "integrity": "sha512-dJxPBlzC7NugB2PDLwo9Q8JiTR3M3e4/XANkreKSUxF8vvXKqm1Yfq4Q5dl8budlunRVlUUaDUgFt7eA8D6NLg==",
       "license": "ISC",
-      "peer": true,
       "dependencies": {
         "d3-time": "1 - 3"
       },
@@ -22613,7 +22818,6 @@
       "resolved": "https://registry.npmjs.org/d3-timer/-/d3-timer-3.0.1.tgz",
       "integrity": "sha512-ndfJ/JxxMd3nw31uyKoY2naivF+r29V+Lc0svZxe1JvvIRmi8hUsrMvdOwgS1o6uBHmiz91geQ0ylPP0aj1VUA==",
       "license": "ISC",
-      "peer": true,
       "engines": {
         "node": ">=12"
       }
@@ -22657,7 +22861,6 @@
       "resolved": "https://registry.npmjs.org/dayzed/-/dayzed-3.2.3.tgz",
       "integrity": "sha512-qXTIKs+R6ydWwNo+X1wu3lUptyRSGoyY+ZzRcQSM0zUlaG+/Ei+bFjqbQm1T2oJ+WKNkTHURBcGsxnx9N+9kfA==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@babel/runtime": "^7.6.2",
         "date-fns": "^2.0.0"
@@ -22672,7 +22875,6 @@
       "resolved": "https://registry.npmjs.org/date-fns/-/date-fns-2.30.0.tgz",
       "integrity": "sha512-fnULvOpxnC5/Vg3NCiWelDsLiUc9bRwAPs/+LfTLNvetFCtCTN+yQz15C/fs4AwX1R9K5GLtLfn8QW+dWisaAw==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@babel/runtime": "^7.21.0"
       },
@@ -22795,6 +22997,7 @@
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/decentraland-crypto-fetch/-/decentraland-crypto-fetch-2.0.1.tgz",
       "integrity": "sha512-2IKu6Y4k/fle8bmU0b4zy7V1i1R0oCXtqlJumBXc4jwHUHKAcHDLD2YtgJFdd7JjsWQwf+t0DsKpzBCjQDKANg==",
+      "peer": true,
       "dependencies": {
         "@dcl/crypto": "^3.3.1",
         "core-js-pure": "^3.19.1"
@@ -22914,15 +23117,15 @@
       }
     },
     "node_modules/decentraland-gatsby": {
-      "version": "8.4.6",
-      "resolved": "https://registry.npmjs.org/decentraland-gatsby/-/decentraland-gatsby-8.4.6.tgz",
-      "integrity": "sha512-V72OrZzLWOvEY/GC4a3GZBAnN+Y/wlPVhdU6IS9W5KHC8aYcWwSpTybBsBV7GVoc9H/c92z8sVC43IauHkz6Sw==",
+      "version": "8.4.8",
+      "resolved": "https://registry.npmjs.org/decentraland-gatsby/-/decentraland-gatsby-8.4.8.tgz",
+      "integrity": "sha512-OTpFvODinVrNEat/72guACSl4nddSkF7ZhbgexPslKh2ddRFoi1Z9N/z4w3DMG4tKn2RquRWjUHu4rg19V6c8Q==",
       "license": "MIT",
       "dependencies": {
         "@aws-sdk/client-ses": "^3.421.0",
         "@dcl/core-commons": "^0.10.0",
         "@dcl/crypto": "^3.4.3",
-        "@dcl/crypto-middleware": "^4.0.0",
+        "@dcl/crypto-middleware": "^5.1.0",
         "@dcl/feature-flags": "^1.2.0",
         "@dcl/http-server": "^2.1.0",
         "@dcl/schemas": "^25.1.0",
@@ -23209,7 +23412,6 @@
       "resolved": "https://registry.npmjs.org/decentraland-ui/-/decentraland-ui-7.2.0.tgz",
       "integrity": "sha512-0BcYFQYf2RQA+LUlhYnqNx052GVcdEdLgJgykfmL607W522njFivmNN5gkBKyz+pyal3mYuKN7g0mjG3N+6+lA==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@dcl/schemas": "^22.5.0",
         "@dcl/ui-env": "^1.5.1",
@@ -23250,15 +23452,13 @@
       "version": "1.5.1",
       "resolved": "https://registry.npmjs.org/@dcl/ui-env/-/ui-env-1.5.1.tgz",
       "integrity": "sha512-03cPMH3wrNK5bdDEoidnXIr0ZpGPe0ly8ObDNwik6PjXF+g2YBAbo5/jDUN0panddL6N6YnCJROP8NkZl/ThnQ==",
-      "license": "ISC",
-      "peer": true
+      "license": "ISC"
     },
     "node_modules/decentraland-ui/node_modules/mitt": {
       "version": "3.0.1",
       "resolved": "https://registry.npmjs.org/mitt/-/mitt-3.0.1.tgz",
       "integrity": "sha512-vKivATfr97l2/QBCYAkXYDbrIWPM2IIKEl7YPhjCvKlG3kE2gm+uBo6nEXK3M5/Ffh/FLpKExzOQ3JJoJGFKBw==",
-      "license": "MIT",
-      "peer": true
+      "license": "MIT"
     },
     "node_modules/decentraland-ui/node_modules/uuid": {
       "version": "9.0.1",
@@ -23270,7 +23470,6 @@
         "https://github.com/sponsors/ctavan"
       ],
       "license": "MIT",
-      "peer": true,
       "bin": {
         "uuid": "dist/bin/uuid"
       }
@@ -23280,7 +23479,6 @@
       "resolved": "https://registry.npmjs.org/decentraland-ui2/-/decentraland-ui2-3.13.1.tgz",
       "integrity": "sha512-HU31iHeJXiM2pWQQHOR7BBUlkX0twrJ4IS5Op6BxtX2hpygsxpd1kwQ4gVQr9lH/FhN5JEUlZdZVa+MDGUlgrQ==",
       "license": "Apache-2.0",
-      "peer": true,
       "dependencies": {
         "@emotion/react": "11.14.0",
         "@emotion/styled": "11.14.0",
@@ -23322,7 +23520,6 @@
       "resolved": "https://registry.npmjs.org/@emotion/is-prop-valid/-/is-prop-valid-1.4.0.tgz",
       "integrity": "sha512-QgD4fyscGcbbKwJmqNvUMSE02OsHUa+lAWKdEUIJKgqe5IwRSKd7+KhibEWdaKwgjLj0DRSHA9biAIqGBk05lw==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@emotion/memoize": "^0.9.0"
       }
@@ -23331,15 +23528,13 @@
       "version": "0.9.0",
       "resolved": "https://registry.npmjs.org/@emotion/memoize/-/memoize-0.9.0.tgz",
       "integrity": "sha512-30FAj7/EoJ5mwVPOWhAyCX+FPfMDrVecJAM+Iw9NRoSl4BBAQeqj4cApHHUXOVvIPgLVDsCFoz/hGD+5QQD1GQ==",
-      "license": "MIT",
-      "peer": true
+      "license": "MIT"
     },
     "node_modules/decentraland-ui2/node_modules/@emotion/styled": {
       "version": "11.14.0",
       "resolved": "https://registry.npmjs.org/@emotion/styled/-/styled-11.14.0.tgz",
       "integrity": "sha512-XxfOnXFffatap2IyCeJyNov3kiDQWoR08gPUQxvbL7fxKryGBKUZUkG6Hz48DZwVrJSVh9sJboyV1Ds4OW6SgA==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@babel/runtime": "^7.18.3",
         "@emotion/babel-plugin": "^11.13.5",
@@ -23363,7 +23558,6 @@
       "resolved": "https://registry.npmjs.org/date-fns/-/date-fns-3.6.0.tgz",
       "integrity": "sha512-fRHTG8g/Gif+kSh50gaGEdToemgfj74aRX3swtiouboip5JDLAyDE9F11nHMIcvOaXeOC6D7SpNhi7uFyB7Uww==",
       "license": "MIT",
-      "peer": true,
       "funding": {
         "type": "github",
         "url": "https://github.com/sponsors/kossnocorp"
@@ -23373,8 +23567,7 @@
       "version": "3.0.1",
       "resolved": "https://registry.npmjs.org/mitt/-/mitt-3.0.1.tgz",
       "integrity": "sha512-vKivATfr97l2/QBCYAkXYDbrIWPM2IIKEl7YPhjCvKlG3kE2gm+uBo6nEXK3M5/Ffh/FLpKExzOQ3JJoJGFKBw==",
-      "license": "MIT",
-      "peer": true
+      "license": "MIT"
     },
     "node_modules/decentraland-ui2/node_modules/uuid": {
       "version": "11.1.0",
@@ -23385,7 +23578,6 @@
         "https://github.com/sponsors/ctavan"
       ],
       "license": "MIT",
-      "peer": true,
       "bin": {
         "uuid": "dist/esm/bin/uuid"
       }
@@ -23394,15 +23586,13 @@
       "version": "10.6.0",
       "resolved": "https://registry.npmjs.org/decimal.js/-/decimal.js-10.6.0.tgz",
       "integrity": "sha512-YpgQiITW3JXGntzdUmyUR1V812Hn8T1YVXhCu+wO3OpS4eU9l4YdD3qjyiKdV6mvV29zapkMeD390UVEf2lkUg==",
-      "license": "MIT",
-      "peer": true
+      "license": "MIT"
     },
     "node_modules/decimal.js-light": {
       "version": "2.5.1",
       "resolved": "https://registry.npmjs.org/decimal.js-light/-/decimal.js-light-2.5.1.tgz",
       "integrity": "sha512-qIMFpTMZmny+MMIitAB6D7iVPEorVw6YQRWkvarTkT4tBeSLLiHzcwj6q0MmYSFCiVpiqPJTJEYIrpcPzVEIvg==",
-      "license": "MIT",
-      "peer": true
+      "license": "MIT"
     },
     "node_modules/decode-named-character-reference": {
       "version": "1.0.1",
@@ -23440,7 +23630,6 @@
       "resolved": "https://registry.npmjs.org/deep-equal/-/deep-equal-2.2.3.tgz",
       "integrity": "sha512-ZIwpnevOurS8bpT4192sqAowWM76JDKSHYzMLty3BZGSswgq6pBaH3DhCSW5xVAZICZyKdOBPjwww5wfgT/6PA==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "array-buffer-byte-length": "^1.0.0",
         "call-bind": "^1.0.5",
@@ -23472,8 +23661,7 @@
       "version": "2.0.5",
       "resolved": "https://registry.npmjs.org/isarray/-/isarray-2.0.5.tgz",
       "integrity": "sha512-xHjhDr3cNBK0BzdUJSPXZntQUx/mwMS5Rw4A7lPJ90XGAO6ISP/ePDNuo0vhqOZU+UD5JoodwCAAoZQd3FeAKw==",
-      "license": "MIT",
-      "peer": true
+      "license": "MIT"
     },
     "node_modules/deep-extend": {
       "version": "0.6.0",
@@ -23952,7 +24140,6 @@
       "resolved": "https://registry.npmjs.org/dom-helpers/-/dom-helpers-5.2.1.tgz",
       "integrity": "sha512-nRCa7CK3VTrM2NmGkIy4cbK7IZlgBE/PYMn55rrXefr5xXDP0LdtfPnblFDoVdcAfslJ7or6iqAUnx0CCGIWQA==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@babel/runtime": "^7.8.7",
         "csstype": "^3.0.2"
@@ -24044,8 +24231,7 @@
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/dprop/-/dprop-1.0.0.tgz",
       "integrity": "sha512-CNrGk9cBoRzsLtyGRTcjsYh0n63nLtnWelCV31DlEK/yftX05rLK7qb9et891DYLUwhadlh/lOxq7W/+8XA2pQ==",
-      "license": "MIT",
-      "peer": true
+      "license": "MIT"
     },
     "node_modules/drbg.js": {
       "version": "1.0.1",
@@ -24065,7 +24251,6 @@
       "resolved": "https://registry.npmjs.org/dset/-/dset-3.1.4.tgz",
       "integrity": "sha512-2QF/g9/zTaPDc3BjNcVTGoBbXBgYfMTTceLaYcFJ/W9kggFUkhxD/hMEeuLKbugyef9SqAx8cpgwlIP/jinUTA==",
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=4"
       }
@@ -24125,6 +24310,7 @@
       "resolved": "https://registry.npmjs.org/eciesjs/-/eciesjs-0.4.18.tgz",
       "integrity": "sha512-wG99Zcfcys9fZux7Cft8BAX/YrOJLJSZ3jyYPfhZHqN2E+Ffx+QXBDsv3gubEgPtV6dTzJMSQUwk1H98/t/0wQ==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@ecies/ciphers": "^0.2.5",
         "@noble/ciphers": "^1.3.0",
@@ -24254,6 +24440,7 @@
       "version": "0.1.13",
       "resolved": "https://registry.npmjs.org/encoding/-/encoding-0.1.13.tgz",
       "integrity": "sha512-ETBauow1T35Y/WZMkio9jiM0Z5xjHHmJ4XmjZOq1l/dXz3lr2sRn87nJy20RupqSh1F2m3HHPSp8ShIPQJrJ3A==",
+      "peer": true,
       "dependencies": {
         "iconv-lite": "^0.6.2"
       }
@@ -24521,7 +24708,6 @@
       "resolved": "https://registry.npmjs.org/es-get-iterator/-/es-get-iterator-1.1.3.tgz",
       "integrity": "sha512-sPZmqHBe6JIiTfN5q2pEi//TwxmAFHwj/XEuYjTuse78i8KxaqMTTzxPoFKuzRpDpTJ+0NAbpfenkmH2rePtuw==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "call-bind": "^1.0.2",
         "get-intrinsic": "^1.1.3",
@@ -24541,8 +24727,7 @@
       "version": "2.0.5",
       "resolved": "https://registry.npmjs.org/isarray/-/isarray-2.0.5.tgz",
       "integrity": "sha512-xHjhDr3cNBK0BzdUJSPXZntQUx/mwMS5Rw4A7lPJ90XGAO6ISP/ePDNuo0vhqOZU+UD5JoodwCAAoZQd3FeAKw==",
-      "license": "MIT",
-      "peer": true
+      "license": "MIT"
     },
     "node_modules/es-module-lexer": {
       "version": "1.4.1",
@@ -24696,6 +24881,7 @@
       "version": "8.15.0",
       "resolved": "https://registry.npmjs.org/eslint/-/eslint-8.15.0.tgz",
       "integrity": "sha512-GG5USZ1jhCu8HJkzGgeK8/+RGnHaNYZGrGDzUtigK3BsGESW/rs2az23XqE0WVwDxy1VRvvjSSGu5nB0Bu+6SA==",
+      "peer": true,
       "dependencies": {
         "@eslint/eslintrc": "^1.2.3",
         "@humanwhocodes/config-array": "^0.9.2",
@@ -24859,6 +25045,7 @@
       "version": "2.26.0",
       "resolved": "https://registry.npmjs.org/eslint-plugin-import/-/eslint-plugin-import-2.26.0.tgz",
       "integrity": "sha512-hYfi3FXaM8WPLf4S1cikh/r4IxnO6zrhZbEGz2b660EJRbuxgpDS5gkCuYgGWg2xxh2rBuIr4Pvhve/7c31koA==",
+      "peer": true,
       "dependencies": {
         "array-includes": "^3.1.4",
         "array.prototype.flat": "^1.2.5",
@@ -24896,6 +25083,7 @@
       "version": "6.6.1",
       "resolved": "https://registry.npmjs.org/eslint-plugin-jsx-a11y/-/eslint-plugin-jsx-a11y-6.6.1.tgz",
       "integrity": "sha512-sXgFVNHiWffBq23uiS/JaP6eVR622DqwB4yTzKvGZGcPq6/yZ3WmOZfuBks/vHWo9GaFOqC2ZK4i6+C35knx7Q==",
+      "peer": true,
       "dependencies": {
         "@babel/runtime": "^7.18.9",
         "aria-query": "^4.2.2",
@@ -24956,6 +25144,7 @@
       "version": "7.31.8",
       "resolved": "https://registry.npmjs.org/eslint-plugin-react/-/eslint-plugin-react-7.31.8.tgz",
       "integrity": "sha512-5lBTZmgQmARLLSYiwI71tiGVTLUuqXantZM6vlSY39OaDSV0M7+32K5DnLkmFrwTe+Ksz0ffuLUC91RUviVZfw==",
+      "peer": true,
       "dependencies": {
         "array-includes": "^3.1.5",
         "array.prototype.flatmap": "^1.3.0",
@@ -24983,6 +25172,7 @@
       "version": "4.6.0",
       "resolved": "https://registry.npmjs.org/eslint-plugin-react-hooks/-/eslint-plugin-react-hooks-4.6.0.tgz",
       "integrity": "sha512-oFc7Itz9Qxh2x4gNHStv3BqJq54ExXmfC+a1NjAta66IAN87Wu0R/QArgIS9qKzX3dXKPI9H5crl9QchNMY9+g==",
+      "peer": true,
       "engines": {
         "node": ">=10"
       },
@@ -25455,8 +25645,7 @@
       "version": "0.1.1",
       "resolved": "https://registry.npmjs.org/ethereum-blockies/-/ethereum-blockies-0.1.1.tgz",
       "integrity": "sha512-ED+noMZ6z7RrzzhvrQna1L30C27MX+ZsdB5c/d5vygXtHjEyAQjQS2TgCYhPxs+z3U+u2YQsL9PiRkNl1f+ugg==",
-      "license": "MIT",
-      "peer": true
+      "license": "MIT"
     },
     "node_modules/ethereum-bloom-filters": {
       "version": "1.2.0",
@@ -25578,6 +25767,7 @@
         }
       ],
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@ethersproject/abi": "5.8.0",
         "@ethersproject/abstract-provider": "5.8.0",
@@ -25670,7 +25860,8 @@
       "version": "6.4.9",
       "resolved": "https://registry.npmjs.org/eventemitter2/-/eventemitter2-6.4.9.tgz",
       "integrity": "sha512-JEPTiaOt9f04oa6NOkc4aH+nVp5I3wEjpHbIPqfgCdD5v5bUzy7xQqwcVO2aDQgOWhI28da57HksMrzK9HlRxg==",
-      "license": "MIT"
+      "license": "MIT",
+      "peer": true
     },
     "node_modules/eventemitter3": {
       "version": "4.0.7",
@@ -25763,8 +25954,7 @@
       "version": "1.2.2",
       "resolved": "https://registry.npmjs.org/exenv/-/exenv-1.2.2.tgz",
       "integrity": "sha512-Z+ktTxTwv9ILfgKCk32OX3n/doe+OcLTRtqK9pcL+JsP3J1/VW8Uvl4ZjLlKqeW4rzK4oesDOGMEMRIZqtP4Iw==",
-      "license": "BSD-3-Clause",
-      "peer": true
+      "license": "BSD-3-Clause"
     },
     "node_modules/exit": {
       "version": "0.1.2",
@@ -25796,6 +25986,7 @@
       "resolved": "https://registry.npmjs.org/express/-/express-4.22.2.tgz",
       "integrity": "sha512-IuL+Elrou2ZvCFHs18/CIzy2Nzvo25nZ1/D2eIZlz7c+QUayAcYoiM2BthCjs+EBHVpjYjcuLDAiCWgeIX3X1Q==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "accepts": "~1.3.8",
         "array-flatten": "1.1.1",
@@ -25932,8 +26123,7 @@
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/exsolve/-/exsolve-1.1.0.tgz",
       "integrity": "sha512-D+42+T12DdIlJM3uepa55qGiL3sYdLBOxIl2ifQCzCHz4c7eiolaHsi3BIqEr7JxBzxv2pYZQX9kw16ziMcEmw==",
-      "license": "MIT",
-      "peer": true
+      "license": "MIT"
     },
     "node_modules/ext": {
       "version": "1.6.0",
@@ -26022,7 +26212,6 @@
       "resolved": "https://registry.npmjs.org/fast-equals/-/fast-equals-5.4.0.tgz",
       "integrity": "sha512-jt2DW/aNFNwke7AUd+Z+e6pz39KO5rzdbbFCg2sGafS4mk13MI7Z8O5z9cADNn5lhGODIgLwug6TZO2ctf7kcw==",
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=6.0.0"
       }
@@ -26583,7 +26772,6 @@
       "resolved": "https://registry.npmjs.org/format-string-by-pattern/-/format-string-by-pattern-1.2.2.tgz",
       "integrity": "sha512-dYhtZGK/V7iif43UGjHu3ExGASwmoDdHPIejcVv/dYnCjtkzFl4XIXqKuzryj26DaXMAwvEQ3FUv09fROvgY/Q==",
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=10"
       }
@@ -27872,6 +28060,7 @@
       "version": "4.33.0",
       "resolved": "https://registry.npmjs.org/@typescript-eslint/parser/-/parser-4.33.0.tgz",
       "integrity": "sha512-ZohdsbXadjGBSK0/r+d87X0SBmKzOq4/S5nzK6SBgJspFo9/CUDJ7hjayuze+JK7CZQLDMroqytp7pOcFKTxZA==",
+      "peer": true,
       "dependencies": {
         "@typescript-eslint/scope-manager": "4.33.0",
         "@typescript-eslint/types": "4.33.0",
@@ -28043,6 +28232,7 @@
       "version": "7.32.0",
       "resolved": "https://registry.npmjs.org/eslint/-/eslint-7.32.0.tgz",
       "integrity": "sha512-VHZ8gX+EDfz+97jGcgyGCyRia/dPOd6Xh9yPv8Bl1+SoaIwD+a/vlrOmGRUyOYu7MwUhc7CxqeaDZU13S4+EpA==",
+      "peer": true,
       "dependencies": {
         "@babel/code-frame": "7.12.11",
         "@eslint/eslintrc": "^0.4.3",
@@ -28131,6 +28321,7 @@
       "version": "5.10.0",
       "resolved": "https://registry.npmjs.org/eslint-plugin-flowtype/-/eslint-plugin-flowtype-5.10.0.tgz",
       "integrity": "sha512-vcz32f+7TP+kvTUyMXZmCnNujBQZDNmcqPImw8b9PZ+16w1Qdm6ryRuYZYVaG9xRqqmAPr2Cs9FAX5gN+x/bjw==",
+      "peer": true,
       "dependencies": {
         "lodash": "^4.17.15",
         "string-natural-compare": "^3.0.1"
@@ -28578,7 +28769,6 @@
       "resolved": "https://registry.npmjs.org/get-tsconfig/-/get-tsconfig-4.14.0.tgz",
       "integrity": "sha512-yTb+8DXzDREzgvYmh6s9vHsSVCHeC0G3PI5bEXNBHtmshPnO+S5O7qgLEOn0I5QvMy6kpZN8K1NKGyilLb93wA==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "resolve-pkg-maps": "^1.0.0"
       },
@@ -28591,7 +28781,6 @@
       "resolved": "https://registry.npmjs.org/giget/-/giget-3.3.0.tgz",
       "integrity": "sha512-gzi2D96p+AMfDcmJHGDj3KJ9NRiwvlFAU5yfa3ROwWZmFUjX4P43x3BcyRaOMMLto1vUo7C+86+MFhYTl6Ryiw==",
       "license": "MIT",
-      "peer": true,
       "bin": {
         "giget": "dist/cli.mjs"
       }
@@ -28609,8 +28798,7 @@
       "version": "1.3.0",
       "resolved": "https://registry.npmjs.org/gl-vec2/-/gl-vec2-1.3.0.tgz",
       "integrity": "sha512-YiqaAuNsheWmUV0Sa8k94kBB0D6RWjwZztyO+trEYS8KzJ6OQB/4686gdrf59wld4hHFIvaxynO3nRxpk1Ij/A==",
-      "license": "zlib",
-      "peer": true
+      "license": "zlib"
     },
     "node_modules/glob": {
       "version": "7.2.3",
@@ -28801,6 +28989,7 @@
       "version": "15.8.0",
       "resolved": "https://registry.npmjs.org/graphql/-/graphql-15.8.0.tgz",
       "integrity": "sha512-5gghUc24tP9HRznNpV2+FIoq3xKkj5dTQqf4v0CpdPbFVwFkWoxOM+o+2OC9ZSvjEMTjfmG9QT+gcvggTwW1zw==",
+      "peer": true,
       "engines": {
         "node": ">= 10.x"
       }
@@ -29393,8 +29582,7 @@
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/hyphenate-style-name/-/hyphenate-style-name-1.1.0.tgz",
       "integrity": "sha512-WDC/ui2VVRrz3jOVi+XtjqkDjiVjTtFaAGiW37k6b+ohyQ5wYDOGkvCZa8+H0nx3gyvv0+BST9xuOgIyGQ00gw==",
-      "license": "BSD-3-Clause",
-      "peer": true
+      "license": "BSD-3-Clause"
     },
     "node_modules/iconv-lite": {
       "version": "0.6.3",
@@ -29458,6 +29646,7 @@
       "version": "9.0.15",
       "resolved": "https://registry.npmjs.org/immer/-/immer-9.0.15.tgz",
       "integrity": "sha512-2eB/sswms9AEUSkOm4SbV5Y7Vmt/bKRwByd52jfLkW4OLYeaTP3EEiJ9agqU0O/tq6Dk62Zfj+TJSqfm1rLVGQ==",
+      "peer": true,
       "funding": {
         "type": "opencollective",
         "url": "https://opencollective.com/immer"
@@ -29468,7 +29657,6 @@
       "resolved": "https://registry.npmjs.org/impetus/-/impetus-0.8.8.tgz",
       "integrity": "sha512-7ejVjFxRAiBlnZQbdNGzUGgxMvLjVke/QNP2TFN/VK8baASsuRiE8YuSbD0qyiU8Pae+w95De4ZYz+rxSo5FJw==",
       "license": "MIT",
-      "peer": true,
       "engines": {
         "npm": ">=2.13.0"
       }
@@ -29659,7 +29847,6 @@
       "resolved": "https://registry.npmjs.org/internmap/-/internmap-2.0.3.tgz",
       "integrity": "sha512-5Hh7Y1wQbvY5ooGgPbDaL5iYLAPzMTUrjMulskHLH6wnv/A+1q5rgEaiuqEjB+oxGXIVZs1FF+R/KPN3ZSQYYg==",
       "license": "ISC",
-      "peer": true,
       "engines": {
         "node": ">=12"
       }
@@ -30224,7 +30411,6 @@
       "resolved": "https://registry.npmjs.org/is-in-ssh/-/is-in-ssh-1.0.0.tgz",
       "integrity": "sha512-jYa6Q9rH90kR1vKB6NM7qqd1mge3Fx4Dhw5TVlK1MUBqhEOuCagrEHMevNuCcbECmXZ0ThXkRm+Ymr51HwEPAw==",
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=20"
       },
@@ -30347,7 +30533,6 @@
       "resolved": "https://registry.npmjs.org/is-map/-/is-map-2.0.3.tgz",
       "integrity": "sha512-1Qed0/Hr2m+YqxnM09CjA2d/i6YZNfF6R2oRAOj36eUdS6qIV/huPJNSEpKbupewFs+ZsJlxsjjPbc0/afW6Lw==",
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">= 0.4"
       },
@@ -30500,7 +30685,6 @@
       "resolved": "https://registry.npmjs.org/is-set/-/is-set-2.0.3.tgz",
       "integrity": "sha512-iPAjerrse27/ygGLxw+EBR9agv9Y6uLeYVJMu+QNCoouJ1/1ri0mGrcWpfCqFZuzzx3WjtwxG098X+n4OuRkPg==",
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">= 0.4"
       },
@@ -30661,7 +30845,6 @@
       "resolved": "https://registry.npmjs.org/is-weakmap/-/is-weakmap-2.0.2.tgz",
       "integrity": "sha512-K5pXYOm9wqY1RgjpL3YTkF39tni1XajUIkawTLUo9EZEVUFga5gSQJF8nNS7ZwJQ02y+1YCNYcMh+HIf1ZqE+w==",
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">= 0.4"
       },
@@ -30685,7 +30868,6 @@
       "resolved": "https://registry.npmjs.org/is-weakset/-/is-weakset-2.0.4.tgz",
       "integrity": "sha512-mfcwb6IzQyOKTs84CQMrOwW4gQcaTOAWJ0zzJCl2WSPDrWk/OzDaImWFH3djXhb24g4eudZfLRozAvPGw4d9hQ==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "call-bound": "^1.0.3",
         "get-intrinsic": "^1.2.6"
@@ -31002,6 +31184,7 @@
       "resolved": "https://registry.npmjs.org/jest/-/jest-29.7.0.tgz",
       "integrity": "sha512-NIy3oAFp9shda19hy4HK0HRTWKtPJmGdnvywu01nOqNC2vZg+Z+fvJDxpMQA88eb2I9EcafcdjYgsDthnYTvGw==",
       "dev": true,
+      "peer": true,
       "dependencies": {
         "@jest/core": "^29.7.0",
         "@jest/types": "^29.6.3",
@@ -31826,7 +32009,6 @@
       "resolved": "https://registry.npmjs.org/jiti/-/jiti-2.7.0.tgz",
       "integrity": "sha512-AC/7JofJvZGrrneWNaEnJeOLUx+JlGt7tNa0wZiRPT4MY1wmfKjt2+6O2p2uz2+skll8OZZmJMNqeke7kKbNgQ==",
       "license": "MIT",
-      "peer": true,
       "bin": {
         "jiti": "lib/jiti-cli.mjs"
       }
@@ -31861,8 +32043,7 @@
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/jquery/-/jquery-4.0.0.tgz",
       "integrity": "sha512-TXCHVR3Lb6TZdtw1l3RTLf8RBWVGexdxL6AC8/e0xZKEpBflBsjh9/8LXw+dkNFuOyW9B7iB3O1sP7hS0Kiacg==",
-      "license": "MIT",
-      "peer": true
+      "license": "MIT"
     },
     "node_modules/js-base64": {
       "version": "3.7.5",
@@ -31874,7 +32055,6 @@
       "resolved": "https://registry.npmjs.org/js-cookie/-/js-cookie-3.0.1.tgz",
       "integrity": "sha512-+0rgsUXZu4ncpPxRL+lNEptWMOWl9etvPHc/koSRp6MPwpRYAhmk0dUG00J4bxVV3r9uUzfo24wW0knS07SKSw==",
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=12"
       }
@@ -32059,8 +32239,7 @@
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/keyboard-key/-/keyboard-key-1.1.0.tgz",
       "integrity": "sha512-qkBzPTi3rlAKvX7k0/ub44sqOfXeLc/jcnGGmj5c7BJpU8eDrEVPyhCvNYAaoubbsLm9uGWwQJO1ytQK1a9/dQ==",
-      "license": "MIT",
-      "peer": true
+      "license": "MIT"
     },
     "node_modules/keyv": {
       "version": "3.1.0",
@@ -32475,6 +32654,7 @@
       "resolved": "https://registry.npmjs.org/localforage/-/localforage-1.10.0.tgz",
       "integrity": "sha512-14/H1aX7hzBBmmh7sGPd+AOMkkIrHM3Z1PAyGgZigA1H1p5O5ANnMyWzvpAETtG68/dC4pC0ncy3+PPGzXZHPg==",
       "license": "Apache-2.0",
+      "peer": true,
       "dependencies": {
         "lie": "3.1.1"
       }
@@ -32505,8 +32685,7 @@
       "version": "4.18.1",
       "resolved": "https://registry.npmjs.org/lodash-es/-/lodash-es-4.18.1.tgz",
       "integrity": "sha512-J8xewKD/Gk22OZbhpOVSwcs60zhd95ESDwezOFuA3/099925PdHJ7OFHNTGtajL3AlZkykD32HykiMo+BIBI8A==",
-      "license": "MIT",
-      "peer": true
+      "license": "MIT"
     },
     "node_modules/lodash._baseiteratee": {
       "version": "4.7.0",
@@ -32879,7 +33058,6 @@
       "resolved": "https://registry.npmjs.org/matchmediaquery/-/matchmediaquery-0.3.1.tgz",
       "integrity": "sha512-Hlk20WQHRIm9EE9luN1kjRjYXAQToHOIAHPJn9buxBwuhfTHoKUcX+lXBbxc85DVQfXYbEQ4HcwQdd128E3qHQ==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "css-mediaquery": "^0.1.2"
       }
@@ -34139,15 +34317,13 @@
       "version": "3.0.2",
       "resolved": "https://registry.npmjs.org/mouse-event-offset/-/mouse-event-offset-3.0.2.tgz",
       "integrity": "sha512-s9sqOs5B1Ykox3Xo8b3Ss2IQju4UwlW6LSR+Q5FXWpprJ5fzMLefIIItr3PH8RwzfGy6gxs/4GAmiNuZScE25w==",
-      "license": "MIT",
-      "peer": true
+      "license": "MIT"
     },
     "node_modules/mouse-wheel": {
       "version": "1.2.0",
       "resolved": "https://registry.npmjs.org/mouse-wheel/-/mouse-wheel-1.2.0.tgz",
       "integrity": "sha512-+OfYBiUOCTWcTECES49neZwL5AoGkXE+lFjIvzwNCnYRlso+EnfvovcBxGoyQ0yQt806eSPjS675K0EwWknXmw==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "right-now": "^1.0.0",
         "signum": "^1.0.0",
@@ -34335,7 +34511,6 @@
       "resolved": "https://registry.npmjs.org/new-date/-/new-date-1.0.3.tgz",
       "integrity": "sha512-0fsVvQPbo2I18DT2zVHpezmeeNYV2JaJSrseiHLc17GNOxJzUdx5mvSigPu8LtIfZSij5i1wXnXFspEs2CD6hA==",
       "license": "SEE LICENSE IN LICENSE",
-      "peer": true,
       "dependencies": {
         "@segment/isodate": "1.0.3"
       }
@@ -34412,6 +34587,7 @@
       "version": "2.7.0",
       "resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-2.7.0.tgz",
       "integrity": "sha512-c4FRfUm/dbcWZ7U+1Wq0AwCyFL+3nt2bEw05wfxSz+DWpWsitgmSgYmy2dQdWyKC1694ELPqMs/YzUSNozLt8A==",
+      "peer": true,
       "dependencies": {
         "whatwg-url": "^5.0.0"
       },
@@ -34887,8 +35063,7 @@
       "version": "0.2.1",
       "resolved": "https://registry.npmjs.org/obj-case/-/obj-case-0.2.1.tgz",
       "integrity": "sha512-PquYBBTy+Y6Ob/O2574XHhDtHJlV1cJHMCgW+rDRc9J5hhmRelJB3k5dTK/3cVmFVtzvAKuENeuLpoyTzMzkOg==",
-      "license": "MIT",
-      "peer": true
+      "license": "MIT"
     },
     "node_modules/obj-multiplex": {
       "version": "1.0.0",
@@ -34956,7 +35131,6 @@
       "resolved": "https://registry.npmjs.org/object-is/-/object-is-1.1.6.tgz",
       "integrity": "sha512-F8cZ+KfGlSGi09lJT7/Nd6KJZ9ygtvYC0/UYYLI9nmQKLMnydpB9yvbv9K1uSkEu7FU9vYPmVwLg328tX+ot3Q==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "call-bind": "^1.0.7",
         "define-properties": "^1.2.1"
@@ -35074,8 +35248,7 @@
       "version": "2.0.11",
       "resolved": "https://registry.npmjs.org/ohash/-/ohash-2.0.11.tgz",
       "integrity": "sha512-RdR9FQrFwNBNXAr4GixM8YaRZRJ5PUWbKYbE5eOsrwAjJW0q2REGcf79oYPsLyskQCZG1PLN+S/K1V00joZAoQ==",
-      "license": "MIT",
-      "peer": true
+      "license": "MIT"
     },
     "node_modules/on-exit-leak-free": {
       "version": "2.1.2",
@@ -35500,7 +35673,6 @@
       "resolved": "https://registry.npmjs.org/parallax-js/-/parallax-js-3.1.0.tgz",
       "integrity": "sha512-UONoPKSQykeNvFcemDPxYYDU/T89LSffoaZAwOMhDp0ABhmFPwthgn2GrfB7An9Qo+8nPZIuQeZsh2pWn1qN3A==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "object-assign": "^4.1.1",
         "raf": "^3.3.0"
@@ -35610,8 +35782,7 @@
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/parse-unit/-/parse-unit-1.0.1.tgz",
       "integrity": "sha512-hrqldJHokR3Qj88EIlV/kAyAi/G5R2+R56TBANxNMy0uPlYcttx0jnMW6Yx5KsKPSbC3KddM/7qQm3+0wEXKxg==",
-      "license": "MIT",
-      "peer": true
+      "license": "MIT"
     },
     "node_modules/parse-url": {
       "version": "8.1.0",
@@ -35834,8 +36005,7 @@
       "version": "2.0.3",
       "resolved": "https://registry.npmjs.org/pathe/-/pathe-2.0.3.tgz",
       "integrity": "sha512-WUjGcAqP1gQacoQe+OBJsFA7Ld4DyXuUIjZ5cc75cLHvJ7dtNsTugphxIADwspS+AraAUePCKrSVtPLFj/F88w==",
-      "license": "MIT",
-      "peer": true
+      "license": "MIT"
     },
     "node_modules/pbkdf2": {
       "version": "3.1.2",
@@ -35868,20 +36038,19 @@
       "version": "2.1.0",
       "resolved": "https://registry.npmjs.org/perfect-debounce/-/perfect-debounce-2.1.0.tgz",
       "integrity": "sha512-LjgdTytVFXeUgtHZr9WYViYSM/g8MkcTPYDlPa3cDqMirHjKiSZPYd6DoL7pK8AJQr+uWkQvCjHNdiMqsrJs+g==",
-      "license": "MIT",
-      "peer": true
+      "license": "MIT"
     },
     "node_modules/performance-now": {
       "version": "2.1.0",
       "resolved": "https://registry.npmjs.org/performance-now/-/performance-now-2.1.0.tgz",
       "integrity": "sha512-7EAHlyLHI56VEIdK57uwHdHKIaAGbnXPiw0yWbarQZOKaKpvUIgW0jWRVLiatnM+XXlSwsanIBH/hzGMJulMow==",
-      "license": "MIT",
-      "peer": true
+      "license": "MIT"
     },
     "node_modules/pg": {
       "version": "8.7.3",
       "resolved": "https://registry.npmjs.org/pg/-/pg-8.7.3.tgz",
       "integrity": "sha512-HPmH4GH4H3AOprDJOazoIcpI49XFsHCe8xlrjHkWiapdbHK+HLtbm/GQzXYAZwmPju/kzKhjaSfMACG+8cgJcw==",
+      "peer": true,
       "dependencies": {
         "buffer-writer": "2.0.0",
         "packet-reader": "1.0.0",
@@ -36107,7 +36276,6 @@
       "resolved": "https://registry.npmjs.org/pkg-types/-/pkg-types-2.3.1.tgz",
       "integrity": "sha512-y+ichcgc2LrADuhLNAx8DFjVfgz91pRxfZdI3UDhxHvcVEZsenLO+7XaU5vOp0u/7V/wZ+plyuQxtrDlZJ+yeg==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "confbox": "^0.2.4",
         "exsolve": "^1.0.8",
@@ -36153,6 +36321,7 @@
       "resolved": "https://registry.npmjs.org/porto/-/porto-0.2.35.tgz",
       "integrity": "sha512-gu9FfjjvvYBgQXUHWTp6n3wkTxVtEcqFotM7i3GEZeoQbvLGbssAicCz6hFZ8+xggrJWwi/RLmbwNra50SMmUQ==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "hono": "^4.10.3",
         "idb-keyval": "^6.2.1",
@@ -36298,6 +36467,7 @@
       "resolved": "https://registry.npmjs.org/zod/-/zod-4.4.3.tgz",
       "integrity": "sha512-ytENFjIJFl2UwYglde2jchW2Hwm4GJFLDiSXWdTrJQBIN9Fcyp7n4DhxJEiWNAJMV1/BqWfW/kkg71UDcHJyTQ==",
       "license": "MIT",
+      "peer": true,
       "funding": {
         "url": "https://github.com/sponsors/colinhacks"
       }
@@ -36358,6 +36528,7 @@
           "url": "https://github.com/sponsors/ai"
         }
       ],
+      "peer": true,
       "dependencies": {
         "nanoid": "^3.3.6",
         "picocolors": "^1.0.0",
@@ -36525,7 +36696,6 @@
       "resolved": "https://registry.npmjs.org/powershell-utils/-/powershell-utils-0.1.0.tgz",
       "integrity": "sha512-dM0jVuXJPsDN6DvRpea484tCUaMiXWjuCn++HGTqUWzGDjv5tZkEZldAJ/UMlqRYGFrD/etByo4/xOuC/snX2A==",
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=20"
       },
@@ -36556,6 +36726,7 @@
       "resolved": "https://registry.npmjs.org/prettier/-/prettier-2.6.2.tgz",
       "integrity": "sha512-PkUpF+qoXTqhOeWL9fu7As8LXsIUZ1WYaJiY/a7McAQzxjk82OF0tibkFXVCDImZtWxbvojFjerkiLb0/q8mew==",
       "dev": true,
+      "peer": true,
       "bin": {
         "prettier": "bin-prettier.js"
       },
@@ -36692,6 +36863,7 @@
       "version": "15.8.1",
       "resolved": "https://registry.npmjs.org/prop-types/-/prop-types-15.8.1.tgz",
       "integrity": "sha512-oj87CgZICdulUohogVAR7AjlC0327U4el4L6eAvOqCeudMDVU0NThNaV+b9Df4dXgSP1gXMTnPdhfe/2qDH5cg==",
+      "peer": true,
       "dependencies": {
         "loose-envify": "^1.4.0",
         "object-assign": "^4.1.1",
@@ -37037,7 +37209,6 @@
       "resolved": "https://registry.npmjs.org/raf/-/raf-3.4.1.tgz",
       "integrity": "sha512-Sq4CW4QhwOHE8ucn6J34MqtZCeWFP2aQSmrlroYgqAV1PjStIhJXxYuTgUIfkEk7zTLjmIjLmU5q+fbD1NnOJA==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "performance-now": "^2.1.0"
       }
@@ -37152,7 +37323,6 @@
       "resolved": "https://registry.npmjs.org/rc9/-/rc9-3.0.1.tgz",
       "integrity": "sha512-gMDyleLWVE+i6Sgtc0QbbY6pEKqYs97NGi6isHQPqYlLemPoO8dxQ3uGi0f4NiP98c+jMW6cG1Kx9dDwfvqARQ==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "defu": "^6.1.6",
         "destr": "^2.0.5"
@@ -37163,6 +37333,7 @@
       "resolved": "https://registry.npmjs.org/react/-/react-18.3.1.tgz",
       "integrity": "sha512-wS+hAgJShR0KhEvPJArfuPVN1+Hz1t0Y6n5jLrGQbkb4urgPE/0Rve+1kMB1v/oWgHgm4WIcV+i7F2pTVj+2iQ==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "loose-envify": "^1.1.0"
       },
@@ -37314,6 +37485,7 @@
       "resolved": "https://registry.npmjs.org/react-dom/-/react-dom-18.3.1.tgz",
       "integrity": "sha512-5m4nQKp+rZRb09LNH59GM4BxTh9251/ylbKIbpe7TpGxfJ+9kv6BLkLBXIjjspbgbnIBNqlI23tRnTWT0snUIw==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "loose-envify": "^1.1.0",
         "scheduler": "^0.23.2"
@@ -37359,6 +37531,7 @@
       "resolved": "https://registry.npmjs.org/react-intl/-/react-intl-6.8.9.tgz",
       "integrity": "sha512-TUfj5E7lyUDvz/GtovC9OMh441kBr08rtIbgh3p0R8iF3hVY+V2W9Am7rb8BpJ/29BH1utJOqOOhmvEVh3GfZg==",
       "license": "BSD-3-Clause",
+      "peer": true,
       "dependencies": {
         "@formatjs/ecma402-abstract": "2.2.4",
         "@formatjs/icu-messageformat-parser": "2.9.4",
@@ -37487,7 +37660,6 @@
       "resolved": "https://registry.npmjs.org/react-popper/-/react-popper-2.3.0.tgz",
       "integrity": "sha512-e1hj8lL3uM+sgSR4Lxzn5h1GxBlpa4CQz0XLF8kx4MDrDRWY0Ena4c97PUeSX9i5W3UAfDP0z0FXCTQkoXUl3Q==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "react-fast-compare": "^3.0.1",
         "warning": "^4.0.2"
@@ -37503,7 +37675,6 @@
       "resolved": "https://registry.npmjs.org/react-redux/-/react-redux-8.1.3.tgz",
       "integrity": "sha512-n0ZrutD7DaX/j9VscF+uTALI3oUPa/pO4Z3soOBIjuRn/FzVu6aehhysxZCLi6y7duMf52WNZGMl7CtuK5EnRw==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@babel/runtime": "^7.12.1",
         "@types/hoist-non-react-statics": "^3.3.1",
@@ -37542,13 +37713,13 @@
       "version": "18.3.1",
       "resolved": "https://registry.npmjs.org/react-is/-/react-is-18.3.1.tgz",
       "integrity": "sha512-/LLMVyas0ljjAtoYiPqYiL8VWXzUUdThrmU5+n20DZv+a+ClRoevUzw5JxU+Ieh5/c87ytoTBV9G1FiKfNJdmg==",
-      "license": "MIT",
-      "peer": true
+      "license": "MIT"
     },
     "node_modules/react-refresh": {
       "version": "0.14.0",
       "resolved": "https://registry.npmjs.org/react-refresh/-/react-refresh-0.14.0.tgz",
       "integrity": "sha512-wViHqhAd8OHeLS/IRMJjTSDHF3U9eWi62F/MledQGPdJGDhodXJ9PBLNGr6WWL7qlH12Mt3TyTpbS+hGXMjCzQ==",
+      "peer": true,
       "engines": {
         "node": ">=0.10.0"
       }
@@ -37617,7 +37788,6 @@
       "resolved": "https://registry.npmjs.org/react-responsive/-/react-responsive-9.0.2.tgz",
       "integrity": "sha512-+4CCab7z8G8glgJoRjAwocsgsv6VA2w7JPxFWHRc7kvz8mec1/K5LutNC2MG28Mn8mu6+bu04XZxHv5gyfT7xQ==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "hyphenate-style-name": "^1.0.0",
         "matchmediaquery": "^0.3.0",
@@ -37636,7 +37806,6 @@
       "resolved": "https://registry.npmjs.org/react-router/-/react-router-5.3.4.tgz",
       "integrity": "sha512-Ys9K+ppnJah3QuaRiLxk+jDWOR1MekYQrlytiXxC1RyfbdsZkS5pvKAzCCr031xHixZwpnsYNT5xysdFHQaYsA==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@babel/runtime": "^7.12.13",
         "history": "^4.9.0",
@@ -37656,15 +37825,13 @@
       "version": "0.0.1",
       "resolved": "https://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz",
       "integrity": "sha512-D2S+3GLxWH+uhrNEcoh/fnmYeP8E8/zHl644d/jdA0g2uyXvy3sb0qxotE+ne0LtccHknQzWwZEzhak7oJ0COQ==",
-      "license": "MIT",
-      "peer": true
+      "license": "MIT"
     },
     "node_modules/react-router/node_modules/path-to-regexp": {
       "version": "1.9.0",
       "resolved": "https://registry.npmjs.org/path-to-regexp/-/path-to-regexp-1.9.0.tgz",
       "integrity": "sha512-xIp7/apCFJuUHdDLWe8O1HIkb0kQrOMb/0u6FXQjemHn/ii5LrIzU6bdECnsiTF/GjZkMEKg1xdiZwNqDYlZ6g==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "isarray": "0.0.1"
       }
@@ -37674,7 +37841,6 @@
       "resolved": "https://registry.npmjs.org/react-semantic-ui-datepickers/-/react-semantic-ui-datepickers-2.17.2.tgz",
       "integrity": "sha512-rYFFwdPOi3C+7vP/KpU7jgj05BoVATEOAhlEvkeQhGtMfaxUIh/9eWF7Fas5QmUsyXXGrMm8alccIwKe34m5ug==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@date-fns/upgrade": "1.0.3",
         "classnames": "2.3.2",
@@ -37691,15 +37857,13 @@
       "version": "2.3.2",
       "resolved": "https://registry.npmjs.org/classnames/-/classnames-2.3.2.tgz",
       "integrity": "sha512-CSbhY4cFEJRe6/GQzIk5qXZ4Jeg5pcsP7b5peFSDpffpe1cqjASH/n9UTjBwOp6XpMSTwQ8Za2K5V02ueA7Tmw==",
-      "license": "MIT",
-      "peer": true
+      "license": "MIT"
     },
     "node_modules/react-semantic-ui-datepickers/node_modules/date-fns": {
       "version": "2.29.3",
       "resolved": "https://registry.npmjs.org/date-fns/-/date-fns-2.29.3.tgz",
       "integrity": "sha512-dDCnyH2WnnKusqvZZ6+jA1O51Ibt8ZMRNkDZdyAyK4YfbDwa/cEmuztzG5pk6hqlp9aSBPYcjOlktquahGwGeA==",
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=0.11"
       },
@@ -37721,7 +37885,6 @@
       "resolved": "https://registry.npmjs.org/react-smooth/-/react-smooth-4.0.4.tgz",
       "integrity": "sha512-gnGKTpYwqL0Iii09gHobNolvX4Kiq4PKx6eWBCYYix+8cdw+cGo3do906l1NBPKkSWx1DghC1dlWG9L2uGd61Q==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "fast-equals": "^5.0.1",
         "prop-types": "^15.8.1",
@@ -37765,7 +37928,6 @@
       "resolved": "https://registry.npmjs.org/react-tile-map/-/react-tile-map-0.4.1.tgz",
       "integrity": "sha512-aBcZY4a3X17cngvEo9TAnn030PFqh9uyx4vVbeaS6MYOAbTnftSF+rkDPSabYWONWzhVIxOEuI4dM8tYckmAdw==",
       "license": "ISC",
-      "peer": true,
       "dependencies": {
         "impetus": "^0.8.8",
         "mouse-wheel": "^1.2.0",
@@ -37783,7 +37945,6 @@
       "resolved": "https://registry.npmjs.org/react-transition-group/-/react-transition-group-4.4.5.tgz",
       "integrity": "sha512-pZcd1MCJoiKiBR2NRxeCRg13uCXbydPnmB4EOeRrY7480qNWO8IIgQG6zlDkm6uRMsURXPuKq0GWtiM59a5Q6g==",
       "license": "BSD-3-Clause",
-      "peer": true,
       "dependencies": {
         "@babel/runtime": "^7.5.5",
         "dom-helpers": "^5.0.1",
@@ -37800,7 +37961,6 @@
       "resolved": "https://registry.npmjs.org/react-virtualized-auto-sizer/-/react-virtualized-auto-sizer-1.0.26.tgz",
       "integrity": "sha512-CblNyiNVw2o+hsa5/49NH2ogGxZ+t+3aweRvNSq7TVjDIlwk7ir4lencEg5HxHeSzwNarSkNkiu0qJSOXtxm5A==",
       "license": "MIT",
-      "peer": true,
       "peerDependencies": {
         "react": "^15.3.0 || ^16.0.0-alpha || ^17.0.0 || ^18.0.0 || ^19.0.0",
         "react-dom": "^15.3.0 || ^16.0.0-alpha || ^17.0.0 || ^18.0.0 || ^19.0.0"
@@ -37910,6 +38070,7 @@
       "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-3.6.2.tgz",
       "integrity": "sha512-9u/sniCrY3D5WdsERHzHE4G2YCXqoG5FTHUiCC4SIbr6XcLZBY05ya9EKjYek9O5xOAwjGq+1JdGBAS7Q9ScoA==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "inherits": "^2.0.3",
         "string_decoder": "^1.1.1",
@@ -37973,7 +38134,6 @@
       "integrity": "sha512-UT/q6fwS3c1dHbXv2uFgYJ9BMFHu3fwnd7AYZaEQhXuYQ4hgsxLvsUXzGdKeZrW5xopzDCvuA2N41WJ88I7zIw==",
       "deprecated": "1.x and 2.x branches are no longer active. Bump to Recharts v3 to receive latest features and bugfixes. See https://github.com/recharts/recharts/wiki/3.0-migration-guide",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "clsx": "^2.0.0",
         "eventemitter3": "^4.0.1",
@@ -37997,7 +38157,6 @@
       "resolved": "https://registry.npmjs.org/recharts-scale/-/recharts-scale-0.4.5.tgz",
       "integrity": "sha512-kivNFO+0OcUNu7jQquLXAxz1FIwZj8nrj+YkOKc5694NbjCvcT6aSZiIzNzd2Kul4o4rTto8QVR9lMNtxD4G1w==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "decimal.js-light": "^2.4.1"
       }
@@ -38007,7 +38166,6 @@
       "resolved": "https://registry.npmjs.org/clsx/-/clsx-2.1.1.tgz",
       "integrity": "sha512-eYm0QWBtUrBWZWG0d386OGAw16Z995PiOVo2B7bjWSbHedGl5e0ZWaq65kOGgUSNesEIDkB9ISbTg/JK9dhCZA==",
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=6"
       }
@@ -38016,8 +38174,7 @@
       "version": "18.3.1",
       "resolved": "https://registry.npmjs.org/react-is/-/react-is-18.3.1.tgz",
       "integrity": "sha512-/LLMVyas0ljjAtoYiPqYiL8VWXzUUdThrmU5+n20DZv+a+ClRoevUzw5JxU+Ieh5/c87ytoTBV9G1FiKfNJdmg==",
-      "license": "MIT",
-      "peer": true
+      "license": "MIT"
     },
     "node_modules/recursive-readdir": {
       "version": "2.2.3",
@@ -38046,6 +38203,7 @@
       "version": "4.1.2",
       "resolved": "https://registry.npmjs.org/redux/-/redux-4.1.2.tgz",
       "integrity": "sha512-SH8PglcebESbd/shgf6mii6EIoRM0zrQyjcuQ+ojmfxjTtE0z9Y8pa62iA/OJ58qjP6j27uyW4kUF4jl/jd6sw==",
+      "peer": true,
       "dependencies": {
         "@babel/runtime": "^7.9.2"
       }
@@ -38761,15 +38919,13 @@
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/resolve-pathname/-/resolve-pathname-3.0.0.tgz",
       "integrity": "sha512-C7rARubxI8bXFNB/hqcp/4iUeIXJhJZvFPFPiSPRnhU5UPxzMFIl+2E6yY6c4k9giDJAhtV+enfA+G89N6Csng==",
-      "license": "MIT",
-      "peer": true
+      "license": "MIT"
     },
     "node_modules/resolve-pkg-maps": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/resolve-pkg-maps/-/resolve-pkg-maps-1.0.0.tgz",
       "integrity": "sha512-seS2Tj26TBVOC2NIc2rOe2y2ZO7efxITtLZcGSOnHHNOQ7CkiUBfw0Iw2ck6xkIhPwLhKNLS8BO+hEpngQlqzw==",
       "license": "MIT",
-      "peer": true,
       "funding": {
         "url": "https://github.com/privatenumber/resolve-pkg-maps?sponsor=1"
       }
@@ -38835,8 +38991,7 @@
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/right-now/-/right-now-1.0.0.tgz",
       "integrity": "sha512-DA8+YS+sMIVpbsuKgy+Z67L9Lxb1p05mNxRpDPNksPDEFir4vmBlUtuN9jkTGn9YMMdlBuK7XQgFiz6ws+yhSg==",
-      "license": "MIT",
-      "peer": true
+      "license": "MIT"
     },
     "node_modules/rimraf": {
       "version": "3.0.2",
@@ -38881,6 +39036,7 @@
       "version": "2.26.2",
       "resolved": "https://registry.npmjs.org/rollbar/-/rollbar-2.26.2.tgz",
       "integrity": "sha512-7ASvrlal87ek2vhTmpu2LPvkdlcnala1qeMT2Ra76s0KjWkQ8d1fTl6dk7AqHx1Qa/puahg3tYw7EPB7wYx9RQ==",
+      "peer": true,
       "dependencies": {
         "async": "~3.2.3",
         "console-polyfill": "0.3.0",
@@ -39094,7 +39250,6 @@
       "resolved": "https://registry.npmjs.org/semantic-ui-css/-/semantic-ui-css-2.5.0.tgz",
       "integrity": "sha512-jIWn3WXXE2uSaWCcB+gVJVRG3masIKtTMNEP2X8Aw909H2rHpXGneYOxzO3hT8TpyvB5/dEEo9mBFCitGwoj1A==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "jquery": "x.*"
       }
@@ -39104,7 +39259,6 @@
       "resolved": "https://registry.npmjs.org/semantic-ui-react/-/semantic-ui-react-2.1.5.tgz",
       "integrity": "sha512-nIqmmUNpFHfovEb+RI2w3E2/maZQutd8UIWyRjf1SLse+XF51hI559xbz/sLN3O6RpLjr/echLOOXwKCirPy3Q==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@babel/runtime": "^7.10.5",
         "@fluentui/react-component-event-listener": "~0.63.0",
@@ -39314,15 +39468,13 @@
       "version": "1.2.1",
       "resolved": "https://registry.npmjs.org/shallow-equal/-/shallow-equal-1.2.1.tgz",
       "integrity": "sha512-S4vJDjHHMBaiZuT9NPb616CSmLf618jawtv3sufLl6ivK8WocjAo58cXwbRV1cgqxH0Qbv+iUt6m05eqEa2IRA==",
-      "license": "MIT",
-      "peer": true
+      "license": "MIT"
     },
     "node_modules/shallowequal": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/shallowequal/-/shallowequal-1.1.0.tgz",
       "integrity": "sha512-y0m1JoUZSlPAjXVtPPW70aZWfIL/dSP7AFkRnniLCrK/8MDKog3TySTBmckD+RObVxH0v4Tox67+F14PdED2oQ==",
-      "license": "MIT",
-      "peer": true
+      "license": "MIT"
     },
     "node_modules/sharp": {
       "version": "0.33.5",
@@ -39482,8 +39634,7 @@
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/signum/-/signum-1.0.0.tgz",
       "integrity": "sha512-yodFGwcyt59XRh7w5W3jPcIQb3Bwi21suEfT7MAWnBX3iCdklJpgDgvGT9o04UonglZN5SNMfJFkHIR/jO8GHw==",
-      "license": "MIT",
-      "peer": true
+      "license": "MIT"
     },
     "node_modules/simple-concat": {
       "version": "1.0.1",
@@ -39677,6 +39828,7 @@
       "resolved": "https://registry.npmjs.org/socket.io-client/-/socket.io-client-4.8.3.tgz",
       "integrity": "sha512-uP0bpjWrjQmUt5DTHq9RuoCBdFJF10cdX9X+a368j/Ft0wmaVgxlrjvK3kjvgCODOMMOz9lcaRzxmso0bTWZ/g==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@socket.io/component-emitter": "~3.1.0",
         "debug": "~4.4.1",
@@ -39991,7 +40143,6 @@
       "resolved": "https://registry.npmjs.org/stop-iteration-iterator/-/stop-iteration-iterator-1.1.0.tgz",
       "integrity": "sha512-eLoXW/DHyl62zxY4SCaIgnRhuMr6ri4juEYARS8E6sCEqzKpOiE521Ucofdx+KnDZl5xmvGYaaKCk5FEOxJCoQ==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "es-errors": "^1.3.0",
         "internal-slot": "^1.1.0"
@@ -41690,6 +41841,7 @@
       "resolved": "https://registry.npmjs.org/zod/-/zod-3.25.75.tgz",
       "integrity": "sha512-OhpzAmVzabPOL6C3A3gpAifqr9MqihV/Msx3gor2b2kviCgcb+HM9SEOpMWwwNp9MRunWnhtAKUoo0AHhjyPPg==",
       "license": "MIT",
+      "peer": true,
       "funding": {
         "url": "https://github.com/sponsors/colinhacks"
       }
@@ -41822,7 +41974,6 @@
       "resolved": "https://registry.npmjs.org/to-px/-/to-px-1.1.0.tgz",
       "integrity": "sha512-bfg3GLYrGoEzrGoE05TAL/Uw+H/qrf2ptr9V3W7U0lkjjyYnIfgxmVLUfhQ1hZpIQwin81uxhDjvUkDYsC0xWw==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "parse-unit": "^1.0.1"
       }
@@ -41912,7 +42063,6 @@
       "resolved": "https://registry.npmjs.org/touch-pinch/-/touch-pinch-1.0.1.tgz",
       "integrity": "sha512-If5caiHlfY2JBQYM8XWjOB4mwEidkYpjLXV6zx1uuama0lrbGNVxhzG0wSpaAdHduoGVtWKAQNoCLrgJDEnnfQ==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "dprop": "^1.0.0",
         "events": "^1.0.2",
@@ -41925,7 +42075,6 @@
       "resolved": "https://registry.npmjs.org/events/-/events-1.1.1.tgz",
       "integrity": "sha512-kEcvvCBByWXGnZy6JUlgAp2gBIUjfCAV6P6TgT1/aaQKcmuAEC4OZTV1I4EWQLz2gxZw76atuVyvHhTxvi0Flw==",
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=0.4.x"
       }
@@ -41935,7 +42084,6 @@
       "resolved": "https://registry.npmjs.org/touch-position/-/touch-position-2.0.0.tgz",
       "integrity": "sha512-/lzepy++NyN/FcjWrYEWXrNqkontDGm6+5BzMdlFOQybTGyVq1JXm+sEzlsZjcPSThJozcs6Flp68n152tWb3w==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "events": "^1.0.2",
         "mouse-event-offset": "^3.0.2"
@@ -41946,7 +42094,6 @@
       "resolved": "https://registry.npmjs.org/events/-/events-1.1.1.tgz",
       "integrity": "sha512-kEcvvCBByWXGnZy6JUlgAp2gBIUjfCAV6P6TgT1/aaQKcmuAEC4OZTV1I4EWQLz2gxZw76atuVyvHhTxvi0Flw==",
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=0.4.x"
       }
@@ -42058,6 +42205,7 @@
       "resolved": "https://registry.npmjs.org/ts-node/-/ts-node-10.7.0.tgz",
       "integrity": "sha512-TbIGS4xgJoX2i3do417KSaep1uRAW/Lu+WAL2doDHC0D6ummjirVOXU5/7aiZotbQ5p1Zp9tP7U6cYhA0O7M8A==",
       "dev": true,
+      "peer": true,
       "dependencies": {
         "@cspotcode/source-map-support": "0.7.0",
         "@tsconfig/node10": "^1.0.7",
@@ -42314,6 +42462,7 @@
       "version": "5.2.2",
       "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.2.2.tgz",
       "integrity": "sha512-mI4WrpHsbCIcwT9cF4FZvr80QUeKvsUsUvKDoR+X/7XHQH98xYD8YHZg7ANtz2GtZt/CBq2QJ0thkGJMHfqc1w==",
+      "peer": true,
       "bin": {
         "tsc": "bin/tsc",
         "tsserver": "bin/tsserver"
@@ -42491,8 +42640,7 @@
       "version": "4.2.0",
       "resolved": "https://registry.npmjs.org/unfetch/-/unfetch-4.2.0.tgz",
       "integrity": "sha512-F9p7yYCn6cIW9El1zi0HI6vqpeIvBsr3dSuRO6Xuppb1u5rXpCPmMvLSyECLhybr9isec8Ohl0hPekMVrEinDA==",
-      "license": "MIT",
-      "peer": true
+      "license": "MIT"
     },
     "node_modules/unicode-canonical-property-names-ecmascript": {
       "version": "2.0.0",
@@ -43118,6 +43266,7 @@
       "integrity": "sha512-Z6czzLq4u8fPOyx7TU6X3dvUZVvoJmxSQ+IcrlmagKhilxlhZgxPK6C5Jqbkw1IDUmFTM+cz9QDnnLTwDz/2gQ==",
       "hasInstallScript": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "node-gyp-build": "^4.3.0"
       },
@@ -43271,6 +43420,7 @@
       "resolved": "https://registry.npmjs.org/valtio/-/valtio-2.1.7.tgz",
       "integrity": "sha512-DwJhCDpujuQuKdJ2H84VbTjEJJteaSmqsuUltsfbfdbotVfNeTE4K/qc/Wi57I9x8/2ed4JNdjEna7O6PfavRg==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "proxy-compare": "^3.0.1"
       },
@@ -43294,8 +43444,7 @@
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/value-equal/-/value-equal-1.0.1.tgz",
       "integrity": "sha512-NOJ6JZCAWr0zlxZt+xqCHNTEKOsrks2HQd4MqhP1qy4z1SkbEP467eNx6TgDKXMvUOb+OENfJCZwM+16n7fRfw==",
-      "license": "MIT",
-      "peer": true
+      "license": "MIT"
     },
     "node_modules/value-or-promise": {
       "version": "1.0.11",
@@ -43351,7 +43500,6 @@
       "resolved": "https://registry.npmjs.org/victory-vendor/-/victory-vendor-36.9.2.tgz",
       "integrity": "sha512-PnpQQMuxlwYdocC8fIJqVXvkeViHYzotI+NJrCuav0ZYFoq912ZHBk3mCeuj+5/VpodOjPe1z0Fk2ihgzlXqjQ==",
       "license": "MIT AND ISC",
-      "peer": true,
       "dependencies": {
         "@types/d3-array": "^3.0.3",
         "@types/d3-ease": "^3.0.0",
@@ -43385,6 +43533,7 @@
         }
       ],
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@noble/curves": "1.9.1",
         "@noble/hashes": "1.8.0",
@@ -43499,6 +43648,7 @@
       "resolved": "https://registry.npmjs.org/wagmi/-/wagmi-2.19.5.tgz",
       "integrity": "sha512-RQUfKMv6U+EcSNNGiPbdkDtJwtuFxZWLmvDiQmjjBgkuPulUwDJsKhi7gjynzJdsx2yDqhHCXkKsbbfbIsHfcQ==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@wagmi/connectors": "6.2.0",
         "@wagmi/core": "2.22.1",
@@ -43589,6 +43739,7 @@
       "resolved": "https://registry.npmjs.org/use-sync-external-store/-/use-sync-external-store-1.4.0.tgz",
       "integrity": "sha512-9WXSPC5fMv61vaupRkCKCxsPxBocVnwakBEkMIHHpkTTg6icbJtg6jzgtLDm4bl3cSHAca52rYWih0k4K3PfHw==",
       "license": "MIT",
+      "peer": true,
       "peerDependencies": {
         "react": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0"
       }
@@ -43636,7 +43787,6 @@
       "resolved": "https://registry.npmjs.org/warning/-/warning-4.0.3.tgz",
       "integrity": "sha512-rpJyN222KWIvHJ/F53XSZv0Zl/accqHR8et1kpaMTD/fLCRxtV8iX8czMzY7sVZupTI3zcUTg8eycS2kNF9l6w==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "loose-envify": "^1.0.0"
       }
@@ -44039,6 +44189,7 @@
       "version": "5.89.0",
       "resolved": "https://registry.npmjs.org/webpack/-/webpack-5.89.0.tgz",
       "integrity": "sha512-qyfIC10pOr70V+jkmud8tMfajraGCZMBWJtrmuBymQKCrLTRejBI8STDp1MCyZu/QTdZSeacCQYpYNQVOzX5kw==",
+      "peer": true,
       "dependencies": {
         "@types/eslint-scope": "^3.7.3",
         "@types/estree": "^1.0.0",
@@ -44258,7 +44409,6 @@
       "resolved": "https://registry.npmjs.org/which-collection/-/which-collection-1.0.2.tgz",
       "integrity": "sha512-K4jVyjnBdgvc86Y6BkaLZEN933SwYOuBFkdmBu9ZfkcAbdVbpITnDmjvZ/aQjRXQrv5EPkTnD1s39GiiqbngCw==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "is-map": "^2.0.3",
         "is-set": "^2.0.3",
@@ -44409,6 +44559,7 @@
       "version": "7.4.6",
       "resolved": "https://registry.npmjs.org/ws/-/ws-7.4.6.tgz",
       "integrity": "sha512-YmhHDO4MzaDLB+M9ym/mDA5z0naX8j7SIlT8f8z+I0VtzsRbekxEutHSme7NPS2qE8StCYQNUnfWdXta/Yu85A==",
+      "peer": true,
       "engines": {
         "node": ">=8.3.0"
       },
@@ -44430,7 +44581,6 @@
       "resolved": "https://registry.npmjs.org/wsl-utils/-/wsl-utils-0.3.1.tgz",
       "integrity": "sha512-g/eziiSUNBSsdDJtCLB8bdYEUMj4jR7AGeUo96p/3dTafgjHhpF4RiCFPiRILwjQoDXx5MqkBr4fwWtR3Ky4Wg==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "is-wsl": "^3.1.0",
         "powershell-utils": "^0.1.0"
@@ -44447,7 +44597,6 @@
       "resolved": "https://registry.npmjs.org/is-wsl/-/is-wsl-3.1.1.tgz",
       "integrity": "sha512-e6rvdUCiQCAuumZslxRJWR/Doq4VpPR82kqclvcS0efgt430SlGIk05vdCN58+VrzgtIcfNODjozVielycD4Sw==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "is-inside-container": "^1.0.0"
       },
@@ -45563,6 +45712,7 @@
       "version": "3.22.4",
       "resolved": "https://registry.npmjs.org/zod/-/zod-3.22.4.tgz",
       "integrity": "sha512-iC+8Io04lddc+mVqQ9AZ7OQ2MrUKGN+oIQyq1vemgt46jwCwLfhq7/pwnBnNXXXZb8VTVLKwp9EDkx+ryxIWmg==",
+      "peer": true,
       "funding": {
         "url": "https://github.com/sponsors/colinhacks"
       }
@@ -46418,6 +46568,7 @@
       "version": "7.22.15",
       "resolved": "https://registry.npmjs.org/@babel/core/-/core-7.22.15.tgz",
       "integrity": "sha512-PtZqMmgRrvj8ruoEOIwVA3yoF91O+Hgw9o7DAUTNBA6Mo2jpu31clx9a7Nz/9JznqetTR6zwfC4L3LAjKQXUwA==",
+      "peer": true,
       "requires": {
         "@ampproject/remapping": "^2.2.0",
         "@babel/code-frame": "^7.22.13",
@@ -47873,6 +48024,7 @@
           "version": "5.5.1",
           "resolved": "https://registry.npmjs.org/@solana/kit/-/kit-5.5.1.tgz",
           "integrity": "sha512-irKUGiV2yRoyf+4eGQ/ZeCRxa43yjFEL1DUI5B0DkcfZw3cr0VJtVJnrG8OtVF01vT0OUfYOcUn6zJW5TROHvQ==",
+          "peer": true,
           "requires": {
             "@solana/accounts": "5.5.1",
             "@solana/addresses": "5.5.1",
@@ -47919,6 +48071,7 @@
           "version": "1.16.0",
           "resolved": "https://registry.npmjs.org/axios/-/axios-1.16.0.tgz",
           "integrity": "sha512-6hp5CwvTPlN2A31g5dxnwAX0orzM7pmCRDLnZSX772mv8WDqICwFjowHuPs04Mc8deIld1+ejhtaMn5vp6b+1w==",
+          "peer": true,
           "requires": {
             "follow-redirects": "^1.16.0",
             "form-data": "^4.0.5",
@@ -47966,7 +48119,8 @@
         "zod": {
           "version": "3.25.76",
           "resolved": "https://registry.npmjs.org/zod/-/zod-3.25.76.tgz",
-          "integrity": "sha512-gzUt/qt81nXsFGKIFcC3YnfEAx5NkunCfnDlvuBSSFS02bcXu4Lmea0AFIUwbLWxWPx3d9p8S5QoaujKcNQxcQ=="
+          "integrity": "sha512-gzUt/qt81nXsFGKIFcC3YnfEAx5NkunCfnDlvuBSSFS02bcXu4Lmea0AFIUwbLWxWPx3d9p8S5QoaujKcNQxcQ==",
+          "peer": true
         }
       }
     },
@@ -48022,7 +48176,6 @@
       "version": "1.0.3",
       "resolved": "https://registry.npmjs.org/@date-fns/upgrade/-/upgrade-1.0.3.tgz",
       "integrity": "sha512-0BLzKmXwWw3Zh3cZzW4xScmwGijXCAulaFdikqNiSnK8PAgYYSWWxOP/kuJFpKaoIT5KzstVGyHsjA7t/QXi1Q==",
-      "peer": true,
       "requires": {
         "date-fns": "^2.1"
       },
@@ -48031,7 +48184,6 @@
           "version": "2.30.0",
           "resolved": "https://registry.npmjs.org/date-fns/-/date-fns-2.30.0.tgz",
           "integrity": "sha512-fnULvOpxnC5/Vg3NCiWelDsLiUc9bRwAPs/+LfTLNvetFCtCTN+yQz15C/fs4AwX1R9K5GLtLfn8QW+dWisaAw==",
-          "peer": true,
           "requires": {
             "@babel/runtime": "^7.21.0"
           }
@@ -48107,9 +48259,9 @@
       }
     },
     "@dcl/crypto-middleware": {
-      "version": "4.1.0",
-      "resolved": "https://registry.npmjs.org/@dcl/crypto-middleware/-/crypto-middleware-4.1.0.tgz",
-      "integrity": "sha512-F9MVyxnLFaLJSyo5o6MtsGTDiQ1r4VqCKuFkaEPcq2JFyI6W4ftIRaKIj7hLb65PP/ywm3FkQrizSJ+6MhWpZw==",
+      "version": "5.1.0",
+      "resolved": "https://registry.npmjs.org/@dcl/crypto-middleware/-/crypto-middleware-5.1.0.tgz",
+      "integrity": "sha512-aiG/aInYDgL5Er+KStaIqjOmGGLlmIHSRlcAK5Jzyn+wiPU/kYiQIpMDyaIsrZ0om9HOi0M6lnqcR7ZVNpj4bA==",
       "requires": {
         "@dcl/core-commons": "^0.10.0",
         "@dcl/crypto": "3.7.0"
@@ -48137,7 +48289,6 @@
       "version": "1.4.0",
       "resolved": "https://registry.npmjs.org/@dcl/hooks/-/hooks-1.4.0.tgz",
       "integrity": "sha512-GFt8SAvL8sb42YE7eNYWOlICKJVMyPM0J+YKivwrrQujNiPX14wed4eugIRDte71KZvzVlg9ohfRqEdj6VhYjA==",
-      "peer": true,
       "requires": {
         "@formatjs/intl": "^3.1.8",
         "@segment/analytics-next": "^1.79.0",
@@ -48150,7 +48301,6 @@
           "version": "2.3.6",
           "resolved": "https://registry.npmjs.org/@formatjs/ecma402-abstract/-/ecma402-abstract-2.3.6.tgz",
           "integrity": "sha512-HJnTFeRM2kVFVr5gr5kH1XP6K0JcJtE7Lzvtr3FS/so5f1kpsqqqxy5JF+FRaO6H2qmcMfAUIox7AJteieRtVw==",
-          "peer": true,
           "requires": {
             "@formatjs/fast-memoize": "2.2.7",
             "@formatjs/intl-localematcher": "0.6.2",
@@ -48162,7 +48312,6 @@
           "version": "2.2.7",
           "resolved": "https://registry.npmjs.org/@formatjs/fast-memoize/-/fast-memoize-2.2.7.tgz",
           "integrity": "sha512-Yabmi9nSvyOMrlSeGGWDiH7rf3a7sIwplbvo/dlz9WCIjzIQAfy1RMf4S0X3yG724n5Ghu2GmEl5NJIV6O9sZQ==",
-          "peer": true,
           "requires": {
             "tslib": "^2.8.0"
           }
@@ -48171,7 +48320,6 @@
           "version": "2.11.4",
           "resolved": "https://registry.npmjs.org/@formatjs/icu-messageformat-parser/-/icu-messageformat-parser-2.11.4.tgz",
           "integrity": "sha512-7kR78cRrPNB4fjGFZg3Rmj5aah8rQj9KPzuLsmcSn4ipLXQvC04keycTI1F7kJYDwIXtT2+7IDEto842CfZBtw==",
-          "peer": true,
           "requires": {
             "@formatjs/ecma402-abstract": "2.3.6",
             "@formatjs/icu-skeleton-parser": "1.8.16",
@@ -48182,7 +48330,6 @@
           "version": "1.8.16",
           "resolved": "https://registry.npmjs.org/@formatjs/icu-skeleton-parser/-/icu-skeleton-parser-1.8.16.tgz",
           "integrity": "sha512-H13E9Xl+PxBd8D5/6TVUluSpxGNvFSlN/b3coUp0e0JpuWXXnQDiavIpY3NnvSp4xhEMoXyyBvVfdFX8jglOHQ==",
-          "peer": true,
           "requires": {
             "@formatjs/ecma402-abstract": "2.3.6",
             "tslib": "^2.8.0"
@@ -48192,7 +48339,6 @@
           "version": "3.1.8",
           "resolved": "https://registry.npmjs.org/@formatjs/intl/-/intl-3.1.8.tgz",
           "integrity": "sha512-LWXgwI5zTMatvR8w8kCNh/priDTOF/ZssokMBHJ7ZWXFoYLVOYo0EJERD9Eajv+xsfQO1QkuAt77KWQ1OI4mOQ==",
-          "peer": true,
           "requires": {
             "@formatjs/ecma402-abstract": "2.3.6",
             "@formatjs/fast-memoize": "2.2.7",
@@ -48205,7 +48351,6 @@
           "version": "0.6.2",
           "resolved": "https://registry.npmjs.org/@formatjs/intl-localematcher/-/intl-localematcher-0.6.2.tgz",
           "integrity": "sha512-XOMO2Hupl0wdd172Y06h6kLpBz6Dv+J4okPLl4LPtzbr8f66WbIoy4ev98EBuZ6ZK4h5ydTN6XneT4QVpD7cdA==",
-          "peer": true,
           "requires": {
             "tslib": "^2.8.0"
           }
@@ -48214,7 +48359,6 @@
           "version": "10.7.18",
           "resolved": "https://registry.npmjs.org/intl-messageformat/-/intl-messageformat-10.7.18.tgz",
           "integrity": "sha512-m3Ofv/X/tV8Y3tHXLohcuVuhWKo7BBq62cqY15etqmLxg2DZ34AGGgQDeR+SCta2+zICb1NX83af0GJmbQ1++g==",
-          "peer": true,
           "requires": {
             "@formatjs/ecma402-abstract": "2.3.6",
             "@formatjs/fast-memoize": "2.2.7",
@@ -48225,8 +48369,7 @@
         "tslib": {
           "version": "2.8.1",
           "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.8.1.tgz",
-          "integrity": "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==",
-          "peer": true
+          "integrity": "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w=="
         }
       }
     },
@@ -48262,6 +48405,7 @@
       "version": "26.5.0",
       "resolved": "https://registry.npmjs.org/@dcl/schemas/-/schemas-26.5.0.tgz",
       "integrity": "sha512-R7/IXI3g4SFGsVKtsLzwUk7romfV9vxWtI0A7pbwlNEyfPtIVgdIqpgHAXD06vDTAyrEZAWMyzhHxcBEoIXniQ==",
+      "peer": true,
       "requires": {
         "ajv": "^8.11.0",
         "ajv-errors": "^3.0.0",
@@ -48273,6 +48417,7 @@
           "version": "8.12.0",
           "resolved": "https://registry.npmjs.org/ajv/-/ajv-8.12.0.tgz",
           "integrity": "sha512-sRu1kpcO9yLtYxBKvqfTeh9KzZEwO3STyX1HT+4CaDzC6HpTGYhIhPIzj9XuKU7KYDwnaeh5hcOwjy1QuJzBPA==",
+          "peer": true,
           "requires": {
             "fast-deep-equal": "^3.1.1",
             "json-schema-traverse": "^1.0.0",
@@ -48313,7 +48458,8 @@
     "@dcl/ui-env": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/@dcl/ui-env/-/ui-env-2.0.0.tgz",
-      "integrity": "sha512-Is+LqRhVU4BzxzCvWC5xbnYAF9dEiFUDOU3nuHpRyd19QCDrCm9HFt+cV+Q7RaNzXeHEsTqqPJ+Iej9aB70bmQ=="
+      "integrity": "sha512-Is+LqRhVU4BzxzCvWC5xbnYAF9dEiFUDOU3nuHpRyd19QCDrCm9HFt+cV+Q7RaNzXeHEsTqqPJ+Iej9aB70bmQ==",
+      "peer": true
     },
     "@discordjs/builders": {
       "version": "1.4.0",
@@ -48506,6 +48652,7 @@
       "version": "11.14.0",
       "resolved": "https://registry.npmjs.org/@emotion/react/-/react-11.14.0.tgz",
       "integrity": "sha512-O000MLDBDdk/EohJPFUqvnp4qnHeYkVP5B0xEG0D/L7cOKP9kefu2DXn8dj74cQfsEzUqh+sr1RzFqiL1o+PpA==",
+      "peer": true,
       "requires": {
         "@babel/runtime": "^7.18.3",
         "@emotion/babel-plugin": "^11.13.5",
@@ -49242,7 +49389,6 @@
       "version": "0.63.1",
       "resolved": "https://registry.npmjs.org/@fluentui/react-component-event-listener/-/react-component-event-listener-0.63.1.tgz",
       "integrity": "sha512-gSMdOh6tI3IJKZFqxfQwbTpskpME0CvxdxGM2tdglmf6ZPVDi0L4+KKIm+2dN8nzb8Ya1A8ZT+Ddq0KmZtwVQg==",
-      "peer": true,
       "requires": {
         "@babel/runtime": "^7.10.4"
       }
@@ -49251,7 +49397,6 @@
       "version": "0.63.1",
       "resolved": "https://registry.npmjs.org/@fluentui/react-component-ref/-/react-component-ref-0.63.1.tgz",
       "integrity": "sha512-8MkXX4+R3i80msdbD4rFpEB4WWq2UDvGwG386g3ckIWbekdvN9z2kWAd9OXhRGqB7QeOsoAGWocp6gAMCivRlw==",
-      "peer": true,
       "requires": {
         "@babel/runtime": "^7.10.4",
         "react-is": "^16.6.3"
@@ -49407,6 +49552,7 @@
       "version": "1.3.9",
       "resolved": "https://registry.npmjs.org/@gatsbyjs/reach-router/-/reach-router-1.3.9.tgz",
       "integrity": "sha512-/354IaUSM54xb7K/TxpLBJB94iEAJ3P82JD38T8bLnIDWF+uw8+W/82DKnQ7y24FJcKxtVmG43aiDLG88KSuYQ==",
+      "peer": true,
       "requires": {
         "invariant": "^2.2.3",
         "prop-types": "^15.6.1",
@@ -49793,7 +49939,6 @@
       "version": "0.9.1",
       "resolved": "https://registry.npmjs.org/@hey-api/codegen-core/-/codegen-core-0.9.1.tgz",
       "integrity": "sha512-s97jL1dgTMuiMHv2BZ1X4Tgd99Mf9GOvGdNqNcGwIMmnR+PgYNoraj4Zvp134MKsNCap/m7k0r0vKKnl56pj4w==",
-      "peer": true,
       "requires": {
         "@hey-api/types": "0.1.4",
         "ansi-colors": "4.1.3",
@@ -49805,7 +49950,6 @@
       "version": "1.4.4",
       "resolved": "https://registry.npmjs.org/@hey-api/json-schema-ref-parser/-/json-schema-ref-parser-1.4.4.tgz",
       "integrity": "sha512-otmd+zCxbYVBIp/mlMTnGkvlNYLkVKgs3VOIq0kSnenhB1+fRwLPQIeSwyWM6E51oXhUedkYjVsVpkVexeuJOA==",
-      "peer": true,
       "requires": {
         "@jsdevtools/ono": "7.1.3",
         "@types/json-schema": "7.0.15",
@@ -49815,14 +49959,12 @@
         "argparse": {
           "version": "2.0.1",
           "resolved": "https://registry.npmjs.org/argparse/-/argparse-2.0.1.tgz",
-          "integrity": "sha512-8+9WqebbFzpX9OR+Wa6O29asIogeRMzcGtAINdpMHHyAg10f05aSFVBbcEqGf/PXw1EjAZ+q2/bEBg3DvurK3Q==",
-          "peer": true
+          "integrity": "sha512-8+9WqebbFzpX9OR+Wa6O29asIogeRMzcGtAINdpMHHyAg10f05aSFVBbcEqGf/PXw1EjAZ+q2/bEBg3DvurK3Q=="
         },
         "js-yaml": {
           "version": "4.2.0",
           "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.2.0.tgz",
           "integrity": "sha512-ePWsvanv0DWuDRsW8dnt+R4jQ31SCRCQ7hhNcPXZPsoBZiemuZNYGf7adZdqX2D86j6rvKp3RpCxVTSb8WQlOw==",
-          "peer": true,
           "requires": {
             "argparse": "^2.0.1"
           }
@@ -49833,7 +49975,6 @@
       "version": "0.99.0",
       "resolved": "https://registry.npmjs.org/@hey-api/openapi-ts/-/openapi-ts-0.99.0.tgz",
       "integrity": "sha512-SePU/5oEWWkvUBYmvzdYRctseoLuskyhs4ET0RvLIcmzc8yLQoA2R+KtBIQ8bPsoSUB0m4E5SmBnl6aGSA0szQ==",
-      "peer": true,
       "requires": {
         "@hey-api/codegen-core": "0.9.1",
         "@hey-api/json-schema-ref-parser": "1.4.4",
@@ -49850,8 +49991,7 @@
         "commander": {
           "version": "15.0.0",
           "resolved": "https://registry.npmjs.org/commander/-/commander-15.0.0.tgz",
-          "integrity": "sha512-z67u4ZhzCL/Tydu1lJARtEZYWbWaN7oYLHbsuzocr6y4N6WZAagG3RQ4FW61V1/0+jImpj293XfrcYnd1qxtPg==",
-          "peer": true
+          "integrity": "sha512-z67u4ZhzCL/Tydu1lJARtEZYWbWaN7oYLHbsuzocr6y4N6WZAagG3RQ4FW61V1/0+jImpj293XfrcYnd1qxtPg=="
         }
       }
     },
@@ -49859,7 +49999,6 @@
       "version": "0.5.0",
       "resolved": "https://registry.npmjs.org/@hey-api/shared/-/shared-0.5.0.tgz",
       "integrity": "sha512-JN/j4Ebh4cJGYIQ5cwWuqe7GeSUyQoz7oC51WqyhKOcrejK6DKZMDkshc5d1eKTRuRL+rjozuRcoUaZZn2DGPw==",
-      "peer": true,
       "requires": {
         "@hey-api/codegen-core": "0.9.1",
         "@hey-api/json-schema-ref-parser": "1.4.4",
@@ -49874,14 +50013,12 @@
         "define-lazy-prop": {
           "version": "3.0.0",
           "resolved": "https://registry.npmjs.org/define-lazy-prop/-/define-lazy-prop-3.0.0.tgz",
-          "integrity": "sha512-N+MeXYoqr3pOgn8xfyRPREN7gHakLYjhsHhWGT3fWAiL4IkAt0iDw14QiiEm2bE30c5XX5q0FtAA3CK5f9/BUg==",
-          "peer": true
+          "integrity": "sha512-N+MeXYoqr3pOgn8xfyRPREN7gHakLYjhsHhWGT3fWAiL4IkAt0iDw14QiiEm2bE30c5XX5q0FtAA3CK5f9/BUg=="
         },
         "open": {
           "version": "11.0.0",
           "resolved": "https://registry.npmjs.org/open/-/open-11.0.0.tgz",
           "integrity": "sha512-smsWv2LzFjP03xmvFoJ331ss6h+jixfA4UUV/Bsiyuu4YJPfN+FIQGOIiv4w9/+MoHkfkJ22UIaQWRVFRfH6Vw==",
-          "peer": true,
           "requires": {
             "default-browser": "^5.4.0",
             "define-lazy-prop": "^3.0.0",
@@ -49897,7 +50034,6 @@
       "version": "0.2.0",
       "resolved": "https://registry.npmjs.org/@hey-api/spec-types/-/spec-types-0.2.0.tgz",
       "integrity": "sha512-ibQ8Is7evMavzr8GNyJCcTg975d8DpaMUyLmOrQ85UBdy1l6t1KuRAwgChAbesJsIlNV6gjmlXruWyegDX18Fg==",
-      "peer": true,
       "requires": {
         "@hey-api/types": "0.1.4"
       }
@@ -49905,8 +50041,7 @@
     "@hey-api/types": {
       "version": "0.1.4",
       "resolved": "https://registry.npmjs.org/@hey-api/types/-/types-0.1.4.tgz",
-      "integrity": "sha512-thWfawrDIP7wSI9ioT13I5soaaqB5vAPIiZmgD8PbeEVKNrkonc0N/Sjj97ezl7oQgusZmaNphGdMKipPO6IBg==",
-      "peer": true
+      "integrity": "sha512-thWfawrDIP7wSI9ioT13I5soaaqB5vAPIiZmgD8PbeEVKNrkonc0N/Sjj97ezl7oQgusZmaNphGdMKipPO6IBg=="
     },
     "@humanwhocodes/config-array": {
       "version": "0.9.5",
@@ -50557,8 +50692,7 @@
     "@jsdevtools/ono": {
       "version": "7.1.3",
       "resolved": "https://registry.npmjs.org/@jsdevtools/ono/-/ono-7.1.3.tgz",
-      "integrity": "sha512-4JQNk+3mVzK3xh2rqd6RB4J46qUR19azEHBneZyTZM+c456qOrbbM/5xcR8huNCCcbVt7+UmizG6GuUvPvKUYg==",
-      "peer": true
+      "integrity": "sha512-4JQNk+3mVzK3xh2rqd6RB4J46qUR19azEHBneZyTZM+c456qOrbbM/5xcR8huNCCcbVt7+UmizG6GuUvPvKUYg=="
     },
     "@lezer/common": {
       "version": "0.15.12",
@@ -50651,20 +50785,17 @@
     "@lukeed/csprng": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/@lukeed/csprng/-/csprng-1.1.0.tgz",
-      "integrity": "sha512-Z7C/xXCiGWsg0KuKsHTKJxbWhpI3Vs5GwLfOean7MGyVFGqdRgBbAjOCh6u4bbjPc/8MJ2pZmK/0DLdCbivLDA==",
-      "peer": true
+      "integrity": "sha512-Z7C/xXCiGWsg0KuKsHTKJxbWhpI3Vs5GwLfOean7MGyVFGqdRgBbAjOCh6u4bbjPc/8MJ2pZmK/0DLdCbivLDA=="
     },
     "@lukeed/ms": {
       "version": "2.0.2",
       "resolved": "https://registry.npmjs.org/@lukeed/ms/-/ms-2.0.2.tgz",
-      "integrity": "sha512-9I2Zn6+NJLfaGoz9jN3lpwDgAYvfGeNYdbAIjJOqzs4Tpc+VU3Jqq4IofSUBKajiDS8k9fZIg18/z13mpk1bsA==",
-      "peer": true
+      "integrity": "sha512-9I2Zn6+NJLfaGoz9jN3lpwDgAYvfGeNYdbAIjJOqzs4Tpc+VU3Jqq4IofSUBKajiDS8k9fZIg18/z13mpk1bsA=="
     },
     "@lukeed/uuid": {
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/@lukeed/uuid/-/uuid-2.0.1.tgz",
       "integrity": "sha512-qC72D4+CDdjGqJvkFMMEAtancHUQ7/d/tAiHf64z8MopFDmcrtbcJuerDtFceuAfQJ2pDSfCKCtbqoGBNnwg0w==",
-      "peer": true,
       "requires": {
         "@lukeed/csprng": "^1.1.0"
       }
@@ -50687,6 +50818,7 @@
       "version": "27.0.0",
       "resolved": "https://registry.npmjs.org/@magic-sdk/provider/-/provider-27.0.0.tgz",
       "integrity": "sha512-k2haK2zhYkqf+cbMF+/HKvqa8qPWqdZbW10qgN6AdqaOE750ceC3GDQCUwAfkzdofmWrRtFgW5jVAVCVz5WklQ==",
+      "peer": true,
       "requires": {
         "@magic-sdk/types": "^23.0.0",
         "eventemitter3": "^4.0.4",
@@ -50696,7 +50828,8 @@
     "@magic-sdk/types": {
       "version": "23.0.0",
       "resolved": "https://registry.npmjs.org/@magic-sdk/types/-/types-23.0.0.tgz",
-      "integrity": "sha512-NTjgGPJVYxoncSrHtDZLDiJzdSbxHV0jCy6J+YvT+LY7QUiGY3zzu+NhLqgLxE6KZODXERhSLYSimotcokZbmw=="
+      "integrity": "sha512-NTjgGPJVYxoncSrHtDZLDiJzdSbxHV0jCy6J+YvT+LY7QUiGY3zzu+NhLqgLxE6KZODXERhSLYSimotcokZbmw==",
+      "peer": true
     },
     "@metamask/eth-json-rpc-provider": {
       "version": "1.0.1",
@@ -51183,7 +51316,6 @@
       "version": "5.0.0-beta.40",
       "resolved": "https://registry.npmjs.org/@mui/base/-/base-5.0.0-beta.40.tgz",
       "integrity": "sha512-I/lGHztkCzvwlXpjD2+SNmvNQvB4227xBXhISPjEaJUXGImOQ9f3D2Yj/T3KasSI/h0MLWy74X0J6clhPmsRbQ==",
-      "peer": true,
       "requires": {
         "@babel/runtime": "^7.23.9",
         "@floating-ui/react-dom": "^2.0.8",
@@ -51197,22 +51329,19 @@
         "clsx": {
           "version": "2.1.1",
           "resolved": "https://registry.npmjs.org/clsx/-/clsx-2.1.1.tgz",
-          "integrity": "sha512-eYm0QWBtUrBWZWG0d386OGAw16Z995PiOVo2B7bjWSbHedGl5e0ZWaq65kOGgUSNesEIDkB9ISbTg/JK9dhCZA==",
-          "peer": true
+          "integrity": "sha512-eYm0QWBtUrBWZWG0d386OGAw16Z995PiOVo2B7bjWSbHedGl5e0ZWaq65kOGgUSNesEIDkB9ISbTg/JK9dhCZA=="
         }
       }
     },
     "@mui/core-downloads-tracker": {
       "version": "5.18.0",
       "resolved": "https://registry.npmjs.org/@mui/core-downloads-tracker/-/core-downloads-tracker-5.18.0.tgz",
-      "integrity": "sha512-jbhwoQ1AY200PSSOrNXmrFCaSDSJWP7qk6urkTmIirvRXDROkqe+QwcLlUiw/PrREwsIF/vm3/dAXvjlMHF0RA==",
-      "peer": true
+      "integrity": "sha512-jbhwoQ1AY200PSSOrNXmrFCaSDSJWP7qk6urkTmIirvRXDROkqe+QwcLlUiw/PrREwsIF/vm3/dAXvjlMHF0RA=="
     },
     "@mui/icons-material": {
       "version": "5.16.0",
       "resolved": "https://registry.npmjs.org/@mui/icons-material/-/icons-material-5.16.0.tgz",
       "integrity": "sha512-6ISoOhkp9w5gD0PEW9JklrcbyARDkFWNTBdwXZ1Oy5IGlyu9B0zG0hnUIe4H17IaF1Vgj6C8VI+v4tkSdK0veg==",
-      "peer": true,
       "requires": {
         "@babel/runtime": "^7.23.9"
       }
@@ -51240,14 +51369,12 @@
         "clsx": {
           "version": "2.1.1",
           "resolved": "https://registry.npmjs.org/clsx/-/clsx-2.1.1.tgz",
-          "integrity": "sha512-eYm0QWBtUrBWZWG0d386OGAw16Z995PiOVo2B7bjWSbHedGl5e0ZWaq65kOGgUSNesEIDkB9ISbTg/JK9dhCZA==",
-          "peer": true
+          "integrity": "sha512-eYm0QWBtUrBWZWG0d386OGAw16Z995PiOVo2B7bjWSbHedGl5e0ZWaq65kOGgUSNesEIDkB9ISbTg/JK9dhCZA=="
         },
         "react-is": {
           "version": "18.3.1",
           "resolved": "https://registry.npmjs.org/react-is/-/react-is-18.3.1.tgz",
-          "integrity": "sha512-/LLMVyas0ljjAtoYiPqYiL8VWXzUUdThrmU5+n20DZv+a+ClRoevUzw5JxU+Ieh5/c87ytoTBV9G1FiKfNJdmg==",
-          "peer": true
+          "integrity": "sha512-/LLMVyas0ljjAtoYiPqYiL8VWXzUUdThrmU5+n20DZv+a+ClRoevUzw5JxU+Ieh5/c87ytoTBV9G1FiKfNJdmg=="
         }
       }
     },
@@ -51255,7 +51382,6 @@
       "version": "5.17.1",
       "resolved": "https://registry.npmjs.org/@mui/private-theming/-/private-theming-5.17.1.tgz",
       "integrity": "sha512-XMxU0NTYcKqdsG8LRmSoxERPXwMbp16sIXPcLVgLGII/bVNagX0xaheWAwFv8+zDK7tI3ajllkuD3GZZE++ICQ==",
-      "peer": true,
       "requires": {
         "@babel/runtime": "^7.23.9",
         "@mui/utils": "^5.17.1",
@@ -51266,7 +51392,6 @@
       "version": "5.18.0",
       "resolved": "https://registry.npmjs.org/@mui/styled-engine/-/styled-engine-5.18.0.tgz",
       "integrity": "sha512-BN/vKV/O6uaQh2z5rXV+MBlVrEkwoS/TK75rFQ2mjxA7+NBo8qtTAOA4UaM0XeJfn7kh2wZ+xQw2HAx0u+TiBg==",
-      "peer": true,
       "requires": {
         "@babel/runtime": "^7.23.9",
         "@emotion/cache": "^11.13.5",
@@ -51279,7 +51404,6 @@
       "version": "5.18.0",
       "resolved": "https://registry.npmjs.org/@mui/system/-/system-5.18.0.tgz",
       "integrity": "sha512-ojZGVcRWqWhu557cdO3pWHloIGJdzVtxs3rk0F9L+x55LsUjcMUVkEhiF7E4TMxZoF9MmIHGGs0ZX3FDLAf0Xw==",
-      "peer": true,
       "requires": {
         "@babel/runtime": "^7.23.9",
         "@mui/private-theming": "^5.17.1",
@@ -51295,14 +51419,12 @@
           "version": "7.2.24",
           "resolved": "https://registry.npmjs.org/@mui/types/-/types-7.2.24.tgz",
           "integrity": "sha512-3c8tRt/CbWZ+pEg7QpSwbdxOk36EfmhbKf6AGZsD1EcLDLTSZoxxJ86FVtcjxvjuhdyBiWKSTGZFaXCnidO2kw==",
-          "peer": true,
           "requires": {}
         },
         "clsx": {
           "version": "2.1.1",
           "resolved": "https://registry.npmjs.org/clsx/-/clsx-2.1.1.tgz",
-          "integrity": "sha512-eYm0QWBtUrBWZWG0d386OGAw16Z995PiOVo2B7bjWSbHedGl5e0ZWaq65kOGgUSNesEIDkB9ISbTg/JK9dhCZA==",
-          "peer": true
+          "integrity": "sha512-eYm0QWBtUrBWZWG0d386OGAw16Z995PiOVo2B7bjWSbHedGl5e0ZWaq65kOGgUSNesEIDkB9ISbTg/JK9dhCZA=="
         }
       }
     },
@@ -51310,7 +51432,6 @@
       "version": "7.4.12",
       "resolved": "https://registry.npmjs.org/@mui/types/-/types-7.4.12.tgz",
       "integrity": "sha512-iKNAF2u9PzSIj40CjvKJWxFXJo122jXVdrmdh0hMYd+FR+NuJMkr/L88XwWLCRiJ5P1j+uyac25+Kp6YC4hu6w==",
-      "peer": true,
       "requires": {
         "@babel/runtime": "^7.28.6"
       }
@@ -51319,7 +51440,6 @@
       "version": "5.17.1",
       "resolved": "https://registry.npmjs.org/@mui/utils/-/utils-5.17.1.tgz",
       "integrity": "sha512-jEZ8FTqInt2WzxDV8bhImWBqeQRD99c/id/fq83H0ER9tFl+sfZlaAoCdznGvbSQQ9ividMxqSV2c7cC1vBcQg==",
-      "peer": true,
       "requires": {
         "@babel/runtime": "^7.23.9",
         "@mui/types": "~7.2.15",
@@ -51333,20 +51453,17 @@
           "version": "7.2.24",
           "resolved": "https://registry.npmjs.org/@mui/types/-/types-7.2.24.tgz",
           "integrity": "sha512-3c8tRt/CbWZ+pEg7QpSwbdxOk36EfmhbKf6AGZsD1EcLDLTSZoxxJ86FVtcjxvjuhdyBiWKSTGZFaXCnidO2kw==",
-          "peer": true,
           "requires": {}
         },
         "clsx": {
           "version": "2.1.1",
           "resolved": "https://registry.npmjs.org/clsx/-/clsx-2.1.1.tgz",
-          "integrity": "sha512-eYm0QWBtUrBWZWG0d386OGAw16Z995PiOVo2B7bjWSbHedGl5e0ZWaq65kOGgUSNesEIDkB9ISbTg/JK9dhCZA==",
-          "peer": true
+          "integrity": "sha512-eYm0QWBtUrBWZWG0d386OGAw16Z995PiOVo2B7bjWSbHedGl5e0ZWaq65kOGgUSNesEIDkB9ISbTg/JK9dhCZA=="
         },
         "react-is": {
           "version": "19.2.7",
           "resolved": "https://registry.npmjs.org/react-is/-/react-is-19.2.7.tgz",
-          "integrity": "sha512-kZFnouyVv7eP/Phmrlo9FK+zcAdriZJvzxXHF1Sl1P377WSGe2G/JxVolhTrB/jeV47lKImhNUsijjHAAbcl/A==",
-          "peer": true
+          "integrity": "sha512-kZFnouyVv7eP/Phmrlo9FK+zcAdriZJvzxXHF1Sl1P377WSGe2G/JxVolhTrB/jeV47lKImhNUsijjHAAbcl/A=="
         }
       }
     },
@@ -51362,7 +51479,8 @@
     "@noble/ciphers": {
       "version": "1.3.0",
       "resolved": "https://registry.npmjs.org/@noble/ciphers/-/ciphers-1.3.0.tgz",
-      "integrity": "sha512-2I0gnIVPtfnMw9ee9h1dJG7tp81+8Ob3OJb3Mv37rx5L40/b0i7djjCVvGOVqc9AEIQyvyu1i6ypKdFw8R8gQw=="
+      "integrity": "sha512-2I0gnIVPtfnMw9ee9h1dJG7tp81+8Ob3OJb3Mv37rx5L40/b0i7djjCVvGOVqc9AEIQyvyu1i6ypKdFw8R8gQw==",
+      "peer": true
     },
     "@noble/curves": {
       "version": "1.1.0",
@@ -51518,6 +51636,7 @@
       "version": "2.6.2",
       "resolved": "https://registry.npmjs.org/@parcel/core/-/core-2.6.2.tgz",
       "integrity": "sha512-JlKS3Ux0ngmdooSBbzQLShHJdsapF9E7TGMo1hFaHRquZip/DaqzvysYrgMJlDuCoLArciq5ei7ZKzGeK9zexA==",
+      "peer": true,
       "requires": {
         "@mischnic/json-sourcemap": "^0.1.0",
         "@parcel/cache": "2.6.2",
@@ -52272,6 +52391,7 @@
           "version": "8.13.0",
           "resolved": "https://registry.npmjs.org/ws/-/ws-8.13.0.tgz",
           "integrity": "sha512-x9vcZYTrFPC7aSIbj7sRCYo7L/Xb8Iy+pW0ng0wt2vCJv7M9HOMy0UoN3rr+IFC7hb7vXoqS+P9ktyLLLhO+LA==",
+          "peer": true,
           "requires": {}
         }
       }
@@ -52504,7 +52624,6 @@
       "version": "1.5.0",
       "resolved": "https://registry.npmjs.org/@redux-saga/core/-/core-1.5.0.tgz",
       "integrity": "sha512-oMWpQntvVikLhr+wZsvGDzkjW79HphBgEb6Hncz8OkM0azsT3uUnP1Her/W5QZhcDG+tWmjDhah8uDbPSRLs/Q==",
-      "peer": true,
       "requires": {
         "@babel/runtime": "^7.28.4",
         "@redux-saga/deferred": "^1.3.1",
@@ -52517,14 +52636,12 @@
     "@redux-saga/deferred": {
       "version": "1.3.1",
       "resolved": "https://registry.npmjs.org/@redux-saga/deferred/-/deferred-1.3.1.tgz",
-      "integrity": "sha512-0YZ4DUivWojXBqLB/TmuRRpDDz7tyq1I0AuDV7qi01XlLhM5m51W7+xYtIckH5U2cMlv9eAuicsfRAi1XHpXIg==",
-      "peer": true
+      "integrity": "sha512-0YZ4DUivWojXBqLB/TmuRRpDDz7tyq1I0AuDV7qi01XlLhM5m51W7+xYtIckH5U2cMlv9eAuicsfRAi1XHpXIg=="
     },
     "@redux-saga/delay-p": {
       "version": "1.3.1",
       "resolved": "https://registry.npmjs.org/@redux-saga/delay-p/-/delay-p-1.3.1.tgz",
       "integrity": "sha512-597I7L5MXbD/1i3EmcaOOjL/5suxJD7p5tnbV1PiWnE28c2cYiIHqmSMK2s7us2/UrhOL2KTNBiD0qBg6KnImg==",
-      "peer": true,
       "requires": {
         "@redux-saga/symbols": "^1.2.1"
       }
@@ -52533,7 +52650,6 @@
       "version": "1.2.1",
       "resolved": "https://registry.npmjs.org/@redux-saga/is/-/is-1.2.1.tgz",
       "integrity": "sha512-x3aWtX3GmQfEvn8dh0ovPbsXgK9JjpiR24wKztpGbZP8JZUWWvUgKrvnWZ/T/4iphOBftyVc9VrIwhAnsM+OFA==",
-      "peer": true,
       "requires": {
         "@redux-saga/symbols": "^1.2.1",
         "@redux-saga/types": "^1.3.1"
@@ -52542,14 +52658,12 @@
     "@redux-saga/symbols": {
       "version": "1.2.1",
       "resolved": "https://registry.npmjs.org/@redux-saga/symbols/-/symbols-1.2.1.tgz",
-      "integrity": "sha512-3dh+uDvpBXi7EUp/eO+N7eFM4xKaU4yuGBXc50KnZGzIrR/vlvkTFQsX13zsY8PB6sCFYAgROfPSRUj8331QSA==",
-      "peer": true
+      "integrity": "sha512-3dh+uDvpBXi7EUp/eO+N7eFM4xKaU4yuGBXc50KnZGzIrR/vlvkTFQsX13zsY8PB6sCFYAgROfPSRUj8331QSA=="
     },
     "@redux-saga/types": {
       "version": "1.4.0",
       "resolved": "https://registry.npmjs.org/@redux-saga/types/-/types-1.4.0.tgz",
-      "integrity": "sha512-fq3Vy0TRl0mEb+1CyTx5wPBY3jxDi7yD4GL1Kz4S6ud7/leGEgRq1NYJDIiVbHMRBJd5rU/BB0Z+akrXSR0DJg==",
-      "peer": true
+      "integrity": "sha512-fq3Vy0TRl0mEb+1CyTx5wPBY3jxDi7yD4GL1Kz4S6ud7/leGEgRq1NYJDIiVbHMRBJd5rU/BB0Z+akrXSR0DJg=="
     },
     "@reown/appkit": {
       "version": "1.8.21",
@@ -52857,7 +52971,6 @@
       "version": "1.8.3",
       "resolved": "https://registry.npmjs.org/@segment/analytics-core/-/analytics-core-1.8.3.tgz",
       "integrity": "sha512-63X8e2DWb2ZnJ9S3H8iSOFnbeDXMkTGhA8kZG4eFAO07QBwBVyWo5BCpv6vmuOMEkv2le6t2FMg1p6ZeJQA/4A==",
-      "peer": true,
       "requires": {
         "@lukeed/uuid": "^2.0.0",
         "@segment/analytics-generic-utils": "1.2.0",
@@ -52868,8 +52981,7 @@
         "tslib": {
           "version": "2.8.1",
           "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.8.1.tgz",
-          "integrity": "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==",
-          "peer": true
+          "integrity": "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w=="
         }
       }
     },
@@ -52877,7 +52989,6 @@
       "version": "1.2.0",
       "resolved": "https://registry.npmjs.org/@segment/analytics-generic-utils/-/analytics-generic-utils-1.2.0.tgz",
       "integrity": "sha512-DfnW6mW3YQOLlDQQdR89k4EqfHb0g/3XvBXkovH1FstUN93eL1kfW9CsDcVQyH3bAC5ZsFyjA/o/1Q2j0QeoWw==",
-      "peer": true,
       "requires": {
         "tslib": "^2.4.1"
       },
@@ -52885,8 +52996,7 @@
         "tslib": {
           "version": "2.8.1",
           "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.8.1.tgz",
-          "integrity": "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==",
-          "peer": true
+          "integrity": "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w=="
         }
       }
     },
@@ -52894,7 +53004,6 @@
       "version": "1.84.0",
       "resolved": "https://registry.npmjs.org/@segment/analytics-next/-/analytics-next-1.84.0.tgz",
       "integrity": "sha512-V5scoCrhiTpRPOuBwNVpvE4KvHwrjgQ5fs282R72KiAZ0HoxmjLgReZYjZogBf7qq/c6VmQG3nidwh8PQGcY1A==",
-      "peer": true,
       "requires": {
         "@lukeed/uuid": "^2.0.0",
         "@segment/analytics-core": "1.8.3",
@@ -52912,8 +53021,7 @@
         "tslib": {
           "version": "2.8.1",
           "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.8.1.tgz",
-          "integrity": "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==",
-          "peer": true
+          "integrity": "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w=="
         }
       }
     },
@@ -52921,7 +53029,6 @@
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/@segment/analytics-page-tools/-/analytics-page-tools-1.0.0.tgz",
       "integrity": "sha512-o9OVB91qLB9qb0Bw1HfjmWm5AnrMNULRjx++4lBqLt8InKRX1urrRBparVlpj+yJA0sckN5ZcsfazRLuPgBYDQ==",
-      "peer": true,
       "requires": {
         "tslib": "^2.4.1"
       },
@@ -52929,8 +53036,7 @@
         "tslib": {
           "version": "2.8.1",
           "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.8.1.tgz",
-          "integrity": "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==",
-          "peer": true
+          "integrity": "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w=="
         }
       }
     },
@@ -52938,7 +53044,6 @@
       "version": "0.2.1",
       "resolved": "https://registry.npmjs.org/@segment/analytics.js-video-plugins/-/analytics.js-video-plugins-0.2.1.tgz",
       "integrity": "sha512-lZwCyEXT4aaHBLNK433okEKdxGAuyrVmop4BpQqQSJuRz0DglPZgd9B/XjiiWs1UyOankg2aNYMN3VcS8t4eSQ==",
-      "peer": true,
       "requires": {
         "unfetch": "^3.1.1"
       },
@@ -52946,8 +53051,7 @@
         "unfetch": {
           "version": "3.1.2",
           "resolved": "https://registry.npmjs.org/unfetch/-/unfetch-3.1.2.tgz",
-          "integrity": "sha512-L0qrK7ZeAudGiKYw6nzFjnJ2D5WHblUBwmHIqtPS6oKUd+Hcpk7/hKsSmcHsTlpd1TbTNsiRBUKRq3bHLNIqIw==",
-          "peer": true
+          "integrity": "sha512-L0qrK7ZeAudGiKYw6nzFjnJ2D5WHblUBwmHIqtPS6oKUd+Hcpk7/hKsSmcHsTlpd1TbTNsiRBUKRq3bHLNIqIw=="
         }
       }
     },
@@ -52955,7 +53059,6 @@
       "version": "3.4.10",
       "resolved": "https://registry.npmjs.org/@segment/facade/-/facade-3.4.10.tgz",
       "integrity": "sha512-xVQBbB/lNvk/u8+ey0kC/+g8pT3l0gCT8O2y9Z+StMMn3KAFAQ9w8xfgef67tJybktOKKU7pQGRPolRM1i1pdA==",
-      "peer": true,
       "requires": {
         "@segment/isodate-traverse": "^1.1.1",
         "inherits": "^2.0.4",
@@ -52966,14 +53069,12 @@
     "@segment/isodate": {
       "version": "1.0.3",
       "resolved": "https://registry.npmjs.org/@segment/isodate/-/isodate-1.0.3.tgz",
-      "integrity": "sha512-BtanDuvJqnACFkeeYje7pWULVv8RgZaqKHWwGFnL/g/TH/CcZjkIVTfGDp/MAxmilYHUkrX70SqwnYSTNEaN7A==",
-      "peer": true
+      "integrity": "sha512-BtanDuvJqnACFkeeYje7pWULVv8RgZaqKHWwGFnL/g/TH/CcZjkIVTfGDp/MAxmilYHUkrX70SqwnYSTNEaN7A=="
     },
     "@segment/isodate-traverse": {
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/@segment/isodate-traverse/-/isodate-traverse-1.1.1.tgz",
       "integrity": "sha512-+G6e1SgAUkcq0EDMi+SRLfT48TNlLPF3QnSgFGVs0V9F3o3fq/woQ2rHFlW20W0yy5NnCUH0QGU3Am2rZy/E3w==",
-      "peer": true,
       "requires": {
         "@segment/isodate": "^1.0.3"
       }
@@ -52991,7 +53092,6 @@
       "version": "3.1.3",
       "resolved": "https://registry.npmjs.org/@semantic-ui-react/event-stack/-/event-stack-3.1.3.tgz",
       "integrity": "sha512-FdTmJyWvJaYinHrKRsMLDrz4tTMGdFfds299Qory53hBugiDvGC0tEJf+cHsi5igDwWb/CLOgOiChInHwq8URQ==",
-      "peer": true,
       "requires": {
         "exenv": "^1.2.2",
         "prop-types": "^15.6.2"
@@ -53001,7 +53101,6 @@
       "version": "9.47.1",
       "resolved": "https://registry.npmjs.org/@sentry-internal/browser-utils/-/browser-utils-9.47.1.tgz",
       "integrity": "sha512-twv6YhrUlPkvKz4/iQDH4KHgcv9t4cMjmZPf4/dCSCXn4/GOjzjx2d74c1w+1KOdS7lcsQzI+MtbK6SeYLiGfQ==",
-      "peer": true,
       "requires": {
         "@sentry/core": "9.47.1"
       }
@@ -53010,7 +53109,6 @@
       "version": "9.47.1",
       "resolved": "https://registry.npmjs.org/@sentry-internal/feedback/-/feedback-9.47.1.tgz",
       "integrity": "sha512-xJ4vKvIpAT8e+Sz80YrsNinPU0XV7jPxPjdZ4ex8R2mMvx7pM0gq8JiR/sIVmNiOE0WiUDr6VwLDE8j2APSRMA==",
-      "peer": true,
       "requires": {
         "@sentry/core": "9.47.1"
       }
@@ -53019,7 +53117,6 @@
       "version": "9.47.1",
       "resolved": "https://registry.npmjs.org/@sentry-internal/replay/-/replay-9.47.1.tgz",
       "integrity": "sha512-O9ZEfySpstGtX1f73m3NbdbS2utwPikaFt6sgp74RG4ZX4LlXe99VAjKR464xKECpYsLmj2bYpiK4opURF0pBA==",
-      "peer": true,
       "requires": {
         "@sentry-internal/browser-utils": "9.47.1",
         "@sentry/core": "9.47.1"
@@ -53029,7 +53126,6 @@
       "version": "9.47.1",
       "resolved": "https://registry.npmjs.org/@sentry-internal/replay-canvas/-/replay-canvas-9.47.1.tgz",
       "integrity": "sha512-r9nve+l5+elGB9NXSN1+PUgJy790tXN1e8lZNH2ziveoU91jW4yYYt34mHZ30fU9tOz58OpaRMj3H3GJ/jYZVA==",
-      "peer": true,
       "requires": {
         "@sentry-internal/replay": "9.47.1",
         "@sentry/core": "9.47.1"
@@ -53051,8 +53147,7 @@
     "@sentry/core": {
       "version": "9.47.1",
       "resolved": "https://registry.npmjs.org/@sentry/core/-/core-9.47.1.tgz",
-      "integrity": "sha512-KX62+qIt4xgy8eHKHiikfhz2p5fOciXd0Cl+dNzhgPFq8klq4MGMNaf148GB3M/vBqP4nw/eFvRMAayFCgdRQw==",
-      "peer": true
+      "integrity": "sha512-KX62+qIt4xgy8eHKHiikfhz2p5fOciXd0Cl+dNzhgPFq8klq4MGMNaf148GB3M/vBqP4nw/eFvRMAayFCgdRQw=="
     },
     "@sideway/address": {
       "version": "4.1.4",
@@ -54010,6 +54105,7 @@
       "version": "2.3.0",
       "resolved": "https://registry.npmjs.org/@solana/kit/-/kit-2.3.0.tgz",
       "integrity": "sha512-sb6PgwoW2LjE5oTFu4lhlS/cGt/NB3YrShEyx7JgWFWysfgLdJnhwWThgwy/4HjNsmtMrQGWVls0yVBHcMvlMQ==",
+      "peer": true,
       "requires": {
         "@solana/accounts": "2.3.0",
         "@solana/addresses": "2.3.0",
@@ -55028,6 +55124,7 @@
       "version": "2.3.0",
       "resolved": "https://registry.npmjs.org/@solana/sysvars/-/sysvars-2.3.0.tgz",
       "integrity": "sha512-LvjADZrpZ+CnhlHqfI5cmsRzX9Rpyb1Ox2dMHnbsRNzeKAMhu9w4ZBIaeTdO322zsTr509G1B+k2ABD3whvUBA==",
+      "peer": true,
       "requires": {
         "@solana/accounts": "2.3.0",
         "@solana/codecs": "2.3.0",
@@ -55367,6 +55464,7 @@
       "version": "5.81.5",
       "resolved": "https://registry.npmjs.org/@tanstack/react-query/-/react-query-5.81.5.tgz",
       "integrity": "sha512-lOf2KqRRiYWpQT86eeeftAGnjuTR35myTP8MXyvHa81VlomoAWNEd8x5vkcAfQefu0qtYCvyqLropFZqgI2EQw==",
+      "peer": true,
       "requires": {
         "@tanstack/query-core": "5.81.5"
       }
@@ -55604,26 +55702,22 @@
     "@types/d3-array": {
       "version": "3.2.2",
       "resolved": "https://registry.npmjs.org/@types/d3-array/-/d3-array-3.2.2.tgz",
-      "integrity": "sha512-hOLWVbm7uRza0BYXpIIW5pxfrKe0W+D5lrFiAEYR+pb6w3N2SwSMaJbXdUfSEv+dT4MfHBLtn5js0LAWaO6otw==",
-      "peer": true
+      "integrity": "sha512-hOLWVbm7uRza0BYXpIIW5pxfrKe0W+D5lrFiAEYR+pb6w3N2SwSMaJbXdUfSEv+dT4MfHBLtn5js0LAWaO6otw=="
     },
     "@types/d3-color": {
       "version": "3.1.3",
       "resolved": "https://registry.npmjs.org/@types/d3-color/-/d3-color-3.1.3.tgz",
-      "integrity": "sha512-iO90scth9WAbmgv7ogoq57O9YpKmFBbmoEoCHDB2xMBY0+/KVrqAaCDyCE16dUspeOvIxFFRI+0sEtqDqy2b4A==",
-      "peer": true
+      "integrity": "sha512-iO90scth9WAbmgv7ogoq57O9YpKmFBbmoEoCHDB2xMBY0+/KVrqAaCDyCE16dUspeOvIxFFRI+0sEtqDqy2b4A=="
     },
     "@types/d3-ease": {
       "version": "3.0.2",
       "resolved": "https://registry.npmjs.org/@types/d3-ease/-/d3-ease-3.0.2.tgz",
-      "integrity": "sha512-NcV1JjO5oDzoK26oMzbILE6HW7uVXOHLQvHshBUW4UMdZGfiY6v5BeQwh9a9tCzv+CeefZQHJt5SRgK154RtiA==",
-      "peer": true
+      "integrity": "sha512-NcV1JjO5oDzoK26oMzbILE6HW7uVXOHLQvHshBUW4UMdZGfiY6v5BeQwh9a9tCzv+CeefZQHJt5SRgK154RtiA=="
     },
     "@types/d3-interpolate": {
       "version": "3.0.4",
       "resolved": "https://registry.npmjs.org/@types/d3-interpolate/-/d3-interpolate-3.0.4.tgz",
       "integrity": "sha512-mgLPETlrpVV1YRJIglr4Ez47g7Yxjl1lj7YKsiMCb27VJH9W8NVM6Bb9d8kkpG/uAQS5AmbA48q2IAolKKo1MA==",
-      "peer": true,
       "requires": {
         "@types/d3-color": "*"
       }
@@ -55631,14 +55725,12 @@
     "@types/d3-path": {
       "version": "3.1.1",
       "resolved": "https://registry.npmjs.org/@types/d3-path/-/d3-path-3.1.1.tgz",
-      "integrity": "sha512-VMZBYyQvbGmWyWVea0EHs/BwLgxc+MKi1zLDCONksozI4YJMcTt8ZEuIR4Sb1MMTE8MMW49v0IwI5+b7RmfWlg==",
-      "peer": true
+      "integrity": "sha512-VMZBYyQvbGmWyWVea0EHs/BwLgxc+MKi1zLDCONksozI4YJMcTt8ZEuIR4Sb1MMTE8MMW49v0IwI5+b7RmfWlg=="
     },
     "@types/d3-scale": {
       "version": "4.0.9",
       "resolved": "https://registry.npmjs.org/@types/d3-scale/-/d3-scale-4.0.9.tgz",
       "integrity": "sha512-dLmtwB8zkAeO/juAMfnV+sItKjlsw2lKdZVVy6LRr0cBmegxSABiLEpGVmSJJ8O08i4+sGR6qQtb6WtuwJdvVw==",
-      "peer": true,
       "requires": {
         "@types/d3-time": "*"
       }
@@ -55647,7 +55739,6 @@
       "version": "3.1.8",
       "resolved": "https://registry.npmjs.org/@types/d3-shape/-/d3-shape-3.1.8.tgz",
       "integrity": "sha512-lae0iWfcDeR7qt7rA88BNiqdvPS5pFVPpo5OfjElwNaT2yyekbM0C9vK+yqBqEmHr6lDkRnYNoTBYlAgJa7a4w==",
-      "peer": true,
       "requires": {
         "@types/d3-path": "*"
       }
@@ -55655,14 +55746,12 @@
     "@types/d3-time": {
       "version": "3.0.4",
       "resolved": "https://registry.npmjs.org/@types/d3-time/-/d3-time-3.0.4.tgz",
-      "integrity": "sha512-yuzZug1nkAAaBlBBikKZTgzCeA+k1uy4ZFwWANOfKw5z5LRhV0gNA7gNkKm7HoK+HRN0wX3EkxGk0fpbWhmB7g==",
-      "peer": true
+      "integrity": "sha512-yuzZug1nkAAaBlBBikKZTgzCeA+k1uy4ZFwWANOfKw5z5LRhV0gNA7gNkKm7HoK+HRN0wX3EkxGk0fpbWhmB7g=="
     },
     "@types/d3-timer": {
       "version": "3.0.2",
       "resolved": "https://registry.npmjs.org/@types/d3-timer/-/d3-timer-3.0.2.tgz",
-      "integrity": "sha512-Ps3T8E8dZDam6fUyNiMkekK3XUsaUEik+idO9/YjPtfj2qruF8tFBXS7XhtE4iIXBLxhmLjP3SXpLhVf21I9Lw==",
-      "peer": true
+      "integrity": "sha512-Ps3T8E8dZDam6fUyNiMkekK3XUsaUEik+idO9/YjPtfj2qruF8tFBXS7XhtE4iIXBLxhmLjP3SXpLhVf21I9Lw=="
     },
     "@types/dayjs-precise-range": {
       "version": "1.0.5",
@@ -55705,6 +55794,7 @@
       "version": "4.17.13",
       "resolved": "https://registry.npmjs.org/@types/express/-/express-4.17.13.tgz",
       "integrity": "sha512-6bSZTPaTIACxn48l50SR+axgrqm6qXFIxrdAKaG6PaJk3+zuUr35hBlgT7vOmJcum+OEaIBLtHV/qloEAFITeA==",
+      "peer": true,
       "requires": {
         "@types/body-parser": "*",
         "@types/express-serve-static-core": "^4.17.18",
@@ -55895,7 +55985,8 @@
     "@types/node": {
       "version": "18.15.13",
       "resolved": "https://registry.npmjs.org/@types/node/-/node-18.15.13.tgz",
-      "integrity": "sha512-N+0kuo9KgrUQ1Sn/ifDXsvg0TTleP7rIy4zOBGECxAljqvqfqpTfzx0Q1NUedOixRMBfe2Whhb056a42cWs26Q=="
+      "integrity": "sha512-N+0kuo9KgrUQ1Sn/ifDXsvg0TTleP7rIy4zOBGECxAljqvqfqpTfzx0Q1NUedOixRMBfe2Whhb056a42cWs26Q==",
+      "peer": true
     },
     "@types/node-fetch": {
       "version": "2.6.4",
@@ -55967,6 +56058,7 @@
       "version": "17.0.2",
       "resolved": "https://registry.npmjs.org/@types/react/-/react-17.0.2.tgz",
       "integrity": "sha512-Xt40xQsrkdvjn1EyWe1Bc0dJLcil/9x2vAuW7ya+PuQip4UYUaXyhzWmAbwRsdMgwOFHpfp7/FFZebDU6Y8VHA==",
+      "peer": true,
       "requires": {
         "@types/prop-types": "*",
         "csstype": "^3.0.2"
@@ -55984,7 +56076,6 @@
       "version": "4.4.12",
       "resolved": "https://registry.npmjs.org/@types/react-transition-group/-/react-transition-group-4.4.12.tgz",
       "integrity": "sha512-8TV6R3h2j7a91c+1DXdJi3Syo69zzIZbz7Lg5tORM5LEJG7X/E6a1V3drRyBRZq7/utz7A+c4OgYLiLcYGHG6w==",
-      "peer": true,
       "requires": {}
     },
     "@types/responselike": {
@@ -56122,8 +56213,7 @@
     "@types/use-sync-external-store": {
       "version": "0.0.3",
       "resolved": "https://registry.npmjs.org/@types/use-sync-external-store/-/use-sync-external-store-0.0.3.tgz",
-      "integrity": "sha512-EwmlvuaxPNej9+T4v5AuBPJa2x2UOJVdjCtDHgcDqitUeOtjnJKJ+apYjVcAoBEMjKW1VVFGZLUb5+qqa09XFA==",
-      "peer": true
+      "integrity": "sha512-EwmlvuaxPNej9+T4v5AuBPJa2x2UOJVdjCtDHgcDqitUeOtjnJKJ+apYjVcAoBEMjKW1VVFGZLUb5+qqa09XFA=="
     },
     "@types/validator": {
       "version": "13.7.2",
@@ -56236,6 +56326,7 @@
       "resolved": "https://registry.npmjs.org/@typescript-eslint/parser/-/parser-6.11.0.tgz",
       "integrity": "sha512-+whEdjk+d5do5nxfxx73oanLL9ghKO3EwM9kBCkUtWMRwWuPaFv9ScuqlYfQ6pAD6ZiJhky7TZ2ZYhrMsfMxVQ==",
       "dev": true,
+      "peer": true,
       "requires": {
         "@typescript-eslint/scope-manager": "6.11.0",
         "@typescript-eslint/types": "6.11.0",
@@ -56505,6 +56596,106 @@
         "eslint-visitor-keys": "^2.0.0"
       }
     },
+    "@typescript/typescript-aix-ppc64": {
+      "version": "https://registry.npmjs.org/@typescript/typescript-aix-ppc64/-/typescript-aix-ppc64-7.0.2.tgz",
+      "integrity": "sha512-MTKKkWB7p/0E9xi1d1tHtZ5PiLkGEMIq88pK2CubZjOsLtYTLqhgIgi6zepFa+9GHZ6h05NMCkQxGKiPXMxXtQ==",
+      "optional": true
+    },
+    "@typescript/typescript-darwin-arm64": {
+      "version": "https://registry.npmjs.org/@typescript/typescript-darwin-arm64/-/typescript-darwin-arm64-7.0.2.tgz",
+      "integrity": "sha512-gowzar9MwS/aRWp6f3a4KUqzRjAZjOsmGNCM6LcTgXum+dBfgsBVMN+AgvOCCbguXyick6LJhpBszxMebJ8syA==",
+      "optional": true
+    },
+    "@typescript/typescript-darwin-x64": {
+      "version": "https://registry.npmjs.org/@typescript/typescript-darwin-x64/-/typescript-darwin-x64-7.0.2.tgz",
+      "integrity": "sha512-SZ9xZInqApNlNGc9s0W1VSsktYSOe9cFqNOIqmN1Gs8SmkjKZYFt017G4VwPxASInODuAdbTW7sXiFUf893RgA==",
+      "optional": true
+    },
+    "@typescript/typescript-freebsd-arm64": {
+      "version": "https://registry.npmjs.org/@typescript/typescript-freebsd-arm64/-/typescript-freebsd-arm64-7.0.2.tgz",
+      "integrity": "sha512-W5NH4y/J0plIIS5b2xvTEkU7JFxyqdMAOgf+Ilhl0vHQXKO5dZoxd+C/jEtq56c4F3wk71RB4BMRQ2XdI+bwYQ==",
+      "optional": true
+    },
+    "@typescript/typescript-freebsd-x64": {
+      "version": "https://registry.npmjs.org/@typescript/typescript-freebsd-x64/-/typescript-freebsd-x64-7.0.2.tgz",
+      "integrity": "sha512-UMGDx5sTpzNw3WiPebH7l90IWfJggEd+egHt/q6p7/Cm3zqoV7VxkGXt+3DxPIw8CcmvAB0j3sVVfbhX+M4Tpw==",
+      "optional": true
+    },
+    "@typescript/typescript-linux-arm": {
+      "version": "https://registry.npmjs.org/@typescript/typescript-linux-arm/-/typescript-linux-arm-7.0.2.tgz",
+      "integrity": "sha512-gffT3xPz9sR7j/YJExkyPntrI0P2EP9XbOyWzth2/Gs0RstK+90RBcO0ncXoXy/beYll1SXw846Nf2zdnEz0QQ==",
+      "optional": true
+    },
+    "@typescript/typescript-linux-arm64": {
+      "version": "https://registry.npmjs.org/@typescript/typescript-linux-arm64/-/typescript-linux-arm64-7.0.2.tgz",
+      "integrity": "sha512-Qh4eU4/y3yDjnfjjyPYihMj5/ODIlmt+Bzu17OI+fiSRDW57QmU5SiN63exPRNJPKUzcc1INa1NXdrJ+MqHjUQ==",
+      "optional": true
+    },
+    "@typescript/typescript-linux-loong64": {
+      "version": "https://registry.npmjs.org/@typescript/typescript-linux-loong64/-/typescript-linux-loong64-7.0.2.tgz",
+      "integrity": "sha512-uEHck9i8hoAzXPiYRib1O7miOnz23SxIeVl6F4LXox+qov1K35jHcEW6VHKvZI+pyvl7fZEP4MCU5LYvIq1GuQ==",
+      "optional": true
+    },
+    "@typescript/typescript-linux-mips64el": {
+      "version": "https://registry.npmjs.org/@typescript/typescript-linux-mips64el/-/typescript-linux-mips64el-7.0.2.tgz",
+      "integrity": "sha512-R4KvAMnE43W5Qeqb0Ly56O3mWMWIAgsMyz36DCaycd5nbg/9kzm0liw3JocfRqyJY0KPmzFjbswozXyW0DnIYA==",
+      "optional": true
+    },
+    "@typescript/typescript-linux-ppc64": {
+      "version": "https://registry.npmjs.org/@typescript/typescript-linux-ppc64/-/typescript-linux-ppc64-7.0.2.tgz",
+      "integrity": "sha512-DORx5b3sd/4S7eayxm4FQv+A7CrkUIGRaHiwI8oiHTAI1fAPWhF4J0vAlkC8biAlHSVVwxMQ3tjZ2/DVbnQiiA==",
+      "optional": true
+    },
+    "@typescript/typescript-linux-riscv64": {
+      "version": "https://registry.npmjs.org/@typescript/typescript-linux-riscv64/-/typescript-linux-riscv64-7.0.2.tgz",
+      "integrity": "sha512-wf0jqEDOjrPRnKwYRyyJDRo11KMbvMFrU+q4zqKyChODBzvlkbhNQfKvLxQCcwTpdDaXSHZTVuh0JoCrKCUMHQ==",
+      "optional": true
+    },
+    "@typescript/typescript-linux-s390x": {
+      "version": "https://registry.npmjs.org/@typescript/typescript-linux-s390x/-/typescript-linux-s390x-7.0.2.tgz",
+      "integrity": "sha512-IkwJc3L7yhytWd/ewjyxNDfOmswCm9GWMJT/ue/dU4aZNbwZeYAetq42VyLmsmSjvoX7z74X6ZaYCtzAr0EuGw==",
+      "optional": true
+    },
+    "@typescript/typescript-linux-x64": {
+      "version": "https://registry.npmjs.org/@typescript/typescript-linux-x64/-/typescript-linux-x64-7.0.2.tgz",
+      "integrity": "sha512-EYdf2cNg7rgCWJnxCdJ+F3V39O8ihb37eHAu1LK8oAFizgTQbPOK7zHHXbPt8rX24COqODXeI3sIf0fCXG7H/A==",
+      "optional": true
+    },
+    "@typescript/typescript-netbsd-arm64": {
+      "version": "https://registry.npmjs.org/@typescript/typescript-netbsd-arm64/-/typescript-netbsd-arm64-7.0.2.tgz",
+      "integrity": "sha512-+polYF4MF04aPpO5FTkHran9yUQDSXqy5GiSDKpsll5jy3l3+g9QLhpf39T+ePtefhXLOGrLl0QIjkQP6VnelA==",
+      "optional": true
+    },
+    "@typescript/typescript-netbsd-x64": {
+      "version": "https://registry.npmjs.org/@typescript/typescript-netbsd-x64/-/typescript-netbsd-x64-7.0.2.tgz",
+      "integrity": "sha512-8YIT0EHM/3dq10ZOVF/A7pc/YSMtbcecct4rWtexrnSCHOPcpC2KTLXfTCR6vDpnSiY12heNb1GiN/wu+T/FyA==",
+      "optional": true
+    },
+    "@typescript/typescript-openbsd-arm64": {
+      "version": "https://registry.npmjs.org/@typescript/typescript-openbsd-arm64/-/typescript-openbsd-arm64-7.0.2.tgz",
+      "integrity": "sha512-APT8+ClYnuYm1u9+kgGXoMj2VzWzcymwh2gNSQVySHfkRDGOTVkoWLjCmOQSaO+PoqQ57B0flRp9SA+7GnnkzQ==",
+      "optional": true
+    },
+    "@typescript/typescript-openbsd-x64": {
+      "version": "https://registry.npmjs.org/@typescript/typescript-openbsd-x64/-/typescript-openbsd-x64-7.0.2.tgz",
+      "integrity": "sha512-yX7s+Q0Dln0Dt9tEzZsAjXXR/+ytBM7AlglaqyeMPxQszJ1JhlJdZ6jLA+IzldHtflX81em7lDao1xXu+aRRkg==",
+      "optional": true
+    },
+    "@typescript/typescript-sunos-x64": {
+      "version": "https://registry.npmjs.org/@typescript/typescript-sunos-x64/-/typescript-sunos-x64-7.0.2.tgz",
+      "integrity": "sha512-dLJDGaLZ1D4HPQn62u1n8mBDkJREwMsAkCdkwd4Ieqw+x3TUyTsqY0YiBCtE6H6OzzgGk3iuZ3vFWRS+E8/d1g==",
+      "optional": true
+    },
+    "@typescript/typescript-win32-arm64": {
+      "version": "https://registry.npmjs.org/@typescript/typescript-win32-arm64/-/typescript-win32-arm64-7.0.2.tgz",
+      "integrity": "sha512-Gyl1Vy6OsWesLzmq+EP0Fb7b4Nid5232AvcA2SFcdYreldpNtYFFofPjnt62y9hQy7VTaZp65ICJjuAQRaVcIQ==",
+      "optional": true
+    },
+    "@typescript/typescript-win32-x64": {
+      "version": "https://registry.npmjs.org/@typescript/typescript-win32-x64/-/typescript-win32-x64-7.0.2.tgz",
+      "integrity": "sha512-0BQ3HkAHHlKLSp1qRvf3SUhGpGsDuhB/jgFw75guyqbxJqEaS0Cw/VFO8i2nHglJUzQCRtMMR/IBAKE3ETMC4g==",
+      "optional": true
+    },
     "@vercel/webpack-asset-relocator-loader": {
       "version": "1.7.2",
       "resolved": "https://registry.npmjs.org/@vercel/webpack-asset-relocator-loader/-/webpack-asset-relocator-loader-1.7.2.tgz",
@@ -56521,6 +56712,7 @@
       "version": "2.22.1",
       "resolved": "https://registry.npmjs.org/@wagmi/core/-/core-2.22.1.tgz",
       "integrity": "sha512-cG/xwQWsBEcKgRTkQVhH29cbpbs/TdcUJVFXCyri3ZknxhMyGv0YEjTcrNpRgt2SaswL1KrvslSNYKKo+5YEAg==",
+      "peer": true,
       "requires": {
         "eventemitter3": "5.0.1",
         "mipd": "0.0.7",
@@ -56589,6 +56781,7 @@
       "version": "2.21.1",
       "resolved": "https://registry.npmjs.org/@walletconnect/ethereum-provider/-/ethereum-provider-2.21.1.tgz",
       "integrity": "sha512-SSlIG6QEVxClgl1s0LMk4xr2wg4eT3Zn/Hb81IocyqNSGfXpjtawWxKxiC5/9Z95f1INyBD6MctJbL/R1oBwIw==",
+      "peer": true,
       "requires": {
         "@reown/appkit": "1.7.8",
         "@walletconnect/jsonrpc-http-connection": "1.0.8",
@@ -56808,6 +57001,7 @@
               "version": "8.18.0",
               "resolved": "https://registry.npmjs.org/ws/-/ws-8.18.0.tgz",
               "integrity": "sha512-8VbfWfHLbbwu3+N6OKsOMpBdT4kXPDDB9cJk2bJ6mh9ucxdlnNvH1e+roYkKmN9Nxw2yjz7VzeO9oOz2zJ04Pw==",
+              "peer": true,
               "requires": {}
             }
           }
@@ -56996,6 +57190,7 @@
               "version": "8.18.0",
               "resolved": "https://registry.npmjs.org/ws/-/ws-8.18.0.tgz",
               "integrity": "sha512-8VbfWfHLbbwu3+N6OKsOMpBdT4kXPDDB9cJk2bJ6mh9ucxdlnNvH1e+roYkKmN9Nxw2yjz7VzeO9oOz2zJ04Pw==",
+              "peer": true,
               "requires": {}
             }
           }
@@ -57223,6 +57418,7 @@
               "version": "8.18.0",
               "resolved": "https://registry.npmjs.org/ws/-/ws-8.18.0.tgz",
               "integrity": "sha512-8VbfWfHLbbwu3+N6OKsOMpBdT4kXPDDB9cJk2bJ6mh9ucxdlnNvH1e+roYkKmN9Nxw2yjz7VzeO9oOz2zJ04Pw==",
+              "peer": true,
               "requires": {}
             }
           }
@@ -57412,6 +57608,7 @@
               "version": "8.18.0",
               "resolved": "https://registry.npmjs.org/ws/-/ws-8.18.0.tgz",
               "integrity": "sha512-8VbfWfHLbbwu3+N6OKsOMpBdT4kXPDDB9cJk2bJ6mh9ucxdlnNvH1e+roYkKmN9Nxw2yjz7VzeO9oOz2zJ04Pw==",
+              "peer": true,
               "requires": {}
             }
           }
@@ -58200,6 +58397,7 @@
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/abort-controller/-/abort-controller-3.0.0.tgz",
       "integrity": "sha512-h8lQ8tacZYnR3vNQTgibj+tODHI5/+l06Au2Pcriv/Gmet0eaj4TwWH41sO9wnHDiQsEj19q0drzdWdeAHtweg==",
+      "peer": true,
       "requires": {
         "event-target-shim": "^5.0.0"
       }
@@ -58221,7 +58419,8 @@
     "acorn": {
       "version": "8.11.3",
       "resolved": "https://registry.npmjs.org/acorn/-/acorn-8.11.3.tgz",
-      "integrity": "sha512-Y9rRfJG5jcKOE0CLisYbojUjIrIEE7AGMzA/Sm4BslANhbS+cDMpgBdcPT91oJ7OuJ9hYJBx59RjbhxVnrF8Xg=="
+      "integrity": "sha512-Y9rRfJG5jcKOE0CLisYbojUjIrIEE7AGMzA/Sm4BslANhbS+cDMpgBdcPT91oJ7OuJ9hYJBx59RjbhxVnrF8Xg==",
+      "peer": true
     },
     "acorn-import-assertions": {
       "version": "1.9.0",
@@ -58282,6 +58481,7 @@
       "version": "6.12.6",
       "resolved": "https://registry.npmjs.org/ajv/-/ajv-6.12.6.tgz",
       "integrity": "sha512-j3fVLgvTo527anyYyJOGTYJbG+vnnQYvE0m5mmkc1TK+nxAppkCLMIL0aZ4dblVCNoGShhm+kzE4ZUykBoMg4g==",
+      "peer": true,
       "requires": {
         "fast-deep-equal": "^3.1.1",
         "fast-json-stable-stringify": "^2.0.0",
@@ -58693,7 +58893,6 @@
       "version": "10.1.0",
       "resolved": "https://registry.npmjs.org/babel-eslint/-/babel-eslint-10.1.0.tgz",
       "integrity": "sha512-ifWaTHQ0ce+448CYop8AdrQiBsGrnC+bMgfyKFdi6EsPLTAWG+QfyDeM6OH+FmWnKvEq5NnBMLvlBUPKQZoDSg==",
-      "peer": true,
       "requires": {
         "@babel/code-frame": "^7.0.0",
         "@babel/parser": "^7.7.0",
@@ -58706,8 +58905,7 @@
         "eslint-visitor-keys": {
           "version": "1.3.0",
           "resolved": "https://registry.npmjs.org/eslint-visitor-keys/-/eslint-visitor-keys-1.3.0.tgz",
-          "integrity": "sha512-6J72N8UNa462wa/KFODt/PJ3IU60SDpC3QXC1Hjc1BXXpfL2C9R5+AU7jhe0F6GREqVMh4Juu+NY7xn+6dipUQ==",
-          "peer": true
+          "integrity": "sha512-6J72N8UNa462wa/KFODt/PJ3IU60SDpC3QXC1Hjc1BXXpfL2C9R5+AU7jhe0F6GREqVMh4Juu+NY7xn+6dipUQ=="
         }
       }
     },
@@ -58955,8 +59153,7 @@
     "balloon-css": {
       "version": "0.5.2",
       "resolved": "https://registry.npmjs.org/balloon-css/-/balloon-css-0.5.2.tgz",
-      "integrity": "sha512-zheJpzwyNrG4t39vusA67v3BYg1HTVXOF8cErPEHzWK88PEOFwgo6Ea9VHOgOWNMgeuOtFVtB73NE2NWl9uDyQ==",
-      "peer": true
+      "integrity": "sha512-zheJpzwyNrG4t39vusA67v3BYg1HTVXOF8cErPEHzWK88PEOFwgo6Ea9VHOgOWNMgeuOtFVtB73NE2NWl9uDyQ=="
     },
     "base-x": {
       "version": "3.0.9",
@@ -59229,6 +59426,7 @@
       "version": "4.28.4",
       "resolved": "https://registry.npmjs.org/browserslist/-/browserslist-4.28.4.tgz",
       "integrity": "sha512-MTc8i/x9jBQd1iMw2CFGS+rwMa07eYjLR0CCTLDACl9xhxy+nIs3KeML/biicXtk9JrZ6dnnTatmc7ErPXIxqw==",
+      "peer": true,
       "requires": {
         "baseline-browser-mapping": "^2.10.38",
         "caniuse-lite": "^1.0.30001799",
@@ -59317,6 +59515,7 @@
       "version": "4.1.0",
       "resolved": "https://registry.npmjs.org/bufferutil/-/bufferutil-4.1.0.tgz",
       "integrity": "sha512-ZMANVnAixE6AWWnPzlW2KpUrxhm9woycYvPOo67jWHyFowASTEd9s+QN1EIMsSDtwhIxN4sWE1jotpuDUIgyIw==",
+      "peer": true,
       "requires": {
         "node-gyp-build": "^4.3.0"
       }
@@ -59346,7 +59545,6 @@
       "version": "3.3.4",
       "resolved": "https://registry.npmjs.org/c12/-/c12-3.3.4.tgz",
       "integrity": "sha512-cM0ApFQSBXuourJejzwv/AuPRvAxordTyParRVcHjjtXirtkzM0uK2L9TTn9s0cXZbG7E55jCivRQzoxYmRAlA==",
-      "peer": true,
       "requires": {
         "chokidar": "^5.0.0",
         "confbox": "^0.2.4",
@@ -59366,7 +59564,6 @@
           "version": "5.0.0",
           "resolved": "https://registry.npmjs.org/chokidar/-/chokidar-5.0.0.tgz",
           "integrity": "sha512-TQMmc3w+5AxjpL8iIiwebF73dRDF4fBIieAqGn9RGCWaEVwQ6Fb2cGe31Yns0RRIzii5goJ1Y7xbMwo1TxMplw==",
-          "peer": true,
           "requires": {
             "readdirp": "^5.0.0"
           }
@@ -59374,14 +59571,12 @@
         "dotenv": {
           "version": "17.4.2",
           "resolved": "https://registry.npmjs.org/dotenv/-/dotenv-17.4.2.tgz",
-          "integrity": "sha512-nI4U3TottKAcAD9LLud4Cb7b2QztQMUEfHbvhTH09bqXTxnSie8WnjPALV/WMCrJZ6UV/qHJ6L03OqO3LcdYZw==",
-          "peer": true
+          "integrity": "sha512-nI4U3TottKAcAD9LLud4Cb7b2QztQMUEfHbvhTH09bqXTxnSie8WnjPALV/WMCrJZ6UV/qHJ6L03OqO3LcdYZw=="
         },
         "readdirp": {
           "version": "5.0.0",
           "resolved": "https://registry.npmjs.org/readdirp/-/readdirp-5.0.0.tgz",
-          "integrity": "sha512-9u/XQ1pvrQtYyMpZe7DXKv2p5CNvyVwzUB6uhLAnQwHMSgKMBR62lc7AHljaeteeHXn11XTAaLLUVZYVZyuRBQ==",
-          "peer": true
+          "integrity": "sha512-9u/XQ1pvrQtYyMpZe7DXKv2p5CNvyVwzUB6uhLAnQwHMSgKMBR62lc7AHljaeteeHXn11XTAaLLUVZYVZyuRBQ=="
         }
       }
     },
@@ -59920,8 +60115,7 @@
     "classnames": {
       "version": "2.5.1",
       "resolved": "https://registry.npmjs.org/classnames/-/classnames-2.5.1.tgz",
-      "integrity": "sha512-saHYOzhIQs6wy2sVxTM6bUDsQO4F50V9RQ22qBpEdCW+I+/Wmke2HOl6lS6dTpdxVhb88/I6+Hs+438c3lfUow==",
-      "peer": true
+      "integrity": "sha512-saHYOzhIQs6wy2sVxTM6bUDsQO4F50V9RQ22qBpEdCW+I+/Wmke2HOl6lS6dTpdxVhb88/I6+Hs+438c3lfUow=="
     },
     "clean-css": {
       "version": "3.4.28",
@@ -60214,8 +60408,7 @@
     "color-support": {
       "version": "1.1.3",
       "resolved": "https://registry.npmjs.org/color-support/-/color-support-1.1.3.tgz",
-      "integrity": "sha512-qiBjkpbMLO/HL68y+lh4q0/O1MZFj2RX6X/KmMa3+gJD3z+WwI1ZzDHysvqHGS3mP6mznPckpXmw1nI9cJjyRg==",
-      "peer": true
+      "integrity": "sha512-qiBjkpbMLO/HL68y+lh4q0/O1MZFj2RX6X/KmMa3+gJD3z+WwI1ZzDHysvqHGS3mP6mznPckpXmw1nI9cJjyRg=="
     },
     "colord": {
       "version": "2.9.2",
@@ -60366,8 +60559,7 @@
     "confbox": {
       "version": "0.2.4",
       "resolved": "https://registry.npmjs.org/confbox/-/confbox-0.2.4.tgz",
-      "integrity": "sha512-ysOGlgTFbN2/Y6Cg3Iye8YKulHw+R2fNXHrgSmXISQdMnomY6eNDprVdW9R5xBguEqI954+S6709UyiO7B+6OQ==",
-      "peer": true
+      "integrity": "sha512-ysOGlgTFbN2/Y6Cg3Iye8YKulHw+R2fNXHrgSmXISQdMnomY6eNDprVdW9R5xBguEqI954+S6709UyiO7B+6OQ=="
     },
     "configstore": {
       "version": "5.0.1",
@@ -60465,7 +60657,8 @@
     "core-js": {
       "version": "3.32.2",
       "resolved": "https://registry.npmjs.org/core-js/-/core-js-3.32.2.tgz",
-      "integrity": "sha512-pxXSw1mYZPDGvTQqEc5vgIb83jGQKFGYWY76z4a7weZXUolw3G+OvpZqSRcfYOoOVUQJYEPsWeQK8pKEnUtWxQ=="
+      "integrity": "sha512-pxXSw1mYZPDGvTQqEc5vgIb83jGQKFGYWY76z4a7weZXUolw3G+OvpZqSRcfYOoOVUQJYEPsWeQK8pKEnUtWxQ==",
+      "peer": true
     },
     "core-js-compat": {
       "version": "3.32.2",
@@ -60584,6 +60777,7 @@
       "version": "4.1.0",
       "resolved": "https://registry.npmjs.org/cross-fetch/-/cross-fetch-4.1.0.tgz",
       "integrity": "sha512-uKm5PU+MHTootlWEY+mZ4vvXoCn4fLQxT9dSc1sXVMSFkINTJVN8cAQROpwcKm8bJ/c7rgZVIBWzH5T78sNZZw==",
+      "peer": true,
       "requires": {
         "node-fetch": "^2.7.0"
       }
@@ -60659,8 +60853,7 @@
     "css-mediaquery": {
       "version": "0.1.2",
       "resolved": "https://registry.npmjs.org/css-mediaquery/-/css-mediaquery-0.1.2.tgz",
-      "integrity": "sha512-COtn4EROW5dBGlE/4PiKnh6rZpAPxDeFLaEEwt4i10jpDMFt2EhQGS79QmmrO+iKCHv0PU/HrOWEhijFd1x99Q==",
-      "peer": true
+      "integrity": "sha512-COtn4EROW5dBGlE/4PiKnh6rZpAPxDeFLaEEwt4i10jpDMFt2EhQGS79QmmrO+iKCHv0PU/HrOWEhijFd1x99Q=="
     },
     "css-minimizer-webpack-plugin": {
       "version": "2.0.0",
@@ -61164,7 +61357,6 @@
       "version": "3.2.4",
       "resolved": "https://registry.npmjs.org/d3-array/-/d3-array-3.2.4.tgz",
       "integrity": "sha512-tdQAmyA18i4J7wprpYq8ClcxZy3SC31QMeByyCFyRt7BVHdREQZ5lpzoe5mFEYZUWe+oq8HBvk9JjpibyEV4Jg==",
-      "peer": true,
       "requires": {
         "internmap": "1 - 2"
       }
@@ -61172,26 +61364,22 @@
     "d3-color": {
       "version": "3.1.0",
       "resolved": "https://registry.npmjs.org/d3-color/-/d3-color-3.1.0.tgz",
-      "integrity": "sha512-zg/chbXyeBtMQ1LbD/WSoW2DpC3I0mpmPdW+ynRTj/x2DAWYrIY7qeZIHidozwV24m4iavr15lNwIwLxRmOxhA==",
-      "peer": true
+      "integrity": "sha512-zg/chbXyeBtMQ1LbD/WSoW2DpC3I0mpmPdW+ynRTj/x2DAWYrIY7qeZIHidozwV24m4iavr15lNwIwLxRmOxhA=="
     },
     "d3-ease": {
       "version": "3.0.1",
       "resolved": "https://registry.npmjs.org/d3-ease/-/d3-ease-3.0.1.tgz",
-      "integrity": "sha512-wR/XK3D3XcLIZwpbvQwQ5fK+8Ykds1ip7A2Txe0yxncXSdq1L9skcG7blcedkOX+ZcgxGAmLX1FrRGbADwzi0w==",
-      "peer": true
+      "integrity": "sha512-wR/XK3D3XcLIZwpbvQwQ5fK+8Ykds1ip7A2Txe0yxncXSdq1L9skcG7blcedkOX+ZcgxGAmLX1FrRGbADwzi0w=="
     },
     "d3-format": {
       "version": "3.1.2",
       "resolved": "https://registry.npmjs.org/d3-format/-/d3-format-3.1.2.tgz",
-      "integrity": "sha512-AJDdYOdnyRDV5b6ArilzCPPwc1ejkHcoyFarqlPqT7zRYjhavcT3uSrqcMvsgh2CgoPbK3RCwyHaVyxYcP2Arg==",
-      "peer": true
+      "integrity": "sha512-AJDdYOdnyRDV5b6ArilzCPPwc1ejkHcoyFarqlPqT7zRYjhavcT3uSrqcMvsgh2CgoPbK3RCwyHaVyxYcP2Arg=="
     },
     "d3-interpolate": {
       "version": "3.0.1",
       "resolved": "https://registry.npmjs.org/d3-interpolate/-/d3-interpolate-3.0.1.tgz",
       "integrity": "sha512-3bYs1rOD33uo8aqJfKP3JWPAibgw8Zm2+L9vBKEHJ2Rg+viTR7o5Mmv5mZcieN+FRYaAOWX5SJATX6k1PWz72g==",
-      "peer": true,
       "requires": {
         "d3-color": "1 - 3"
       }
@@ -61199,14 +61387,12 @@
     "d3-path": {
       "version": "3.1.0",
       "resolved": "https://registry.npmjs.org/d3-path/-/d3-path-3.1.0.tgz",
-      "integrity": "sha512-p3KP5HCf/bvjBSSKuXid6Zqijx7wIfNW+J/maPs+iwR35at5JCbLUT0LzF1cnjbCHWhqzQTIN2Jpe8pRebIEFQ==",
-      "peer": true
+      "integrity": "sha512-p3KP5HCf/bvjBSSKuXid6Zqijx7wIfNW+J/maPs+iwR35at5JCbLUT0LzF1cnjbCHWhqzQTIN2Jpe8pRebIEFQ=="
     },
     "d3-scale": {
       "version": "4.0.2",
       "resolved": "https://registry.npmjs.org/d3-scale/-/d3-scale-4.0.2.tgz",
       "integrity": "sha512-GZW464g1SH7ag3Y7hXjf8RoUuAFIqklOAq3MRl4OaWabTFJY9PN/E1YklhXLh+OQ3fM9yS2nOkCoS+WLZ6kvxQ==",
-      "peer": true,
       "requires": {
         "d3-array": "2.10.0 - 3",
         "d3-format": "1 - 3",
@@ -61219,7 +61405,6 @@
       "version": "3.2.0",
       "resolved": "https://registry.npmjs.org/d3-shape/-/d3-shape-3.2.0.tgz",
       "integrity": "sha512-SaLBuwGm3MOViRq2ABk3eLoxwZELpH6zhl3FbAoJ7Vm1gofKx6El1Ib5z23NUEhF9AsGl7y+dzLe5Cw2AArGTA==",
-      "peer": true,
       "requires": {
         "d3-path": "^3.1.0"
       }
@@ -61228,7 +61413,6 @@
       "version": "3.1.0",
       "resolved": "https://registry.npmjs.org/d3-time/-/d3-time-3.1.0.tgz",
       "integrity": "sha512-VqKjzBLejbSMT4IgbmVgDjpkYrNWUYJnbCGo874u7MMKIWsILRX+OpX/gTk8MqjpT1A/c6HY2dCA77ZN0lkQ2Q==",
-      "peer": true,
       "requires": {
         "d3-array": "2 - 3"
       }
@@ -61237,7 +61421,6 @@
       "version": "4.1.0",
       "resolved": "https://registry.npmjs.org/d3-time-format/-/d3-time-format-4.1.0.tgz",
       "integrity": "sha512-dJxPBlzC7NugB2PDLwo9Q8JiTR3M3e4/XANkreKSUxF8vvXKqm1Yfq4Q5dl8budlunRVlUUaDUgFt7eA8D6NLg==",
-      "peer": true,
       "requires": {
         "d3-time": "1 - 3"
       }
@@ -61245,8 +61428,7 @@
     "d3-timer": {
       "version": "3.0.1",
       "resolved": "https://registry.npmjs.org/d3-timer/-/d3-timer-3.0.1.tgz",
-      "integrity": "sha512-ndfJ/JxxMd3nw31uyKoY2naivF+r29V+Lc0svZxe1JvvIRmi8hUsrMvdOwgS1o6uBHmiz91geQ0ylPP0aj1VUA==",
-      "peer": true
+      "integrity": "sha512-ndfJ/JxxMd3nw31uyKoY2naivF+r29V+Lc0svZxe1JvvIRmi8hUsrMvdOwgS1o6uBHmiz91geQ0ylPP0aj1VUA=="
     },
     "damerau-levenshtein": {
       "version": "1.0.8",
@@ -61282,7 +61464,6 @@
       "version": "3.2.3",
       "resolved": "https://registry.npmjs.org/dayzed/-/dayzed-3.2.3.tgz",
       "integrity": "sha512-qXTIKs+R6ydWwNo+X1wu3lUptyRSGoyY+ZzRcQSM0zUlaG+/Ei+bFjqbQm1T2oJ+WKNkTHURBcGsxnx9N+9kfA==",
-      "peer": true,
       "requires": {
         "@babel/runtime": "^7.6.2",
         "date-fns": "^2.0.0"
@@ -61292,7 +61473,6 @@
           "version": "2.30.0",
           "resolved": "https://registry.npmjs.org/date-fns/-/date-fns-2.30.0.tgz",
           "integrity": "sha512-fnULvOpxnC5/Vg3NCiWelDsLiUc9bRwAPs/+LfTLNvetFCtCTN+yQz15C/fs4AwX1R9K5GLtLfn8QW+dWisaAw==",
-          "peer": true,
           "requires": {
             "@babel/runtime": "^7.21.0"
           }
@@ -61396,6 +61576,7 @@
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/decentraland-crypto-fetch/-/decentraland-crypto-fetch-2.0.1.tgz",
       "integrity": "sha512-2IKu6Y4k/fle8bmU0b4zy7V1i1R0oCXtqlJumBXc4jwHUHKAcHDLD2YtgJFdd7JjsWQwf+t0DsKpzBCjQDKANg==",
+      "peer": true,
       "requires": {
         "@dcl/crypto": "^3.3.1",
         "core-js-pure": "^3.19.1"
@@ -61476,14 +61657,14 @@
       }
     },
     "decentraland-gatsby": {
-      "version": "8.4.6",
-      "resolved": "https://registry.npmjs.org/decentraland-gatsby/-/decentraland-gatsby-8.4.6.tgz",
-      "integrity": "sha512-V72OrZzLWOvEY/GC4a3GZBAnN+Y/wlPVhdU6IS9W5KHC8aYcWwSpTybBsBV7GVoc9H/c92z8sVC43IauHkz6Sw==",
+      "version": "8.4.8",
+      "resolved": "https://registry.npmjs.org/decentraland-gatsby/-/decentraland-gatsby-8.4.8.tgz",
+      "integrity": "sha512-OTpFvODinVrNEat/72guACSl4nddSkF7ZhbgexPslKh2ddRFoi1Z9N/z4w3DMG4tKn2RquRWjUHu4rg19V6c8Q==",
       "requires": {
         "@aws-sdk/client-ses": "^3.421.0",
         "@dcl/core-commons": "^0.10.0",
         "@dcl/crypto": "^3.4.3",
-        "@dcl/crypto-middleware": "^4.0.0",
+        "@dcl/crypto-middleware": "^5.1.0",
         "@dcl/feature-flags": "^1.2.0",
         "@dcl/http-server": "^2.1.0",
         "@dcl/schemas": "^26.0.0",
@@ -61699,7 +61880,6 @@
       "version": "7.2.0",
       "resolved": "https://registry.npmjs.org/decentraland-ui/-/decentraland-ui-7.2.0.tgz",
       "integrity": "sha512-0BcYFQYf2RQA+LUlhYnqNx052GVcdEdLgJgykfmL607W522njFivmNN5gkBKyz+pyal3mYuKN7g0mjG3N+6+lA==",
-      "peer": true,
       "requires": {
         "@dcl/schemas": "^26.0.0",
         "@dcl/ui-env": "^1.5.1",
@@ -61724,20 +61904,17 @@
         "@dcl/ui-env": {
           "version": "1.5.1",
           "resolved": "https://registry.npmjs.org/@dcl/ui-env/-/ui-env-1.5.1.tgz",
-          "integrity": "sha512-03cPMH3wrNK5bdDEoidnXIr0ZpGPe0ly8ObDNwik6PjXF+g2YBAbo5/jDUN0panddL6N6YnCJROP8NkZl/ThnQ==",
-          "peer": true
+          "integrity": "sha512-03cPMH3wrNK5bdDEoidnXIr0ZpGPe0ly8ObDNwik6PjXF+g2YBAbo5/jDUN0panddL6N6YnCJROP8NkZl/ThnQ=="
         },
         "mitt": {
           "version": "3.0.1",
           "resolved": "https://registry.npmjs.org/mitt/-/mitt-3.0.1.tgz",
-          "integrity": "sha512-vKivATfr97l2/QBCYAkXYDbrIWPM2IIKEl7YPhjCvKlG3kE2gm+uBo6nEXK3M5/Ffh/FLpKExzOQ3JJoJGFKBw==",
-          "peer": true
+          "integrity": "sha512-vKivATfr97l2/QBCYAkXYDbrIWPM2IIKEl7YPhjCvKlG3kE2gm+uBo6nEXK3M5/Ffh/FLpKExzOQ3JJoJGFKBw=="
         },
         "uuid": {
           "version": "9.0.1",
           "resolved": "https://registry.npmjs.org/uuid/-/uuid-9.0.1.tgz",
-          "integrity": "sha512-b+1eJOlsR9K8HJpow9Ok3fiWOWSIcIzXodvv0rQjVoOVNpWMpxf1wZNpt4y9h10odCNrqnYp1OBzRktckBe3sA==",
-          "peer": true
+          "integrity": "sha512-b+1eJOlsR9K8HJpow9Ok3fiWOWSIcIzXodvv0rQjVoOVNpWMpxf1wZNpt4y9h10odCNrqnYp1OBzRktckBe3sA=="
         }
       }
     },
@@ -61745,7 +61922,6 @@
       "version": "3.13.1",
       "resolved": "https://registry.npmjs.org/decentraland-ui2/-/decentraland-ui2-3.13.1.tgz",
       "integrity": "sha512-HU31iHeJXiM2pWQQHOR7BBUlkX0twrJ4IS5Op6BxtX2hpygsxpd1kwQ4gVQr9lH/FhN5JEUlZdZVa+MDGUlgrQ==",
-      "peer": true,
       "requires": {
         "@emotion/react": "11.14.0",
         "@emotion/styled": "11.14.0",
@@ -61765,7 +61941,6 @@
           "version": "1.4.0",
           "resolved": "https://registry.npmjs.org/@emotion/is-prop-valid/-/is-prop-valid-1.4.0.tgz",
           "integrity": "sha512-QgD4fyscGcbbKwJmqNvUMSE02OsHUa+lAWKdEUIJKgqe5IwRSKd7+KhibEWdaKwgjLj0DRSHA9biAIqGBk05lw==",
-          "peer": true,
           "requires": {
             "@emotion/memoize": "^0.9.0"
           }
@@ -61773,14 +61948,12 @@
         "@emotion/memoize": {
           "version": "0.9.0",
           "resolved": "https://registry.npmjs.org/@emotion/memoize/-/memoize-0.9.0.tgz",
-          "integrity": "sha512-30FAj7/EoJ5mwVPOWhAyCX+FPfMDrVecJAM+Iw9NRoSl4BBAQeqj4cApHHUXOVvIPgLVDsCFoz/hGD+5QQD1GQ==",
-          "peer": true
+          "integrity": "sha512-30FAj7/EoJ5mwVPOWhAyCX+FPfMDrVecJAM+Iw9NRoSl4BBAQeqj4cApHHUXOVvIPgLVDsCFoz/hGD+5QQD1GQ=="
         },
         "@emotion/styled": {
           "version": "11.14.0",
           "resolved": "https://registry.npmjs.org/@emotion/styled/-/styled-11.14.0.tgz",
           "integrity": "sha512-XxfOnXFffatap2IyCeJyNov3kiDQWoR08gPUQxvbL7fxKryGBKUZUkG6Hz48DZwVrJSVh9sJboyV1Ds4OW6SgA==",
-          "peer": true,
           "requires": {
             "@babel/runtime": "^7.18.3",
             "@emotion/babel-plugin": "^11.13.5",
@@ -61793,34 +61966,29 @@
         "date-fns": {
           "version": "3.6.0",
           "resolved": "https://registry.npmjs.org/date-fns/-/date-fns-3.6.0.tgz",
-          "integrity": "sha512-fRHTG8g/Gif+kSh50gaGEdToemgfj74aRX3swtiouboip5JDLAyDE9F11nHMIcvOaXeOC6D7SpNhi7uFyB7Uww==",
-          "peer": true
+          "integrity": "sha512-fRHTG8g/Gif+kSh50gaGEdToemgfj74aRX3swtiouboip5JDLAyDE9F11nHMIcvOaXeOC6D7SpNhi7uFyB7Uww=="
         },
         "mitt": {
           "version": "3.0.1",
           "resolved": "https://registry.npmjs.org/mitt/-/mitt-3.0.1.tgz",
-          "integrity": "sha512-vKivATfr97l2/QBCYAkXYDbrIWPM2IIKEl7YPhjCvKlG3kE2gm+uBo6nEXK3M5/Ffh/FLpKExzOQ3JJoJGFKBw==",
-          "peer": true
+          "integrity": "sha512-vKivATfr97l2/QBCYAkXYDbrIWPM2IIKEl7YPhjCvKlG3kE2gm+uBo6nEXK3M5/Ffh/FLpKExzOQ3JJoJGFKBw=="
         },
         "uuid": {
           "version": "11.1.0",
           "resolved": "https://registry.npmjs.org/uuid/-/uuid-11.1.0.tgz",
-          "integrity": "sha512-0/A9rDy9P7cJ+8w1c9WD9V//9Wj15Ce2MPz8Ri6032usz+NfePxx5AcN3bN+r6ZL6jEo066/yNYB3tn4pQEx+A==",
-          "peer": true
+          "integrity": "sha512-0/A9rDy9P7cJ+8w1c9WD9V//9Wj15Ce2MPz8Ri6032usz+NfePxx5AcN3bN+r6ZL6jEo066/yNYB3tn4pQEx+A=="
         }
       }
     },
     "decimal.js": {
       "version": "10.6.0",
       "resolved": "https://registry.npmjs.org/decimal.js/-/decimal.js-10.6.0.tgz",
-      "integrity": "sha512-YpgQiITW3JXGntzdUmyUR1V812Hn8T1YVXhCu+wO3OpS4eU9l4YdD3qjyiKdV6mvV29zapkMeD390UVEf2lkUg==",
-      "peer": true
+      "integrity": "sha512-YpgQiITW3JXGntzdUmyUR1V812Hn8T1YVXhCu+wO3OpS4eU9l4YdD3qjyiKdV6mvV29zapkMeD390UVEf2lkUg=="
     },
     "decimal.js-light": {
       "version": "2.5.1",
       "resolved": "https://registry.npmjs.org/decimal.js-light/-/decimal.js-light-2.5.1.tgz",
-      "integrity": "sha512-qIMFpTMZmny+MMIitAB6D7iVPEorVw6YQRWkvarTkT4tBeSLLiHzcwj6q0MmYSFCiVpiqPJTJEYIrpcPzVEIvg==",
-      "peer": true
+      "integrity": "sha512-qIMFpTMZmny+MMIitAB6D7iVPEorVw6YQRWkvarTkT4tBeSLLiHzcwj6q0MmYSFCiVpiqPJTJEYIrpcPzVEIvg=="
     },
     "decode-named-character-reference": {
       "version": "1.0.1",
@@ -61847,7 +62015,6 @@
       "version": "2.2.3",
       "resolved": "https://registry.npmjs.org/deep-equal/-/deep-equal-2.2.3.tgz",
       "integrity": "sha512-ZIwpnevOurS8bpT4192sqAowWM76JDKSHYzMLty3BZGSswgq6pBaH3DhCSW5xVAZICZyKdOBPjwww5wfgT/6PA==",
-      "peer": true,
       "requires": {
         "array-buffer-byte-length": "^1.0.0",
         "call-bind": "^1.0.5",
@@ -61872,8 +62039,7 @@
         "isarray": {
           "version": "2.0.5",
           "resolved": "https://registry.npmjs.org/isarray/-/isarray-2.0.5.tgz",
-          "integrity": "sha512-xHjhDr3cNBK0BzdUJSPXZntQUx/mwMS5Rw4A7lPJ90XGAO6ISP/ePDNuo0vhqOZU+UD5JoodwCAAoZQd3FeAKw==",
-          "peer": true
+          "integrity": "sha512-xHjhDr3cNBK0BzdUJSPXZntQUx/mwMS5Rw4A7lPJ90XGAO6ISP/ePDNuo0vhqOZU+UD5JoodwCAAoZQd3FeAKw=="
         }
       }
     },
@@ -62219,7 +62385,6 @@
       "version": "5.2.1",
       "resolved": "https://registry.npmjs.org/dom-helpers/-/dom-helpers-5.2.1.tgz",
       "integrity": "sha512-nRCa7CK3VTrM2NmGkIy4cbK7IZlgBE/PYMn55rrXefr5xXDP0LdtfPnblFDoVdcAfslJ7or6iqAUnx0CCGIWQA==",
-      "peer": true,
       "requires": {
         "@babel/runtime": "^7.8.7",
         "csstype": "^3.0.2"
@@ -62253,8 +62418,7 @@
       "integrity": "sha512-BSKB+TSpMpFI/HOxCNr1O8aMOTZ8hT3pM3GQ0w/mWRmkhEDSFJkkyzz4XQsBV44BChwGkrDfMyjVD0eA2aFV3w=="
     },
     "domhandler": {
-      "version": "2.4.2",
-      "resolved": "https://registry.npmjs.org/domhandler/-/domhandler-2.4.2.tgz",
+      "version": "https://registry.npmjs.org/domhandler/-/domhandler-2.4.2.tgz",
       "integrity": "sha512-JiK04h0Ht5u/80fdLMCEmV4zkNh2BcoMFBmZ/91WtYZ8qVXSKjiw7fXMgFPnHcSZgOo3XdinHvmnDUeMf5R4wA==",
       "requires": {
         "domelementtype": "1"
@@ -62306,8 +62470,7 @@
     "dprop": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/dprop/-/dprop-1.0.0.tgz",
-      "integrity": "sha512-CNrGk9cBoRzsLtyGRTcjsYh0n63nLtnWelCV31DlEK/yftX05rLK7qb9et891DYLUwhadlh/lOxq7W/+8XA2pQ==",
-      "peer": true
+      "integrity": "sha512-CNrGk9cBoRzsLtyGRTcjsYh0n63nLtnWelCV31DlEK/yftX05rLK7qb9et891DYLUwhadlh/lOxq7W/+8XA2pQ=="
     },
     "drbg.js": {
       "version": "1.0.1",
@@ -62322,8 +62485,7 @@
     "dset": {
       "version": "3.1.4",
       "resolved": "https://registry.npmjs.org/dset/-/dset-3.1.4.tgz",
-      "integrity": "sha512-2QF/g9/zTaPDc3BjNcVTGoBbXBgYfMTTceLaYcFJ/W9kggFUkhxD/hMEeuLKbugyef9SqAx8cpgwlIP/jinUTA==",
-      "peer": true
+      "integrity": "sha512-2QF/g9/zTaPDc3BjNcVTGoBbXBgYfMTTceLaYcFJ/W9kggFUkhxD/hMEeuLKbugyef9SqAx8cpgwlIP/jinUTA=="
     },
     "dunder-proto": {
       "version": "1.0.1",
@@ -62374,6 +62536,7 @@
       "version": "0.4.18",
       "resolved": "https://registry.npmjs.org/eciesjs/-/eciesjs-0.4.18.tgz",
       "integrity": "sha512-wG99Zcfcys9fZux7Cft8BAX/YrOJLJSZ3jyYPfhZHqN2E+Ffx+QXBDsv3gubEgPtV6dTzJMSQUwk1H98/t/0wQ==",
+      "peer": true,
       "requires": {
         "@ecies/ciphers": "^0.2.5",
         "@noble/ciphers": "^1.3.0",
@@ -62463,6 +62626,7 @@
       "version": "0.1.13",
       "resolved": "https://registry.npmjs.org/encoding/-/encoding-0.1.13.tgz",
       "integrity": "sha512-ETBauow1T35Y/WZMkio9jiM0Z5xjHHmJ4XmjZOq1l/dXz3lr2sRn87nJy20RupqSh1F2m3HHPSp8ShIPQJrJ3A==",
+      "peer": true,
       "requires": {
         "iconv-lite": "^0.6.2"
       }
@@ -62663,7 +62827,6 @@
       "version": "1.1.3",
       "resolved": "https://registry.npmjs.org/es-get-iterator/-/es-get-iterator-1.1.3.tgz",
       "integrity": "sha512-sPZmqHBe6JIiTfN5q2pEi//TwxmAFHwj/XEuYjTuse78i8KxaqMTTzxPoFKuzRpDpTJ+0NAbpfenkmH2rePtuw==",
-      "peer": true,
       "requires": {
         "call-bind": "^1.0.2",
         "get-intrinsic": "^1.1.3",
@@ -62679,8 +62842,7 @@
         "isarray": {
           "version": "2.0.5",
           "resolved": "https://registry.npmjs.org/isarray/-/isarray-2.0.5.tgz",
-          "integrity": "sha512-xHjhDr3cNBK0BzdUJSPXZntQUx/mwMS5Rw4A7lPJ90XGAO6ISP/ePDNuo0vhqOZU+UD5JoodwCAAoZQd3FeAKw==",
-          "peer": true
+          "integrity": "sha512-xHjhDr3cNBK0BzdUJSPXZntQUx/mwMS5Rw4A7lPJ90XGAO6ISP/ePDNuo0vhqOZU+UD5JoodwCAAoZQd3FeAKw=="
         }
       }
     },
@@ -62801,6 +62963,7 @@
       "version": "8.15.0",
       "resolved": "https://registry.npmjs.org/eslint/-/eslint-8.15.0.tgz",
       "integrity": "sha512-GG5USZ1jhCu8HJkzGgeK8/+RGnHaNYZGrGDzUtigK3BsGESW/rs2az23XqE0WVwDxy1VRvvjSSGu5nB0Bu+6SA==",
+      "peer": true,
       "requires": {
         "@eslint/eslintrc": "^1.2.3",
         "@humanwhocodes/config-array": "^0.9.2",
@@ -62996,6 +63159,7 @@
       "version": "2.26.0",
       "resolved": "https://registry.npmjs.org/eslint-plugin-import/-/eslint-plugin-import-2.26.0.tgz",
       "integrity": "sha512-hYfi3FXaM8WPLf4S1cikh/r4IxnO6zrhZbEGz2b660EJRbuxgpDS5gkCuYgGWg2xxh2rBuIr4Pvhve/7c31koA==",
+      "peer": true,
       "requires": {
         "array-includes": "^3.1.4",
         "array.prototype.flat": "^1.2.5",
@@ -63026,6 +63190,7 @@
       "version": "6.6.1",
       "resolved": "https://registry.npmjs.org/eslint-plugin-jsx-a11y/-/eslint-plugin-jsx-a11y-6.6.1.tgz",
       "integrity": "sha512-sXgFVNHiWffBq23uiS/JaP6eVR622DqwB4yTzKvGZGcPq6/yZ3WmOZfuBks/vHWo9GaFOqC2ZK4i6+C35knx7Q==",
+      "peer": true,
       "requires": {
         "@babel/runtime": "^7.18.9",
         "aria-query": "^4.2.2",
@@ -63067,6 +63232,7 @@
       "version": "7.31.8",
       "resolved": "https://registry.npmjs.org/eslint-plugin-react/-/eslint-plugin-react-7.31.8.tgz",
       "integrity": "sha512-5lBTZmgQmARLLSYiwI71tiGVTLUuqXantZM6vlSY39OaDSV0M7+32K5DnLkmFrwTe+Ksz0ffuLUC91RUviVZfw==",
+      "peer": true,
       "requires": {
         "array-includes": "^3.1.5",
         "array.prototype.flatmap": "^1.3.0",
@@ -63117,6 +63283,7 @@
       "version": "4.6.0",
       "resolved": "https://registry.npmjs.org/eslint-plugin-react-hooks/-/eslint-plugin-react-hooks-4.6.0.tgz",
       "integrity": "sha512-oFc7Itz9Qxh2x4gNHStv3BqJq54ExXmfC+a1NjAta66IAN87Wu0R/QArgIS9qKzX3dXKPI9H5crl9QchNMY9+g==",
+      "peer": true,
       "requires": {}
     },
     "eslint-scope": {
@@ -63367,8 +63534,7 @@
     "ethereum-blockies": {
       "version": "0.1.1",
       "resolved": "https://registry.npmjs.org/ethereum-blockies/-/ethereum-blockies-0.1.1.tgz",
-      "integrity": "sha512-ED+noMZ6z7RrzzhvrQna1L30C27MX+ZsdB5c/d5vygXtHjEyAQjQS2TgCYhPxs+z3U+u2YQsL9PiRkNl1f+ugg==",
-      "peer": true
+      "integrity": "sha512-ED+noMZ6z7RrzzhvrQna1L30C27MX+ZsdB5c/d5vygXtHjEyAQjQS2TgCYhPxs+z3U+u2YQsL9PiRkNl1f+ugg=="
     },
     "ethereum-bloom-filters": {
       "version": "1.2.0",
@@ -63468,6 +63634,7 @@
       "version": "5.8.0",
       "resolved": "https://registry.npmjs.org/ethers/-/ethers-5.8.0.tgz",
       "integrity": "sha512-DUq+7fHrCg1aPDFCHx6UIPb3nmt2XMpM7Y/g2gLhsl3lIBqeAfOJIl1qEvRf2uq3BiKxmh6Fh5pfp2ieyek7Kg==",
+      "peer": true,
       "requires": {
         "@ethersproject/abi": "5.8.0",
         "@ethersproject/abstract-provider": "5.8.0",
@@ -63548,7 +63715,8 @@
     "eventemitter2": {
       "version": "6.4.9",
       "resolved": "https://registry.npmjs.org/eventemitter2/-/eventemitter2-6.4.9.tgz",
-      "integrity": "sha512-JEPTiaOt9f04oa6NOkc4aH+nVp5I3wEjpHbIPqfgCdD5v5bUzy7xQqwcVO2aDQgOWhI28da57HksMrzK9HlRxg=="
+      "integrity": "sha512-JEPTiaOt9f04oa6NOkc4aH+nVp5I3wEjpHbIPqfgCdD5v5bUzy7xQqwcVO2aDQgOWhI28da57HksMrzK9HlRxg==",
+      "peer": true
     },
     "eventemitter3": {
       "version": "4.0.7",
@@ -63613,8 +63781,7 @@
     "exenv": {
       "version": "1.2.2",
       "resolved": "https://registry.npmjs.org/exenv/-/exenv-1.2.2.tgz",
-      "integrity": "sha512-Z+ktTxTwv9ILfgKCk32OX3n/doe+OcLTRtqK9pcL+JsP3J1/VW8Uvl4ZjLlKqeW4rzK4oesDOGMEMRIZqtP4Iw==",
-      "peer": true
+      "integrity": "sha512-Z+ktTxTwv9ILfgKCk32OX3n/doe+OcLTRtqK9pcL+JsP3J1/VW8Uvl4ZjLlKqeW4rzK4oesDOGMEMRIZqtP4Iw=="
     },
     "exit": {
       "version": "0.1.2",
@@ -63639,6 +63806,7 @@
       "version": "4.22.2",
       "resolved": "https://registry.npmjs.org/express/-/express-4.22.2.tgz",
       "integrity": "sha512-IuL+Elrou2ZvCFHs18/CIzy2Nzvo25nZ1/D2eIZlz7c+QUayAcYoiM2BthCjs+EBHVpjYjcuLDAiCWgeIX3X1Q==",
+      "peer": true,
       "requires": {
         "accepts": "~1.3.8",
         "array-flatten": "1.1.1",
@@ -63748,8 +63916,7 @@
     "exsolve": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/exsolve/-/exsolve-1.1.0.tgz",
-      "integrity": "sha512-D+42+T12DdIlJM3uepa55qGiL3sYdLBOxIl2ifQCzCHz4c7eiolaHsi3BIqEr7JxBzxv2pYZQX9kw16ziMcEmw==",
-      "peer": true
+      "integrity": "sha512-D+42+T12DdIlJM3uepa55qGiL3sYdLBOxIl2ifQCzCHz4c7eiolaHsi3BIqEr7JxBzxv2pYZQX9kw16ziMcEmw=="
     },
     "ext": {
       "version": "1.6.0",
@@ -63828,8 +63995,7 @@
     "fast-equals": {
       "version": "5.4.0",
       "resolved": "https://registry.npmjs.org/fast-equals/-/fast-equals-5.4.0.tgz",
-      "integrity": "sha512-jt2DW/aNFNwke7AUd+Z+e6pz39KO5rzdbbFCg2sGafS4mk13MI7Z8O5z9cADNn5lhGODIgLwug6TZO2ctf7kcw==",
-      "peer": true
+      "integrity": "sha512-jt2DW/aNFNwke7AUd+Z+e6pz39KO5rzdbbFCg2sGafS4mk13MI7Z8O5z9cADNn5lhGODIgLwug6TZO2ctf7kcw=="
     },
     "fast-fifo": {
       "version": "1.3.2",
@@ -64212,8 +64378,7 @@
     "format-string-by-pattern": {
       "version": "1.2.2",
       "resolved": "https://registry.npmjs.org/format-string-by-pattern/-/format-string-by-pattern-1.2.2.tgz",
-      "integrity": "sha512-dYhtZGK/V7iif43UGjHu3ExGASwmoDdHPIejcVv/dYnCjtkzFl4XIXqKuzryj26DaXMAwvEQ3FUv09fROvgY/Q==",
-      "peer": true
+      "integrity": "sha512-dYhtZGK/V7iif43UGjHu3ExGASwmoDdHPIejcVv/dYnCjtkzFl4XIXqKuzryj26DaXMAwvEQ3FUv09fROvgY/Q=="
     },
     "formidable": {
       "version": "3.5.4",
@@ -64609,6 +64774,7 @@
           "version": "4.33.0",
           "resolved": "https://registry.npmjs.org/@typescript-eslint/parser/-/parser-4.33.0.tgz",
           "integrity": "sha512-ZohdsbXadjGBSK0/r+d87X0SBmKzOq4/S5nzK6SBgJspFo9/CUDJ7hjayuze+JK7CZQLDMroqytp7pOcFKTxZA==",
+          "peer": true,
           "requires": {
             "@typescript-eslint/scope-manager": "4.33.0",
             "@typescript-eslint/types": "4.33.0",
@@ -64717,6 +64883,7 @@
           "version": "7.32.0",
           "resolved": "https://registry.npmjs.org/eslint/-/eslint-7.32.0.tgz",
           "integrity": "sha512-VHZ8gX+EDfz+97jGcgyGCyRia/dPOd6Xh9yPv8Bl1+SoaIwD+a/vlrOmGRUyOYu7MwUhc7CxqeaDZU13S4+EpA==",
+          "peer": true,
           "requires": {
             "@babel/code-frame": "7.12.11",
             "@eslint/eslintrc": "^0.4.3",
@@ -64800,6 +64967,7 @@
           "version": "5.10.0",
           "resolved": "https://registry.npmjs.org/eslint-plugin-flowtype/-/eslint-plugin-flowtype-5.10.0.tgz",
           "integrity": "sha512-vcz32f+7TP+kvTUyMXZmCnNujBQZDNmcqPImw8b9PZ+16w1Qdm6ryRuYZYVaG9xRqqmAPr2Cs9FAX5gN+x/bjw==",
+          "peer": true,
           "requires": {
             "lodash": "^4.17.15",
             "string-natural-compare": "^3.0.1"
@@ -65644,7 +65812,6 @@
       "version": "4.14.0",
       "resolved": "https://registry.npmjs.org/get-tsconfig/-/get-tsconfig-4.14.0.tgz",
       "integrity": "sha512-yTb+8DXzDREzgvYmh6s9vHsSVCHeC0G3PI5bEXNBHtmshPnO+S5O7qgLEOn0I5QvMy6kpZN8K1NKGyilLb93wA==",
-      "peer": true,
       "requires": {
         "resolve-pkg-maps": "^1.0.0"
       }
@@ -65652,8 +65819,7 @@
     "giget": {
       "version": "3.3.0",
       "resolved": "https://registry.npmjs.org/giget/-/giget-3.3.0.tgz",
-      "integrity": "sha512-gzi2D96p+AMfDcmJHGDj3KJ9NRiwvlFAU5yfa3ROwWZmFUjX4P43x3BcyRaOMMLto1vUo7C+86+MFhYTl6Ryiw==",
-      "peer": true
+      "integrity": "sha512-gzi2D96p+AMfDcmJHGDj3KJ9NRiwvlFAU5yfa3ROwWZmFUjX4P43x3BcyRaOMMLto1vUo7C+86+MFhYTl6Ryiw=="
     },
     "git-up": {
       "version": "7.0.0",
@@ -65667,8 +65833,7 @@
     "gl-vec2": {
       "version": "1.3.0",
       "resolved": "https://registry.npmjs.org/gl-vec2/-/gl-vec2-1.3.0.tgz",
-      "integrity": "sha512-YiqaAuNsheWmUV0Sa8k94kBB0D6RWjwZztyO+trEYS8KzJ6OQB/4686gdrf59wld4hHFIvaxynO3nRxpk1Ij/A==",
-      "peer": true
+      "integrity": "sha512-YiqaAuNsheWmUV0Sa8k94kBB0D6RWjwZztyO+trEYS8KzJ6OQB/4686gdrf59wld4hHFIvaxynO3nRxpk1Ij/A=="
     },
     "glob": {
       "version": "7.2.3",
@@ -65806,7 +65971,8 @@
     "graphql": {
       "version": "15.8.0",
       "resolved": "https://registry.npmjs.org/graphql/-/graphql-15.8.0.tgz",
-      "integrity": "sha512-5gghUc24tP9HRznNpV2+FIoq3xKkj5dTQqf4v0CpdPbFVwFkWoxOM+o+2OC9ZSvjEMTjfmG9QT+gcvggTwW1zw=="
+      "integrity": "sha512-5gghUc24tP9HRznNpV2+FIoq3xKkj5dTQqf4v0CpdPbFVwFkWoxOM+o+2OC9ZSvjEMTjfmG9QT+gcvggTwW1zw==",
+      "peer": true
     },
     "graphql-compose": {
       "version": "9.0.8",
@@ -66232,8 +66398,7 @@
     "hyphenate-style-name": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/hyphenate-style-name/-/hyphenate-style-name-1.1.0.tgz",
-      "integrity": "sha512-WDC/ui2VVRrz3jOVi+XtjqkDjiVjTtFaAGiW37k6b+ohyQ5wYDOGkvCZa8+H0nx3gyvv0+BST9xuOgIyGQ00gw==",
-      "peer": true
+      "integrity": "sha512-WDC/ui2VVRrz3jOVi+XtjqkDjiVjTtFaAGiW37k6b+ohyQ5wYDOGkvCZa8+H0nx3gyvv0+BST9xuOgIyGQ00gw=="
     },
     "iconv-lite": {
       "version": "0.6.3",
@@ -66283,13 +66448,13 @@
     "immer": {
       "version": "9.0.15",
       "resolved": "https://registry.npmjs.org/immer/-/immer-9.0.15.tgz",
-      "integrity": "sha512-2eB/sswms9AEUSkOm4SbV5Y7Vmt/bKRwByd52jfLkW4OLYeaTP3EEiJ9agqU0O/tq6Dk62Zfj+TJSqfm1rLVGQ=="
+      "integrity": "sha512-2eB/sswms9AEUSkOm4SbV5Y7Vmt/bKRwByd52jfLkW4OLYeaTP3EEiJ9agqU0O/tq6Dk62Zfj+TJSqfm1rLVGQ==",
+      "peer": true
     },
     "impetus": {
       "version": "0.8.8",
       "resolved": "https://registry.npmjs.org/impetus/-/impetus-0.8.8.tgz",
-      "integrity": "sha512-7ejVjFxRAiBlnZQbdNGzUGgxMvLjVke/QNP2TFN/VK8baASsuRiE8YuSbD0qyiU8Pae+w95De4ZYz+rxSo5FJw==",
-      "peer": true
+      "integrity": "sha512-7ejVjFxRAiBlnZQbdNGzUGgxMvLjVke/QNP2TFN/VK8baASsuRiE8YuSbD0qyiU8Pae+w95De4ZYz+rxSo5FJw=="
     },
     "import-fresh": {
       "version": "3.3.0",
@@ -66433,8 +66598,7 @@
     "internmap": {
       "version": "2.0.3",
       "resolved": "https://registry.npmjs.org/internmap/-/internmap-2.0.3.tgz",
-      "integrity": "sha512-5Hh7Y1wQbvY5ooGgPbDaL5iYLAPzMTUrjMulskHLH6wnv/A+1q5rgEaiuqEjB+oxGXIVZs1FF+R/KPN3ZSQYYg==",
-      "peer": true
+      "integrity": "sha512-5Hh7Y1wQbvY5ooGgPbDaL5iYLAPzMTUrjMulskHLH6wnv/A+1q5rgEaiuqEjB+oxGXIVZs1FF+R/KPN3ZSQYYg=="
     },
     "intl-messageformat": {
       "version": "10.7.7",
@@ -66847,8 +67011,7 @@
     "is-in-ssh": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/is-in-ssh/-/is-in-ssh-1.0.0.tgz",
-      "integrity": "sha512-jYa6Q9rH90kR1vKB6NM7qqd1mge3Fx4Dhw5TVlK1MUBqhEOuCagrEHMevNuCcbECmXZ0ThXkRm+Ymr51HwEPAw==",
-      "peer": true
+      "integrity": "sha512-jYa6Q9rH90kR1vKB6NM7qqd1mge3Fx4Dhw5TVlK1MUBqhEOuCagrEHMevNuCcbECmXZ0ThXkRm+Ymr51HwEPAw=="
     },
     "is-inside-container": {
       "version": "1.0.0",
@@ -66928,8 +67091,7 @@
     "is-map": {
       "version": "2.0.3",
       "resolved": "https://registry.npmjs.org/is-map/-/is-map-2.0.3.tgz",
-      "integrity": "sha512-1Qed0/Hr2m+YqxnM09CjA2d/i6YZNfF6R2oRAOj36eUdS6qIV/huPJNSEpKbupewFs+ZsJlxsjjPbc0/afW6Lw==",
-      "peer": true
+      "integrity": "sha512-1Qed0/Hr2m+YqxnM09CjA2d/i6YZNfF6R2oRAOj36eUdS6qIV/huPJNSEpKbupewFs+ZsJlxsjjPbc0/afW6Lw=="
     },
     "is-negative-zero": {
       "version": "2.0.2",
@@ -67022,8 +67184,7 @@
     "is-set": {
       "version": "2.0.3",
       "resolved": "https://registry.npmjs.org/is-set/-/is-set-2.0.3.tgz",
-      "integrity": "sha512-iPAjerrse27/ygGLxw+EBR9agv9Y6uLeYVJMu+QNCoouJ1/1ri0mGrcWpfCqFZuzzx3WjtwxG098X+n4OuRkPg==",
-      "peer": true
+      "integrity": "sha512-iPAjerrse27/ygGLxw+EBR9agv9Y6uLeYVJMu+QNCoouJ1/1ri0mGrcWpfCqFZuzzx3WjtwxG098X+n4OuRkPg=="
     },
     "is-shared-array-buffer": {
       "version": "1.0.2",
@@ -67127,8 +67288,7 @@
     "is-weakmap": {
       "version": "2.0.2",
       "resolved": "https://registry.npmjs.org/is-weakmap/-/is-weakmap-2.0.2.tgz",
-      "integrity": "sha512-K5pXYOm9wqY1RgjpL3YTkF39tni1XajUIkawTLUo9EZEVUFga5gSQJF8nNS7ZwJQ02y+1YCNYcMh+HIf1ZqE+w==",
-      "peer": true
+      "integrity": "sha512-K5pXYOm9wqY1RgjpL3YTkF39tni1XajUIkawTLUo9EZEVUFga5gSQJF8nNS7ZwJQ02y+1YCNYcMh+HIf1ZqE+w=="
     },
     "is-weakref": {
       "version": "1.0.2",
@@ -67142,7 +67302,6 @@
       "version": "2.0.4",
       "resolved": "https://registry.npmjs.org/is-weakset/-/is-weakset-2.0.4.tgz",
       "integrity": "sha512-mfcwb6IzQyOKTs84CQMrOwW4gQcaTOAWJ0zzJCl2WSPDrWk/OzDaImWFH3djXhb24g4eudZfLRozAvPGw4d9hQ==",
-      "peer": true,
       "requires": {
         "call-bound": "^1.0.3",
         "get-intrinsic": "^1.2.6"
@@ -67398,6 +67557,7 @@
       "resolved": "https://registry.npmjs.org/jest/-/jest-29.7.0.tgz",
       "integrity": "sha512-NIy3oAFp9shda19hy4HK0HRTWKtPJmGdnvywu01nOqNC2vZg+Z+fvJDxpMQA88eb2I9EcafcdjYgsDthnYTvGw==",
       "dev": true,
+      "peer": true,
       "requires": {
         "@jest/core": "^29.7.0",
         "@jest/types": "^29.6.3",
@@ -68018,8 +68178,7 @@
     "jiti": {
       "version": "2.7.0",
       "resolved": "https://registry.npmjs.org/jiti/-/jiti-2.7.0.tgz",
-      "integrity": "sha512-AC/7JofJvZGrrneWNaEnJeOLUx+JlGt7tNa0wZiRPT4MY1wmfKjt2+6O2p2uz2+skll8OZZmJMNqeke7kKbNgQ==",
-      "peer": true
+      "integrity": "sha512-AC/7JofJvZGrrneWNaEnJeOLUx+JlGt7tNa0wZiRPT4MY1wmfKjt2+6O2p2uz2+skll8OZZmJMNqeke7kKbNgQ=="
     },
     "joi": {
       "version": "17.10.1",
@@ -68046,8 +68205,7 @@
     "jquery": {
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/jquery/-/jquery-4.0.0.tgz",
-      "integrity": "sha512-TXCHVR3Lb6TZdtw1l3RTLf8RBWVGexdxL6AC8/e0xZKEpBflBsjh9/8LXw+dkNFuOyW9B7iB3O1sP7hS0Kiacg==",
-      "peer": true
+      "integrity": "sha512-TXCHVR3Lb6TZdtw1l3RTLf8RBWVGexdxL6AC8/e0xZKEpBflBsjh9/8LXw+dkNFuOyW9B7iB3O1sP7hS0Kiacg=="
     },
     "js-base64": {
       "version": "3.7.5",
@@ -68057,8 +68215,7 @@
     "js-cookie": {
       "version": "3.0.1",
       "resolved": "https://registry.npmjs.org/js-cookie/-/js-cookie-3.0.1.tgz",
-      "integrity": "sha512-+0rgsUXZu4ncpPxRL+lNEptWMOWl9etvPHc/koSRp6MPwpRYAhmk0dUG00J4bxVV3r9uUzfo24wW0knS07SKSw==",
-      "peer": true
+      "integrity": "sha512-+0rgsUXZu4ncpPxRL+lNEptWMOWl9etvPHc/koSRp6MPwpRYAhmk0dUG00J4bxVV3r9uUzfo24wW0knS07SKSw=="
     },
     "js-sha3": {
       "version": "0.8.0",
@@ -68205,8 +68362,7 @@
     "keyboard-key": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/keyboard-key/-/keyboard-key-1.1.0.tgz",
-      "integrity": "sha512-qkBzPTi3rlAKvX7k0/ub44sqOfXeLc/jcnGGmj5c7BJpU8eDrEVPyhCvNYAaoubbsLm9uGWwQJO1ytQK1a9/dQ==",
-      "peer": true
+      "integrity": "sha512-qkBzPTi3rlAKvX7k0/ub44sqOfXeLc/jcnGGmj5c7BJpU8eDrEVPyhCvNYAaoubbsLm9uGWwQJO1ytQK1a9/dQ=="
     },
     "keyv": {
       "version": "3.1.0",
@@ -68524,6 +68680,7 @@
       "version": "1.10.0",
       "resolved": "https://registry.npmjs.org/localforage/-/localforage-1.10.0.tgz",
       "integrity": "sha512-14/H1aX7hzBBmmh7sGPd+AOMkkIrHM3Z1PAyGgZigA1H1p5O5ANnMyWzvpAETtG68/dC4pC0ncy3+PPGzXZHPg==",
+      "peer": true,
       "requires": {
         "lie": "3.1.1"
       }
@@ -68550,8 +68707,7 @@
     "lodash-es": {
       "version": "4.18.1",
       "resolved": "https://registry.npmjs.org/lodash-es/-/lodash-es-4.18.1.tgz",
-      "integrity": "sha512-J8xewKD/Gk22OZbhpOVSwcs60zhd95ESDwezOFuA3/099925PdHJ7OFHNTGtajL3AlZkykD32HykiMo+BIBI8A==",
-      "peer": true
+      "integrity": "sha512-J8xewKD/Gk22OZbhpOVSwcs60zhd95ESDwezOFuA3/099925PdHJ7OFHNTGtajL3AlZkykD32HykiMo+BIBI8A=="
     },
     "lodash._baseiteratee": {
       "version": "4.7.0",
@@ -68879,7 +69035,6 @@
       "version": "0.3.1",
       "resolved": "https://registry.npmjs.org/matchmediaquery/-/matchmediaquery-0.3.1.tgz",
       "integrity": "sha512-Hlk20WQHRIm9EE9luN1kjRjYXAQToHOIAHPJn9buxBwuhfTHoKUcX+lXBbxc85DVQfXYbEQ4HcwQdd128E3qHQ==",
-      "peer": true,
       "requires": {
         "css-mediaquery": "^0.1.2"
       }
@@ -69707,14 +69862,12 @@
     "mouse-event-offset": {
       "version": "3.0.2",
       "resolved": "https://registry.npmjs.org/mouse-event-offset/-/mouse-event-offset-3.0.2.tgz",
-      "integrity": "sha512-s9sqOs5B1Ykox3Xo8b3Ss2IQju4UwlW6LSR+Q5FXWpprJ5fzMLefIIItr3PH8RwzfGy6gxs/4GAmiNuZScE25w==",
-      "peer": true
+      "integrity": "sha512-s9sqOs5B1Ykox3Xo8b3Ss2IQju4UwlW6LSR+Q5FXWpprJ5fzMLefIIItr3PH8RwzfGy6gxs/4GAmiNuZScE25w=="
     },
     "mouse-wheel": {
       "version": "1.2.0",
       "resolved": "https://registry.npmjs.org/mouse-wheel/-/mouse-wheel-1.2.0.tgz",
       "integrity": "sha512-+OfYBiUOCTWcTECES49neZwL5AoGkXE+lFjIvzwNCnYRlso+EnfvovcBxGoyQ0yQt806eSPjS675K0EwWknXmw==",
-      "peer": true,
       "requires": {
         "right-now": "^1.0.0",
         "signum": "^1.0.0",
@@ -69868,7 +70021,6 @@
       "version": "1.0.3",
       "resolved": "https://registry.npmjs.org/new-date/-/new-date-1.0.3.tgz",
       "integrity": "sha512-0fsVvQPbo2I18DT2zVHpezmeeNYV2JaJSrseiHLc17GNOxJzUdx5mvSigPu8LtIfZSij5i1wXnXFspEs2CD6hA==",
-      "peer": true,
       "requires": {
         "@segment/isodate": "1.0.3"
       }
@@ -69944,6 +70096,7 @@
       "version": "2.7.0",
       "resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-2.7.0.tgz",
       "integrity": "sha512-c4FRfUm/dbcWZ7U+1Wq0AwCyFL+3nt2bEw05wfxSz+DWpWsitgmSgYmy2dQdWyKC1694ELPqMs/YzUSNozLt8A==",
+      "peer": true,
       "requires": {
         "whatwg-url": "^5.0.0"
       }
@@ -70273,8 +70426,7 @@
     "obj-case": {
       "version": "0.2.1",
       "resolved": "https://registry.npmjs.org/obj-case/-/obj-case-0.2.1.tgz",
-      "integrity": "sha512-PquYBBTy+Y6Ob/O2574XHhDtHJlV1cJHMCgW+rDRc9J5hhmRelJB3k5dTK/3cVmFVtzvAKuENeuLpoyTzMzkOg==",
-      "peer": true
+      "integrity": "sha512-PquYBBTy+Y6Ob/O2574XHhDtHJlV1cJHMCgW+rDRc9J5hhmRelJB3k5dTK/3cVmFVtzvAKuENeuLpoyTzMzkOg=="
     },
     "obj-multiplex": {
       "version": "1.0.0",
@@ -70329,7 +70481,6 @@
       "version": "1.1.6",
       "resolved": "https://registry.npmjs.org/object-is/-/object-is-1.1.6.tgz",
       "integrity": "sha512-F8cZ+KfGlSGi09lJT7/Nd6KJZ9ygtvYC0/UYYLI9nmQKLMnydpB9yvbv9K1uSkEu7FU9vYPmVwLg328tX+ot3Q==",
-      "peer": true,
       "requires": {
         "call-bind": "^1.0.7",
         "define-properties": "^1.2.1"
@@ -70411,8 +70562,7 @@
     "ohash": {
       "version": "2.0.11",
       "resolved": "https://registry.npmjs.org/ohash/-/ohash-2.0.11.tgz",
-      "integrity": "sha512-RdR9FQrFwNBNXAr4GixM8YaRZRJ5PUWbKYbE5eOsrwAjJW0q2REGcf79oYPsLyskQCZG1PLN+S/K1V00joZAoQ==",
-      "peer": true
+      "integrity": "sha512-RdR9FQrFwNBNXAr4GixM8YaRZRJ5PUWbKYbE5eOsrwAjJW0q2REGcf79oYPsLyskQCZG1PLN+S/K1V00joZAoQ=="
     },
     "on-exit-leak-free": {
       "version": "2.1.2",
@@ -70703,7 +70853,6 @@
       "version": "3.1.0",
       "resolved": "https://registry.npmjs.org/parallax-js/-/parallax-js-3.1.0.tgz",
       "integrity": "sha512-UONoPKSQykeNvFcemDPxYYDU/T89LSffoaZAwOMhDp0ABhmFPwthgn2GrfB7An9Qo+8nPZIuQeZsh2pWn1qN3A==",
-      "peer": true,
       "requires": {
         "object-assign": "^4.1.1",
         "raf": "^3.3.0"
@@ -70795,8 +70944,7 @@
     "parse-unit": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/parse-unit/-/parse-unit-1.0.1.tgz",
-      "integrity": "sha512-hrqldJHokR3Qj88EIlV/kAyAi/G5R2+R56TBANxNMy0uPlYcttx0jnMW6Yx5KsKPSbC3KddM/7qQm3+0wEXKxg==",
-      "peer": true
+      "integrity": "sha512-hrqldJHokR3Qj88EIlV/kAyAi/G5R2+R56TBANxNMy0uPlYcttx0jnMW6Yx5KsKPSbC3KddM/7qQm3+0wEXKxg=="
     },
     "parse-url": {
       "version": "8.1.0",
@@ -70981,8 +71129,7 @@
     "pathe": {
       "version": "2.0.3",
       "resolved": "https://registry.npmjs.org/pathe/-/pathe-2.0.3.tgz",
-      "integrity": "sha512-WUjGcAqP1gQacoQe+OBJsFA7Ld4DyXuUIjZ5cc75cLHvJ7dtNsTugphxIADwspS+AraAUePCKrSVtPLFj/F88w==",
-      "peer": true
+      "integrity": "sha512-WUjGcAqP1gQacoQe+OBJsFA7Ld4DyXuUIjZ5cc75cLHvJ7dtNsTugphxIADwspS+AraAUePCKrSVtPLFj/F88w=="
     },
     "pbkdf2": {
       "version": "3.1.2",
@@ -71004,19 +71151,18 @@
     "perfect-debounce": {
       "version": "2.1.0",
       "resolved": "https://registry.npmjs.org/perfect-debounce/-/perfect-debounce-2.1.0.tgz",
-      "integrity": "sha512-LjgdTytVFXeUgtHZr9WYViYSM/g8MkcTPYDlPa3cDqMirHjKiSZPYd6DoL7pK8AJQr+uWkQvCjHNdiMqsrJs+g==",
-      "peer": true
+      "integrity": "sha512-LjgdTytVFXeUgtHZr9WYViYSM/g8MkcTPYDlPa3cDqMirHjKiSZPYd6DoL7pK8AJQr+uWkQvCjHNdiMqsrJs+g=="
     },
     "performance-now": {
       "version": "2.1.0",
       "resolved": "https://registry.npmjs.org/performance-now/-/performance-now-2.1.0.tgz",
-      "integrity": "sha512-7EAHlyLHI56VEIdK57uwHdHKIaAGbnXPiw0yWbarQZOKaKpvUIgW0jWRVLiatnM+XXlSwsanIBH/hzGMJulMow==",
-      "peer": true
+      "integrity": "sha512-7EAHlyLHI56VEIdK57uwHdHKIaAGbnXPiw0yWbarQZOKaKpvUIgW0jWRVLiatnM+XXlSwsanIBH/hzGMJulMow=="
     },
     "pg": {
       "version": "8.7.3",
       "resolved": "https://registry.npmjs.org/pg/-/pg-8.7.3.tgz",
       "integrity": "sha512-HPmH4GH4H3AOprDJOazoIcpI49XFsHCe8xlrjHkWiapdbHK+HLtbm/GQzXYAZwmPju/kzKhjaSfMACG+8cgJcw==",
+      "peer": true,
       "requires": {
         "buffer-writer": "2.0.0",
         "packet-reader": "1.0.0",
@@ -71180,7 +71326,6 @@
       "version": "2.3.1",
       "resolved": "https://registry.npmjs.org/pkg-types/-/pkg-types-2.3.1.tgz",
       "integrity": "sha512-y+ichcgc2LrADuhLNAx8DFjVfgz91pRxfZdI3UDhxHvcVEZsenLO+7XaU5vOp0u/7V/wZ+plyuQxtrDlZJ+yeg==",
-      "peer": true,
       "requires": {
         "confbox": "^0.2.4",
         "exsolve": "^1.0.8",
@@ -71214,6 +71359,7 @@
       "version": "0.2.35",
       "resolved": "https://registry.npmjs.org/porto/-/porto-0.2.35.tgz",
       "integrity": "sha512-gu9FfjjvvYBgQXUHWTp6n3wkTxVtEcqFotM7i3GEZeoQbvLGbssAicCz6hFZ8+xggrJWwi/RLmbwNra50SMmUQ==",
+      "peer": true,
       "requires": {
         "hono": "^4.10.3",
         "idb-keyval": "^6.2.1",
@@ -71270,7 +71416,8 @@
         "zod": {
           "version": "4.4.3",
           "resolved": "https://registry.npmjs.org/zod/-/zod-4.4.3.tgz",
-          "integrity": "sha512-ytENFjIJFl2UwYglde2jchW2Hwm4GJFLDiSXWdTrJQBIN9Fcyp7n4DhxJEiWNAJMV1/BqWfW/kkg71UDcHJyTQ=="
+          "integrity": "sha512-ytENFjIJFl2UwYglde2jchW2Hwm4GJFLDiSXWdTrJQBIN9Fcyp7n4DhxJEiWNAJMV1/BqWfW/kkg71UDcHJyTQ==",
+          "peer": true
         },
         "zustand": {
           "version": "5.0.14",
@@ -71289,6 +71436,7 @@
       "version": "8.4.31",
       "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.4.31.tgz",
       "integrity": "sha512-PS08Iboia9mts/2ygV3eLpY5ghnUcfLV/EXTOW1E2qYxJKGGBUtNjN76FYHnMs36RmARn41bC0AZmn+rR0OVpQ==",
+      "peer": true,
       "requires": {
         "nanoid": "^3.3.6",
         "picocolors": "^1.0.0",
@@ -71390,8 +71538,7 @@
     "powershell-utils": {
       "version": "0.1.0",
       "resolved": "https://registry.npmjs.org/powershell-utils/-/powershell-utils-0.1.0.tgz",
-      "integrity": "sha512-dM0jVuXJPsDN6DvRpea484tCUaMiXWjuCn++HGTqUWzGDjv5tZkEZldAJ/UMlqRYGFrD/etByo4/xOuC/snX2A==",
-      "peer": true
+      "integrity": "sha512-dM0jVuXJPsDN6DvRpea484tCUaMiXWjuCn++HGTqUWzGDjv5tZkEZldAJ/UMlqRYGFrD/etByo4/xOuC/snX2A=="
     },
     "preact": {
       "version": "10.24.2",
@@ -71407,7 +71554,8 @@
       "version": "2.6.2",
       "resolved": "https://registry.npmjs.org/prettier/-/prettier-2.6.2.tgz",
       "integrity": "sha512-PkUpF+qoXTqhOeWL9fu7As8LXsIUZ1WYaJiY/a7McAQzxjk82OF0tibkFXVCDImZtWxbvojFjerkiLb0/q8mew==",
-      "dev": true
+      "dev": true,
+      "peer": true
     },
     "prettier-linter-helpers": {
       "version": "1.0.0",
@@ -71501,6 +71649,7 @@
       "version": "15.8.1",
       "resolved": "https://registry.npmjs.org/prop-types/-/prop-types-15.8.1.tgz",
       "integrity": "sha512-oj87CgZICdulUohogVAR7AjlC0327U4el4L6eAvOqCeudMDVU0NThNaV+b9Df4dXgSP1gXMTnPdhfe/2qDH5cg==",
+      "peer": true,
       "requires": {
         "loose-envify": "^1.4.0",
         "object-assign": "^4.1.1",
@@ -71741,7 +71890,6 @@
       "version": "3.4.1",
       "resolved": "https://registry.npmjs.org/raf/-/raf-3.4.1.tgz",
       "integrity": "sha512-Sq4CW4QhwOHE8ucn6J34MqtZCeWFP2aQSmrlroYgqAV1PjStIhJXxYuTgUIfkEk7zTLjmIjLmU5q+fbD1NnOJA==",
-      "peer": true,
       "requires": {
         "performance-now": "^2.1.0"
       }
@@ -71828,7 +71976,6 @@
       "version": "3.0.1",
       "resolved": "https://registry.npmjs.org/rc9/-/rc9-3.0.1.tgz",
       "integrity": "sha512-gMDyleLWVE+i6Sgtc0QbbY6pEKqYs97NGi6isHQPqYlLemPoO8dxQ3uGi0f4NiP98c+jMW6cG1Kx9dDwfvqARQ==",
-      "peer": true,
       "requires": {
         "defu": "^6.1.6",
         "destr": "^2.0.5"
@@ -71838,6 +71985,7 @@
       "version": "18.3.1",
       "resolved": "https://registry.npmjs.org/react/-/react-18.3.1.tgz",
       "integrity": "sha512-wS+hAgJShR0KhEvPJArfuPVN1+Hz1t0Y6n5jLrGQbkb4urgPE/0Rve+1kMB1v/oWgHgm4WIcV+i7F2pTVj+2iQ==",
+      "peer": true,
       "requires": {
         "loose-envify": "^1.1.0"
       }
@@ -71942,6 +72090,7 @@
       "version": "18.3.1",
       "resolved": "https://registry.npmjs.org/react-dom/-/react-dom-18.3.1.tgz",
       "integrity": "sha512-5m4nQKp+rZRb09LNH59GM4BxTh9251/ylbKIbpe7TpGxfJ+9kv6BLkLBXIjjspbgbnIBNqlI23tRnTWT0snUIw==",
+      "peer": true,
       "requires": {
         "loose-envify": "^1.1.0",
         "scheduler": "^0.23.2"
@@ -71978,6 +72127,7 @@
       "version": "6.8.9",
       "resolved": "https://registry.npmjs.org/react-intl/-/react-intl-6.8.9.tgz",
       "integrity": "sha512-TUfj5E7lyUDvz/GtovC9OMh441kBr08rtIbgh3p0R8iF3hVY+V2W9Am7rb8BpJ/29BH1utJOqOOhmvEVh3GfZg==",
+      "peer": true,
       "requires": {
         "@formatjs/ecma402-abstract": "2.2.4",
         "@formatjs/icu-messageformat-parser": "2.9.4",
@@ -72077,7 +72227,6 @@
       "version": "2.3.0",
       "resolved": "https://registry.npmjs.org/react-popper/-/react-popper-2.3.0.tgz",
       "integrity": "sha512-e1hj8lL3uM+sgSR4Lxzn5h1GxBlpa4CQz0XLF8kx4MDrDRWY0Ena4c97PUeSX9i5W3UAfDP0z0FXCTQkoXUl3Q==",
-      "peer": true,
       "requires": {
         "react-fast-compare": "^3.0.1",
         "warning": "^4.0.2"
@@ -72087,7 +72236,6 @@
       "version": "8.1.3",
       "resolved": "https://registry.npmjs.org/react-redux/-/react-redux-8.1.3.tgz",
       "integrity": "sha512-n0ZrutD7DaX/j9VscF+uTALI3oUPa/pO4Z3soOBIjuRn/FzVu6aehhysxZCLi6y7duMf52WNZGMl7CtuK5EnRw==",
-      "peer": true,
       "requires": {
         "@babel/runtime": "^7.12.1",
         "@types/hoist-non-react-statics": "^3.3.1",
@@ -72100,15 +72248,15 @@
         "react-is": {
           "version": "18.3.1",
           "resolved": "https://registry.npmjs.org/react-is/-/react-is-18.3.1.tgz",
-          "integrity": "sha512-/LLMVyas0ljjAtoYiPqYiL8VWXzUUdThrmU5+n20DZv+a+ClRoevUzw5JxU+Ieh5/c87ytoTBV9G1FiKfNJdmg==",
-          "peer": true
+          "integrity": "sha512-/LLMVyas0ljjAtoYiPqYiL8VWXzUUdThrmU5+n20DZv+a+ClRoevUzw5JxU+Ieh5/c87ytoTBV9G1FiKfNJdmg=="
         }
       }
     },
     "react-refresh": {
       "version": "0.14.0",
       "resolved": "https://registry.npmjs.org/react-refresh/-/react-refresh-0.14.0.tgz",
-      "integrity": "sha512-wViHqhAd8OHeLS/IRMJjTSDHF3U9eWi62F/MledQGPdJGDhodXJ9PBLNGr6WWL7qlH12Mt3TyTpbS+hGXMjCzQ=="
+      "integrity": "sha512-wViHqhAd8OHeLS/IRMJjTSDHF3U9eWi62F/MledQGPdJGDhodXJ9PBLNGr6WWL7qlH12Mt3TyTpbS+hGXMjCzQ==",
+      "peer": true
     },
     "react-remove-scroll": {
       "version": "2.7.2",
@@ -72149,7 +72297,6 @@
       "version": "9.0.2",
       "resolved": "https://registry.npmjs.org/react-responsive/-/react-responsive-9.0.2.tgz",
       "integrity": "sha512-+4CCab7z8G8glgJoRjAwocsgsv6VA2w7JPxFWHRc7kvz8mec1/K5LutNC2MG28Mn8mu6+bu04XZxHv5gyfT7xQ==",
-      "peer": true,
       "requires": {
         "hyphenate-style-name": "^1.0.0",
         "matchmediaquery": "^0.3.0",
@@ -72161,7 +72308,6 @@
       "version": "5.3.4",
       "resolved": "https://registry.npmjs.org/react-router/-/react-router-5.3.4.tgz",
       "integrity": "sha512-Ys9K+ppnJah3QuaRiLxk+jDWOR1MekYQrlytiXxC1RyfbdsZkS5pvKAzCCr031xHixZwpnsYNT5xysdFHQaYsA==",
-      "peer": true,
       "requires": {
         "@babel/runtime": "^7.12.13",
         "history": "^4.9.0",
@@ -72177,14 +72323,12 @@
         "isarray": {
           "version": "0.0.1",
           "resolved": "https://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz",
-          "integrity": "sha512-D2S+3GLxWH+uhrNEcoh/fnmYeP8E8/zHl644d/jdA0g2uyXvy3sb0qxotE+ne0LtccHknQzWwZEzhak7oJ0COQ==",
-          "peer": true
+          "integrity": "sha512-D2S+3GLxWH+uhrNEcoh/fnmYeP8E8/zHl644d/jdA0g2uyXvy3sb0qxotE+ne0LtccHknQzWwZEzhak7oJ0COQ=="
         },
         "path-to-regexp": {
           "version": "1.9.0",
           "resolved": "https://registry.npmjs.org/path-to-regexp/-/path-to-regexp-1.9.0.tgz",
           "integrity": "sha512-xIp7/apCFJuUHdDLWe8O1HIkb0kQrOMb/0u6FXQjemHn/ii5LrIzU6bdECnsiTF/GjZkMEKg1xdiZwNqDYlZ6g==",
-          "peer": true,
           "requires": {
             "isarray": "0.0.1"
           }
@@ -72195,7 +72339,6 @@
       "version": "2.17.2",
       "resolved": "https://registry.npmjs.org/react-semantic-ui-datepickers/-/react-semantic-ui-datepickers-2.17.2.tgz",
       "integrity": "sha512-rYFFwdPOi3C+7vP/KpU7jgj05BoVATEOAhlEvkeQhGtMfaxUIh/9eWF7Fas5QmUsyXXGrMm8alccIwKe34m5ug==",
-      "peer": true,
       "requires": {
         "@date-fns/upgrade": "1.0.3",
         "classnames": "2.3.2",
@@ -72208,14 +72351,12 @@
         "classnames": {
           "version": "2.3.2",
           "resolved": "https://registry.npmjs.org/classnames/-/classnames-2.3.2.tgz",
-          "integrity": "sha512-CSbhY4cFEJRe6/GQzIk5qXZ4Jeg5pcsP7b5peFSDpffpe1cqjASH/n9UTjBwOp6XpMSTwQ8Za2K5V02ueA7Tmw==",
-          "peer": true
+          "integrity": "sha512-CSbhY4cFEJRe6/GQzIk5qXZ4Jeg5pcsP7b5peFSDpffpe1cqjASH/n9UTjBwOp6XpMSTwQ8Za2K5V02ueA7Tmw=="
         },
         "date-fns": {
           "version": "2.29.3",
           "resolved": "https://registry.npmjs.org/date-fns/-/date-fns-2.29.3.tgz",
-          "integrity": "sha512-dDCnyH2WnnKusqvZZ6+jA1O51Ibt8ZMRNkDZdyAyK4YfbDwa/cEmuztzG5pk6hqlp9aSBPYcjOlktquahGwGeA==",
-          "peer": true
+          "integrity": "sha512-dDCnyH2WnnKusqvZZ6+jA1O51Ibt8ZMRNkDZdyAyK4YfbDwa/cEmuztzG5pk6hqlp9aSBPYcjOlktquahGwGeA=="
         }
       }
     },
@@ -72229,7 +72370,6 @@
       "version": "4.0.4",
       "resolved": "https://registry.npmjs.org/react-smooth/-/react-smooth-4.0.4.tgz",
       "integrity": "sha512-gnGKTpYwqL0Iii09gHobNolvX4Kiq4PKx6eWBCYYix+8cdw+cGo3do906l1NBPKkSWx1DghC1dlWG9L2uGd61Q==",
-      "peer": true,
       "requires": {
         "fast-equals": "^5.0.1",
         "prop-types": "^15.8.1",
@@ -72256,7 +72396,6 @@
       "version": "0.4.1",
       "resolved": "https://registry.npmjs.org/react-tile-map/-/react-tile-map-0.4.1.tgz",
       "integrity": "sha512-aBcZY4a3X17cngvEo9TAnn030PFqh9uyx4vVbeaS6MYOAbTnftSF+rkDPSabYWONWzhVIxOEuI4dM8tYckmAdw==",
-      "peer": true,
       "requires": {
         "impetus": "^0.8.8",
         "mouse-wheel": "^1.2.0",
@@ -72269,7 +72408,6 @@
       "version": "4.4.5",
       "resolved": "https://registry.npmjs.org/react-transition-group/-/react-transition-group-4.4.5.tgz",
       "integrity": "sha512-pZcd1MCJoiKiBR2NRxeCRg13uCXbydPnmB4EOeRrY7480qNWO8IIgQG6zlDkm6uRMsURXPuKq0GWtiM59a5Q6g==",
-      "peer": true,
       "requires": {
         "@babel/runtime": "^7.5.5",
         "dom-helpers": "^5.0.1",
@@ -72281,7 +72419,6 @@
       "version": "1.0.26",
       "resolved": "https://registry.npmjs.org/react-virtualized-auto-sizer/-/react-virtualized-auto-sizer-1.0.26.tgz",
       "integrity": "sha512-CblNyiNVw2o+hsa5/49NH2ogGxZ+t+3aweRvNSq7TVjDIlwk7ir4lencEg5HxHeSzwNarSkNkiu0qJSOXtxm5A==",
-      "peer": true,
       "requires": {}
     },
     "read": {
@@ -72361,6 +72498,7 @@
       "version": "3.6.2",
       "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-3.6.2.tgz",
       "integrity": "sha512-9u/sniCrY3D5WdsERHzHE4G2YCXqoG5FTHUiCC4SIbr6XcLZBY05ya9EKjYek9O5xOAwjGq+1JdGBAS7Q9ScoA==",
+      "peer": true,
       "requires": {
         "inherits": "^2.0.3",
         "string_decoder": "^1.1.1",
@@ -72407,7 +72545,6 @@
       "version": "2.15.4",
       "resolved": "https://registry.npmjs.org/recharts/-/recharts-2.15.4.tgz",
       "integrity": "sha512-UT/q6fwS3c1dHbXv2uFgYJ9BMFHu3fwnd7AYZaEQhXuYQ4hgsxLvsUXzGdKeZrW5xopzDCvuA2N41WJ88I7zIw==",
-      "peer": true,
       "requires": {
         "clsx": "^2.0.0",
         "eventemitter3": "^4.0.1",
@@ -72422,14 +72559,12 @@
         "clsx": {
           "version": "2.1.1",
           "resolved": "https://registry.npmjs.org/clsx/-/clsx-2.1.1.tgz",
-          "integrity": "sha512-eYm0QWBtUrBWZWG0d386OGAw16Z995PiOVo2B7bjWSbHedGl5e0ZWaq65kOGgUSNesEIDkB9ISbTg/JK9dhCZA==",
-          "peer": true
+          "integrity": "sha512-eYm0QWBtUrBWZWG0d386OGAw16Z995PiOVo2B7bjWSbHedGl5e0ZWaq65kOGgUSNesEIDkB9ISbTg/JK9dhCZA=="
         },
         "react-is": {
           "version": "18.3.1",
           "resolved": "https://registry.npmjs.org/react-is/-/react-is-18.3.1.tgz",
-          "integrity": "sha512-/LLMVyas0ljjAtoYiPqYiL8VWXzUUdThrmU5+n20DZv+a+ClRoevUzw5JxU+Ieh5/c87ytoTBV9G1FiKfNJdmg==",
-          "peer": true
+          "integrity": "sha512-/LLMVyas0ljjAtoYiPqYiL8VWXzUUdThrmU5+n20DZv+a+ClRoevUzw5JxU+Ieh5/c87ytoTBV9G1FiKfNJdmg=="
         }
       }
     },
@@ -72437,7 +72572,6 @@
       "version": "0.4.5",
       "resolved": "https://registry.npmjs.org/recharts-scale/-/recharts-scale-0.4.5.tgz",
       "integrity": "sha512-kivNFO+0OcUNu7jQquLXAxz1FIwZj8nrj+YkOKc5694NbjCvcT6aSZiIzNzd2Kul4o4rTto8QVR9lMNtxD4G1w==",
-      "peer": true,
       "requires": {
         "decimal.js-light": "^2.4.1"
       }
@@ -72463,6 +72597,7 @@
       "version": "4.1.2",
       "resolved": "https://registry.npmjs.org/redux/-/redux-4.1.2.tgz",
       "integrity": "sha512-SH8PglcebESbd/shgf6mii6EIoRM0zrQyjcuQ+ojmfxjTtE0z9Y8pa62iA/OJ58qjP6j27uyW4kUF4jl/jd6sw==",
+      "peer": true,
       "requires": {
         "@babel/runtime": "^7.9.2"
       }
@@ -73002,14 +73137,12 @@
     "resolve-pathname": {
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/resolve-pathname/-/resolve-pathname-3.0.0.tgz",
-      "integrity": "sha512-C7rARubxI8bXFNB/hqcp/4iUeIXJhJZvFPFPiSPRnhU5UPxzMFIl+2E6yY6c4k9giDJAhtV+enfA+G89N6Csng==",
-      "peer": true
+      "integrity": "sha512-C7rARubxI8bXFNB/hqcp/4iUeIXJhJZvFPFPiSPRnhU5UPxzMFIl+2E6yY6c4k9giDJAhtV+enfA+G89N6Csng=="
     },
     "resolve-pkg-maps": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/resolve-pkg-maps/-/resolve-pkg-maps-1.0.0.tgz",
-      "integrity": "sha512-seS2Tj26TBVOC2NIc2rOe2y2ZO7efxITtLZcGSOnHHNOQ7CkiUBfw0Iw2ck6xkIhPwLhKNLS8BO+hEpngQlqzw==",
-      "peer": true
+      "integrity": "sha512-seS2Tj26TBVOC2NIc2rOe2y2ZO7efxITtLZcGSOnHHNOQ7CkiUBfw0Iw2ck6xkIhPwLhKNLS8BO+hEpngQlqzw=="
     },
     "resolve.exports": {
       "version": "2.0.2",
@@ -73058,8 +73191,7 @@
     "right-now": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/right-now/-/right-now-1.0.0.tgz",
-      "integrity": "sha512-DA8+YS+sMIVpbsuKgy+Z67L9Lxb1p05mNxRpDPNksPDEFir4vmBlUtuN9jkTGn9YMMdlBuK7XQgFiz6ws+yhSg==",
-      "peer": true
+      "integrity": "sha512-DA8+YS+sMIVpbsuKgy+Z67L9Lxb1p05mNxRpDPNksPDEFir4vmBlUtuN9jkTGn9YMMdlBuK7XQgFiz6ws+yhSg=="
     },
     "rimraf": {
       "version": "3.0.2",
@@ -73097,6 +73229,7 @@
       "version": "2.26.2",
       "resolved": "https://registry.npmjs.org/rollbar/-/rollbar-2.26.2.tgz",
       "integrity": "sha512-7ASvrlal87ek2vhTmpu2LPvkdlcnala1qeMT2Ra76s0KjWkQ8d1fTl6dk7AqHx1Qa/puahg3tYw7EPB7wYx9RQ==",
+      "peer": true,
       "requires": {
         "async": "~3.2.3",
         "console-polyfill": "0.3.0",
@@ -73239,7 +73372,6 @@
       "version": "2.5.0",
       "resolved": "https://registry.npmjs.org/semantic-ui-css/-/semantic-ui-css-2.5.0.tgz",
       "integrity": "sha512-jIWn3WXXE2uSaWCcB+gVJVRG3masIKtTMNEP2X8Aw909H2rHpXGneYOxzO3hT8TpyvB5/dEEo9mBFCitGwoj1A==",
-      "peer": true,
       "requires": {
         "jquery": "x.*"
       }
@@ -73248,7 +73380,6 @@
       "version": "2.1.5",
       "resolved": "https://registry.npmjs.org/semantic-ui-react/-/semantic-ui-react-2.1.5.tgz",
       "integrity": "sha512-nIqmmUNpFHfovEb+RI2w3E2/maZQutd8UIWyRjf1SLse+XF51hI559xbz/sLN3O6RpLjr/echLOOXwKCirPy3Q==",
-      "peer": true,
       "requires": {
         "@babel/runtime": "^7.10.5",
         "@fluentui/react-component-event-listener": "~0.63.0",
@@ -73416,14 +73547,12 @@
     "shallow-equal": {
       "version": "1.2.1",
       "resolved": "https://registry.npmjs.org/shallow-equal/-/shallow-equal-1.2.1.tgz",
-      "integrity": "sha512-S4vJDjHHMBaiZuT9NPb616CSmLf618jawtv3sufLl6ivK8WocjAo58cXwbRV1cgqxH0Qbv+iUt6m05eqEa2IRA==",
-      "peer": true
+      "integrity": "sha512-S4vJDjHHMBaiZuT9NPb616CSmLf618jawtv3sufLl6ivK8WocjAo58cXwbRV1cgqxH0Qbv+iUt6m05eqEa2IRA=="
     },
     "shallowequal": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/shallowequal/-/shallowequal-1.1.0.tgz",
-      "integrity": "sha512-y0m1JoUZSlPAjXVtPPW70aZWfIL/dSP7AFkRnniLCrK/8MDKog3TySTBmckD+RObVxH0v4Tox67+F14PdED2oQ==",
-      "peer": true
+      "integrity": "sha512-y0m1JoUZSlPAjXVtPPW70aZWfIL/dSP7AFkRnniLCrK/8MDKog3TySTBmckD+RObVxH0v4Tox67+F14PdED2oQ=="
     },
     "sharp": {
       "version": "0.33.5",
@@ -73536,8 +73665,7 @@
     "signum": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/signum/-/signum-1.0.0.tgz",
-      "integrity": "sha512-yodFGwcyt59XRh7w5W3jPcIQb3Bwi21suEfT7MAWnBX3iCdklJpgDgvGT9o04UonglZN5SNMfJFkHIR/jO8GHw==",
-      "peer": true
+      "integrity": "sha512-yodFGwcyt59XRh7w5W3jPcIQb3Bwi21suEfT7MAWnBX3iCdklJpgDgvGT9o04UonglZN5SNMfJFkHIR/jO8GHw=="
     },
     "simple-concat": {
       "version": "1.0.1",
@@ -73694,6 +73822,7 @@
       "version": "4.8.3",
       "resolved": "https://registry.npmjs.org/socket.io-client/-/socket.io-client-4.8.3.tgz",
       "integrity": "sha512-uP0bpjWrjQmUt5DTHq9RuoCBdFJF10cdX9X+a368j/Ft0wmaVgxlrjvK3kjvgCODOMMOz9lcaRzxmso0bTWZ/g==",
+      "peer": true,
       "requires": {
         "@socket.io/component-emitter": "~3.1.0",
         "debug": "~4.4.1",
@@ -73921,7 +74050,6 @@
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/stop-iteration-iterator/-/stop-iteration-iterator-1.1.0.tgz",
       "integrity": "sha512-eLoXW/DHyl62zxY4SCaIgnRhuMr6ri4juEYARS8E6sCEqzKpOiE521Ucofdx+KnDZl5xmvGYaaKCk5FEOxJCoQ==",
-      "peer": true,
       "requires": {
         "es-errors": "^1.3.0",
         "internal-slot": "^1.1.0"
@@ -74984,7 +75112,8 @@
         "zod": {
           "version": "3.25.75",
           "resolved": "https://registry.npmjs.org/zod/-/zod-3.25.75.tgz",
-          "integrity": "sha512-OhpzAmVzabPOL6C3A3gpAifqr9MqihV/Msx3gor2b2kviCgcb+HM9SEOpMWwwNp9MRunWnhtAKUoo0AHhjyPPg=="
+          "integrity": "sha512-OhpzAmVzabPOL6C3A3gpAifqr9MqihV/Msx3gor2b2kviCgcb+HM9SEOpMWwwNp9MRunWnhtAKUoo0AHhjyPPg==",
+          "peer": true
         },
         "zustand": {
           "version": "5.0.3",
@@ -75083,7 +75212,6 @@
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/to-px/-/to-px-1.1.0.tgz",
       "integrity": "sha512-bfg3GLYrGoEzrGoE05TAL/Uw+H/qrf2ptr9V3W7U0lkjjyYnIfgxmVLUfhQ1hZpIQwin81uxhDjvUkDYsC0xWw==",
-      "peer": true,
       "requires": {
         "parse-unit": "^1.0.1"
       }
@@ -75140,7 +75268,6 @@
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/touch-pinch/-/touch-pinch-1.0.1.tgz",
       "integrity": "sha512-If5caiHlfY2JBQYM8XWjOB4mwEidkYpjLXV6zx1uuama0lrbGNVxhzG0wSpaAdHduoGVtWKAQNoCLrgJDEnnfQ==",
-      "peer": true,
       "requires": {
         "dprop": "^1.0.0",
         "events": "^1.0.2",
@@ -75151,8 +75278,7 @@
         "events": {
           "version": "1.1.1",
           "resolved": "https://registry.npmjs.org/events/-/events-1.1.1.tgz",
-          "integrity": "sha512-kEcvvCBByWXGnZy6JUlgAp2gBIUjfCAV6P6TgT1/aaQKcmuAEC4OZTV1I4EWQLz2gxZw76atuVyvHhTxvi0Flw==",
-          "peer": true
+          "integrity": "sha512-kEcvvCBByWXGnZy6JUlgAp2gBIUjfCAV6P6TgT1/aaQKcmuAEC4OZTV1I4EWQLz2gxZw76atuVyvHhTxvi0Flw=="
         }
       }
     },
@@ -75160,7 +75286,6 @@
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/touch-position/-/touch-position-2.0.0.tgz",
       "integrity": "sha512-/lzepy++NyN/FcjWrYEWXrNqkontDGm6+5BzMdlFOQybTGyVq1JXm+sEzlsZjcPSThJozcs6Flp68n152tWb3w==",
-      "peer": true,
       "requires": {
         "events": "^1.0.2",
         "mouse-event-offset": "^3.0.2"
@@ -75169,8 +75294,7 @@
         "events": {
           "version": "1.1.1",
           "resolved": "https://registry.npmjs.org/events/-/events-1.1.1.tgz",
-          "integrity": "sha512-kEcvvCBByWXGnZy6JUlgAp2gBIUjfCAV6P6TgT1/aaQKcmuAEC4OZTV1I4EWQLz2gxZw76atuVyvHhTxvi0Flw==",
-          "peer": true
+          "integrity": "sha512-kEcvvCBByWXGnZy6JUlgAp2gBIUjfCAV6P6TgT1/aaQKcmuAEC4OZTV1I4EWQLz2gxZw76atuVyvHhTxvi0Flw=="
         }
       }
     },
@@ -75241,6 +75365,7 @@
       "resolved": "https://registry.npmjs.org/ts-node/-/ts-node-10.7.0.tgz",
       "integrity": "sha512-TbIGS4xgJoX2i3do417KSaep1uRAW/Lu+WAL2doDHC0D6ummjirVOXU5/7aiZotbQ5p1Zp9tP7U6cYhA0O7M8A==",
       "dev": true,
+      "peer": true,
       "requires": {
         "@cspotcode/source-map-support": "0.7.0",
         "@tsconfig/node10": "^1.0.7",
@@ -75432,7 +75557,8 @@
     "typescript": {
       "version": "5.2.2",
       "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.2.2.tgz",
-      "integrity": "sha512-mI4WrpHsbCIcwT9cF4FZvr80QUeKvsUsUvKDoR+X/7XHQH98xYD8YHZg7ANtz2GtZt/CBq2QJ0thkGJMHfqc1w=="
+      "integrity": "sha512-mI4WrpHsbCIcwT9cF4FZvr80QUeKvsUsUvKDoR+X/7XHQH98xYD8YHZg7ANtz2GtZt/CBq2QJ0thkGJMHfqc1w==",
+      "peer": true
     },
     "ua-is-frozen": {
       "version": "0.1.2",
@@ -75547,8 +75673,7 @@
     "unfetch": {
       "version": "4.2.0",
       "resolved": "https://registry.npmjs.org/unfetch/-/unfetch-4.2.0.tgz",
-      "integrity": "sha512-F9p7yYCn6cIW9El1zi0HI6vqpeIvBsr3dSuRO6Xuppb1u5rXpCPmMvLSyECLhybr9isec8Ohl0hPekMVrEinDA==",
-      "peer": true
+      "integrity": "sha512-F9p7yYCn6cIW9El1zi0HI6vqpeIvBsr3dSuRO6Xuppb1u5rXpCPmMvLSyECLhybr9isec8Ohl0hPekMVrEinDA=="
     },
     "unicode-canonical-property-names-ecmascript": {
       "version": "2.0.0",
@@ -75922,6 +76047,7 @@
       "version": "5.0.10",
       "resolved": "https://registry.npmjs.org/utf-8-validate/-/utf-8-validate-5.0.10.tgz",
       "integrity": "sha512-Z6czzLq4u8fPOyx7TU6X3dvUZVvoJmxSQ+IcrlmagKhilxlhZgxPK6C5Jqbkw1IDUmFTM+cz9QDnnLTwDz/2gQ==",
+      "peer": true,
       "requires": {
         "node-gyp-build": "^4.3.0"
       }
@@ -76044,6 +76170,7 @@
       "version": "2.1.7",
       "resolved": "https://registry.npmjs.org/valtio/-/valtio-2.1.7.tgz",
       "integrity": "sha512-DwJhCDpujuQuKdJ2H84VbTjEJJteaSmqsuUltsfbfdbotVfNeTE4K/qc/Wi57I9x8/2ed4JNdjEna7O6PfavRg==",
+      "peer": true,
       "requires": {
         "proxy-compare": "^3.0.1"
       }
@@ -76051,8 +76178,7 @@
     "value-equal": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/value-equal/-/value-equal-1.0.1.tgz",
-      "integrity": "sha512-NOJ6JZCAWr0zlxZt+xqCHNTEKOsrks2HQd4MqhP1qy4z1SkbEP467eNx6TgDKXMvUOb+OENfJCZwM+16n7fRfw==",
-      "peer": true
+      "integrity": "sha512-NOJ6JZCAWr0zlxZt+xqCHNTEKOsrks2HQd4MqhP1qy4z1SkbEP467eNx6TgDKXMvUOb+OENfJCZwM+16n7fRfw=="
     },
     "value-or-promise": {
       "version": "1.0.11",
@@ -76093,7 +76219,6 @@
       "version": "36.9.2",
       "resolved": "https://registry.npmjs.org/victory-vendor/-/victory-vendor-36.9.2.tgz",
       "integrity": "sha512-PnpQQMuxlwYdocC8fIJqVXvkeViHYzotI+NJrCuav0ZYFoq912ZHBk3mCeuj+5/VpodOjPe1z0Fk2ihgzlXqjQ==",
-      "peer": true,
       "requires": {
         "@types/d3-array": "^3.0.3",
         "@types/d3-ease": "^3.0.0",
@@ -76120,6 +76245,7 @@
       "version": "2.53.1",
       "resolved": "https://registry.npmjs.org/viem/-/viem-2.53.1.tgz",
       "integrity": "sha512-FhfJ/SW73CVosiyVLmIMVgKDRKYV1AGCLzZoHYvmNayyVff63Qi1ocPCk59LqC/cNw244RbBJjHnmxqXkE7NpA==",
+      "peer": true,
       "requires": {
         "@noble/curves": "1.9.1",
         "@noble/hashes": "1.8.0",
@@ -76181,6 +76307,7 @@
       "version": "2.19.5",
       "resolved": "https://registry.npmjs.org/wagmi/-/wagmi-2.19.5.tgz",
       "integrity": "sha512-RQUfKMv6U+EcSNNGiPbdkDtJwtuFxZWLmvDiQmjjBgkuPulUwDJsKhi7gjynzJdsx2yDqhHCXkKsbbfbIsHfcQ==",
+      "peer": true,
       "requires": {
         "@wagmi/connectors": "6.2.0",
         "@wagmi/core": "2.22.1",
@@ -76233,6 +76360,7 @@
           "version": "1.4.0",
           "resolved": "https://registry.npmjs.org/use-sync-external-store/-/use-sync-external-store-1.4.0.tgz",
           "integrity": "sha512-9WXSPC5fMv61vaupRkCKCxsPxBocVnwakBEkMIHHpkTTg6icbJtg6jzgtLDm4bl3cSHAca52rYWih0k4K3PfHw==",
+          "peer": true,
           "requires": {}
         },
         "zustand": {
@@ -76256,7 +76384,6 @@
       "version": "4.0.3",
       "resolved": "https://registry.npmjs.org/warning/-/warning-4.0.3.tgz",
       "integrity": "sha512-rpJyN222KWIvHJ/F53XSZv0Zl/accqHR8et1kpaMTD/fLCRxtV8iX8czMzY7sVZupTI3zcUTg8eycS2kNF9l6w==",
-      "peer": true,
       "requires": {
         "loose-envify": "^1.0.0"
       }
@@ -76562,6 +76689,7 @@
       "version": "5.89.0",
       "resolved": "https://registry.npmjs.org/webpack/-/webpack-5.89.0.tgz",
       "integrity": "sha512-qyfIC10pOr70V+jkmud8tMfajraGCZMBWJtrmuBymQKCrLTRejBI8STDp1MCyZu/QTdZSeacCQYpYNQVOzX5kw==",
+      "peer": true,
       "requires": {
         "@types/eslint-scope": "^3.7.3",
         "@types/estree": "^1.0.0",
@@ -76728,7 +76856,6 @@
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/which-collection/-/which-collection-1.0.2.tgz",
       "integrity": "sha512-K4jVyjnBdgvc86Y6BkaLZEN933SwYOuBFkdmBu9ZfkcAbdVbpITnDmjvZ/aQjRXQrv5EPkTnD1s39GiiqbngCw==",
-      "peer": true,
       "requires": {
         "is-map": "^2.0.3",
         "is-set": "^2.0.3",
@@ -76851,13 +76978,13 @@
       "version": "7.4.6",
       "resolved": "https://registry.npmjs.org/ws/-/ws-7.4.6.tgz",
       "integrity": "sha512-YmhHDO4MzaDLB+M9ym/mDA5z0naX8j7SIlT8f8z+I0VtzsRbekxEutHSme7NPS2qE8StCYQNUnfWdXta/Yu85A==",
+      "peer": true,
       "requires": {}
     },
     "wsl-utils": {
       "version": "0.3.1",
       "resolved": "https://registry.npmjs.org/wsl-utils/-/wsl-utils-0.3.1.tgz",
       "integrity": "sha512-g/eziiSUNBSsdDJtCLB8bdYEUMj4jR7AGeUo96p/3dTafgjHhpF4RiCFPiRILwjQoDXx5MqkBr4fwWtR3Ky4Wg==",
-      "peer": true,
       "requires": {
         "is-wsl": "^3.1.0",
         "powershell-utils": "^0.1.0"
@@ -76867,7 +76994,6 @@
           "version": "3.1.1",
           "resolved": "https://registry.npmjs.org/is-wsl/-/is-wsl-3.1.1.tgz",
           "integrity": "sha512-e6rvdUCiQCAuumZslxRJWR/Doq4VpPR82kqclvcS0efgt430SlGIk05vdCN58+VrzgtIcfNODjozVielycD4Sw==",
-          "peer": true,
           "requires": {
             "is-inside-container": "^1.0.0"
           }
@@ -77619,7 +77745,8 @@
     "zod": {
       "version": "3.22.4",
       "resolved": "https://registry.npmjs.org/zod/-/zod-3.22.4.tgz",
-      "integrity": "sha512-iC+8Io04lddc+mVqQ9AZ7OQ2MrUKGN+oIQyq1vemgt46jwCwLfhq7/pwnBnNXXXZb8VTVLKwp9EDkx+ryxIWmg=="
+      "integrity": "sha512-iC+8Io04lddc+mVqQ9AZ7OQ2MrUKGN+oIQyq1vemgt46jwCwLfhq7/pwnBnNXXXZb8VTVLKwp9EDkx+ryxIWmg==",
+      "peer": true
     },
     "zustand": {
       "version": "4.4.1",

--- a/package.json
+++ b/package.json
@@ -58,7 +58,7 @@
     "dayjs-precise-range": "^1.0.1",
     "dcl-catalyst-client": "^22.0.0",
     "decentraland-dapps": "^28.0.0",
-    "decentraland-gatsby": "^8.4.6",
+    "decentraland-gatsby": "^8.4.8",
     "discord.js": "^14.7.1",
     "dotenv": "^16.0.0",
     "ethers": "^5.7.1",


### PR DESCRIPTION
Security fix. Bumps `decentraland-gatsby` `^8.4.6` → `^8.4.8`, which pulls `@dcl/crypto-middleware` from `4.1.0` to `5.1.0`. No source changes.

## What the bug was

The signed-fetch payload is lowercased before it is signed:

```
(method + ':' + path + ':' + timestamp + ':' + metadata).toLowerCase()
```

`verify()` then hands the consumer the `x-identity-metadata` header **exactly as delivered**. So `{"signer":"Decentraland-Kernel-Scene"}` and `{"signer":"decentraland-kernel-scene"}` produce a byte-identical signing payload and share one valid signature.

gatsby's `verifySigner` asserts a **negative** — it throws only on an exact match against `'decentraland-kernel-scene'`. A negative assertion fails **open**. A mixed-case spelling is not an exact match, so it sailed past the check and `withAuth` resolved with the real account address.

This service has **62** `auth` / `withAuth` call sites across `src/routes/` (proposal, project, budget, coauthor, update, subscription, badges, airdrop, …), all of them behind that one comparison. A scene-originated request could be presented to any of them as a directly user-signed one.

Whitespace behaves differently and is worth separating: the payload is lowercased but never trimmed, so a padded value changes the signed bytes and cannot be introduced by a third party in flight. It is a self-signed misclassification rather than a signature-reuse attack — but it slipped past the same strict comparison, and is now rejected too.

## What 5.1.0 does

`verifyMetadata` rejects any string `signer` or `intent` that differs from its own `trim().toLowerCase()` form, with `400 Invalid chain metadata`. Hex addresses are exempt, because EIP-55 checksum casing is meaningful.

The guard runs **before** payload construction, before signature verification, and before any consumer-supplied `metadataValidator` — so it cannot be bypassed by anything downstream.

## Why the gatsby bump alone is sufficient here

This repo performs no signer comparison of its own and declares no direct `@dcl/crypto-middleware` dependency. The tree therefore resolves exactly one copy of the middleware, and it moves `4.1.0` → `5.1.0`. Had a direct dependency on `^4` been declared alongside gatsby's `^5`, npm would have installed **both majors** and the bump would not have been enough.

The declared range moves to `^8.4.8` rather than relying on the previous `^8.4.6` floor, which would still permit resolving back to a gatsby carrying the vulnerable middleware on a fresh install.

Note for a follow-up, not fixed here: `src/clients/API.ts:2` imports header-name constants from `@dcl/crypto-middleware`, but the package is not declared in `package.json`. It resolves today only because npm hoists gatsby's copy. Behaviour-neutral, but it is a phantom dependency.

## On the lockfile diff

It is large, and almost all of it is noise. Comparing the parsed `packages` maps between `master` and this branch shows **exactly two** version changes:

| package | before | after |
|---|---|---|
| `@dcl/crypto-middleware` | 4.1.0 | 5.1.0 |
| `decentraland-gatsby` | 8.4.6 | 8.4.8 |

Nothing else moved. The remaining ~1400 lines are npm 11 recording metadata the npm that wrote the committed lockfile did not — mostly the per-platform `@typescript/typescript-*` optional dependencies. Zero packages were removed.

## Verification

| check | result |
|---|---|
| `npm run build` (`tsc -p .`) | green |
| `npm test` | green — 66 suites, 1093 passed, 1 skipped |
| `npm run test:integration` | green — 16 suites, 246 passed (Postgres 15, migrations applied) |
| `npx eslint 'src/**/*.{ts,tsx}'` | 5 errors, **all pre-existing** |
| resolved `@dcl/crypto-middleware` | one copy, 5.1.0, guard present in `dist/verify.js` |

The 5 lint errors are `@typescript-eslint/no-explicit-any` in files this PR does not touch. Verified pre-existing by stashing the change and re-running: identical output, `5 problems (5 errors, 0 warnings)`.

## Related Issue

Part of the fleet-wide rollout of the canonical `metadata.signer` / `metadata.intent` fix (`@dcl/crypto-middleware@5.1.0`).

- [x] **Functionality validation**
    - [x] Feature working as described in the related issue
    - [x] New environment variables have been set — n/a, none added
    - [x] New API services methods have tests — n/a, no source changes
    - [x] Code errors are being logged in the code health service — rejections surface as `400 Invalid chain metadata` through the existing handler
- [x] **Product validation**
    - [x] Usage events are being sent to the product analytics service — n/a, no user-facing change
- [x] **Documentation**
    - [x] README updated — n/a, dependency bump only
    - [x] New API changes are documented — n/a, no API change
