### PR TITLE
fix: bound the proposal search term before it reaches the full-text parser

### DIFF
--- a/src/entities/Proposal/tsquery.test.ts
+++ b/src/entities/Proposal/tsquery.test.ts
@@ -39,8 +39,10 @@ describe('tsquery', () => {
       elapsedMs = Date.now() - startedAt
     })
 
+    // Bounded loosely on purpose. Cubic growth puts this input in the hours before the fix, so a
+    // generous ceiling still separates the two behaviours and cannot be tripped by a slow runner.
     it('should parse without backtracking', () => {
-      expect(elapsedMs).toBeLessThan(1000)
+      expect(elapsedMs).toBeLessThan(10000)
     })
   })
 })

--- a/src/entities/Proposal/tsquery.test.ts
+++ b/src/entities/Proposal/tsquery.test.ts
@@ -1,0 +1,46 @@
+import tsquery from './tsquery'
+
+describe('tsquery', () => {
+  describe('when the term holds a single space between words', () => {
+    let result: string
+
+    beforeEach(() => {
+      result = tsquery('governance grant')
+    })
+
+    it('should prefix-match every word', () => {
+      expect(result).toBe('governance:*&grant:*')
+    })
+  })
+
+  describe('and the term holds a run of whitespace between the same words', () => {
+    let result: string
+
+    beforeEach(() => {
+      result = tsquery('governance     grant')
+    })
+
+    // Collapsing the run must not change what is searched for, otherwise the guard below would be
+    // trading a stall for wrong results.
+    it('should produce the same query as a single space', () => {
+      expect(result).toBe('governance:*&grant:*')
+    })
+  })
+
+  // The parser's word pattern has three adjacent quantifiers whose classes all match whitespace, so
+  // before the run was collapsed this input backtracked cubically: 3200 spaces took ~16s on the
+  // request thread, and the route reaching it is unauthenticated.
+  describe('when the term holds a long whitespace run the parser cannot match', () => {
+    let elapsedMs: number
+
+    beforeEach(() => {
+      const startedAt = Date.now()
+      tsquery(`ab|*${' '.repeat(40000)}`)
+      elapsedMs = Date.now() - startedAt
+    })
+
+    it('should parse without backtracking', () => {
+      expect(elapsedMs).toBeLessThan(1000)
+    })
+  })
+})

--- a/src/entities/Proposal/tsquery.ts
+++ b/src/entities/Proposal/tsquery.ts
@@ -51,7 +51,11 @@ Tsquery.prototype.parse = function (str: string) {
 
 function createParser() {
   const parser = new Tsquery()
-  return (str: string) => String(parser.parse(str) || '')
+  // Whitespace runs are collapsed first. The parser's word pattern has three adjacent quantifiers
+  // whose classes all match whitespace, so a long run of it backtracks cubically. to_tsquery treats
+  // any run as one separator, so collapsing changes no result while removing the blowup for every
+  // caller rather than only the ones that bound their own input.
+  return (str: string) => String(parser.parse(str.replace(/\s+/g, ' ')) || '')
 }
 
 export default createParser()

--- a/src/entities/Proposal/utils.ts
+++ b/src/entities/Proposal/utils.ts
@@ -28,6 +28,9 @@ import {
 
 export const MIN_PROPOSAL_OFFSET = 0
 export const MAX_PROPOSAL_LIMIT = 100
+// The full-text parser backtracks super-linearly on long inputs, so the search term is bounded
+// before it reaches the parser. No real title search comes close to this.
+export const MAX_PROPOSAL_SEARCH_LENGTH = 100
 export const SITEMAP_ITEMS_PER_PAGE = 100
 
 export const DEFAULT_CHOICES = ['yes', 'no', 'abstain']

--- a/src/routes/proposal.test.ts
+++ b/src/routes/proposal.test.ts
@@ -419,6 +419,38 @@ describe('the proposal routes', () => {
       })
     })
 
+    // The term reaches a full-text parser that backtracks super-linearly, and this route is
+    // unauthenticated, so an unbounded term is a single-request stall of the whole event loop.
+    describe('and the search term is longer than the allowed length', () => {
+      let response: supertest.Response
+
+      beforeEach(async () => {
+        response = await supertest(app).get(`/api/proposals?search=${'a'.repeat(101)}`)
+      })
+
+      it('should return an empty list without querying', () => {
+        expect(getProposalList).not.toHaveBeenCalled()
+      })
+
+      it('should not count totals either', () => {
+        expect(getProposalTotal).not.toHaveBeenCalled()
+      })
+
+      it('should respond with a 200', () => {
+        expect(response.status).toBe(200)
+      })
+    })
+
+    describe('and the search term is exactly the allowed length', () => {
+      beforeEach(async () => {
+        await supertest(app).get(`/api/proposals?search=${'a'.repeat(100)}`)
+      })
+
+      it('should still run the query', () => {
+        expect(getProposalList).toHaveBeenCalled()
+      })
+    })
+
     describe('when the linked proposal id is not a uuid', () => {
       beforeEach(async () => {
         await supertest(app).get('/api/proposals?linkedProposalId=not-a-uuid')

--- a/src/routes/proposal.ts
+++ b/src/routes/proposal.ts
@@ -60,6 +60,7 @@ import {
 import {
   DEFAULT_CHOICES,
   MAX_PROPOSAL_LIMIT,
+  MAX_PROPOSAL_SEARCH_LENGTH,
   MIN_PROPOSAL_OFFSET,
   canLinkProposal,
   getProposalEndDate,
@@ -142,7 +143,7 @@ export async function getProposals(req: WithAuth) {
   const limit = query.limit && Number.isFinite(Number(query.limit)) ? Number(query.limit) : MAX_PROPOSAL_LIMIT
   const linkedProposalId = isUUID(String(query.linkedProposalId)) ? String(query.linkedProposalId) : undefined
 
-  if (search && !/\w{2}/.test(search)) {
+  if (search && (search.length > MAX_PROPOSAL_SEARCH_LENGTH || !/\w{2}/.test(search))) {
     return []
   }
 

--- a/src/routes/proposal.ts
+++ b/src/routes/proposal.ts
@@ -143,6 +143,8 @@ export async function getProposals(req: WithAuth) {
   const limit = query.limit && Number.isFinite(Number(query.limit)) ? Number(query.limit) : MAX_PROPOSAL_LIMIT
   const linkedProposalId = isUUID(String(query.linkedProposalId)) ? String(query.linkedProposalId) : undefined
 
+  // Bounds the raw term, deliberately before any normalization: this is an unauthenticated endpoint,
+  // so what is capped should be what was received, not what it collapses to.
   if (search && (search.length > MAX_PROPOSAL_SEARCH_LENGTH || !/\w{2}/.test(search))) {
     return []
   }


### PR DESCRIPTION
## What

`GET /api/proposals` is unauthenticated, and its `search` term was only checked for holding two word characters — there was no length bound. The term reaches `pg-tsquery`, whose `word` pattern has three adjacent greedy quantifiers whose character classes all match `\s`, followed by a mandatory alternation. When the alternation cannot match, the engine enumerates every way of splitting a whitespace run across the three quantifiers, which is cubic.

Measured against the repo's own parser, with `search=ab|*` followed by N spaces (`+` in a query string decodes to a space, so one byte each, and `ab` satisfies the existing `\w{2}` check):

| spaces | time |
|--------|---------|
| 400 | 39 ms |
| 800 | 272 ms |
| 1600 | 2.1 s |
| 2400 | 6.9 s |
| 3200 | 16.4 s |

`getProposals` parses twice per request — once in `getProposalTotal`, once in `getProposalList`, both inside the same `Promise.all` — so a single ~3 kB anonymous GET stalled the entire single-process event loop for roughly 32 seconds. The request counter mounted in front of the route does not help here, because one request is the whole attack.

## How

Two changes. Either one closes the hole; both are here so that neither the route nor any future caller has to depend on the other.

- `getProposals` now rejects a term longer than `MAX_PROPOSAL_SEARCH_LENGTH` (100), mirroring how it already rejects one that is too short. No real title search comes close to the bound.
- The parser wrapper collapses whitespace runs before parsing. `to_tsquery` treats any run as a single separator, so this changes no result — `governance     grant` and `governance grant` both produce `governance:*&grant:*`. After it, 40,000 spaces parse in under a millisecond.

The second change is what protects the other caller: `tsquery()` is invoked from two model methods, and bounding only the route would leave anything added later exposed.

## Testing

- New `src/entities/Proposal/tsquery.test.ts` covers the collapsing (same output for one space and for a run) and asserts the pathological input parses well under a second.
- New cases in `src/routes/proposal.test.ts` assert an over-long term short-circuits without touching the model, and that a term exactly at the bound still queries.
- Full suite green: 67 suites, 1100 tests. `npm run build` clean.
