### PR TITLE
fix: fail closed when the land owner list cannot be read

### DIFF
--- a/src/entities/Badges/utils.test.ts
+++ b/src/entities/Badges/utils.test.ts
@@ -1,5 +1,3 @@
-import { ErrorClient } from '../../clients/ErrorClient'
-
 import { LandOwnersUnavailableError, getLandOwnerAddresses } from './utils'
 
 const FIRST_OWNER = '0x56d0B5eD3D525332F00C9BC938f93598ab16AAA7'
@@ -7,10 +5,6 @@ const SECOND_OWNER = '0x49E4DbfF86a2E5DA27c540c9A9E8D2C3726E278F'
 
 describe('getLandOwnerAddresses', () => {
   let fetchMock: jest.SpyInstance
-
-  beforeEach(() => {
-    jest.spyOn(ErrorClient, 'report').mockImplementation(() => undefined)
-  })
 
   afterEach(() => {
     jest.restoreAllMocks()

--- a/src/entities/Badges/utils.test.ts
+++ b/src/entities/Badges/utils.test.ts
@@ -1,0 +1,109 @@
+import { ErrorClient } from '../../clients/ErrorClient'
+
+import { LandOwnersUnavailableError, getLandOwnerAddresses } from './utils'
+
+const FIRST_OWNER = '0x56d0B5eD3D525332F00C9BC938f93598ab16AAA7'
+const SECOND_OWNER = '0x49E4DbfF86a2E5DA27c540c9A9E8D2C3726E278F'
+
+describe('getLandOwnerAddresses', () => {
+  let fetchMock: jest.SpyInstance
+
+  beforeEach(() => {
+    jest.spyOn(ErrorClient, 'report').mockImplementation(() => undefined)
+  })
+
+  afterEach(() => {
+    jest.restoreAllMocks()
+  })
+
+  describe('when the land api answers with owned tiles', () => {
+    let result: string[]
+
+    beforeEach(async () => {
+      fetchMock = jest.spyOn(globalThis, 'fetch').mockResolvedValue({
+        json: async () => ({
+          data: {
+            '0,0': { owner: FIRST_OWNER },
+            '0,1': { owner: FIRST_OWNER },
+            '1,0': { owner: SECOND_OWNER },
+          },
+        }),
+      } as Response)
+      result = await getLandOwnerAddresses()
+    })
+
+    it('should return each owner once, lowercased', () => {
+      expect(result).toEqual([FIRST_OWNER.toLowerCase(), SECOND_OWNER.toLowerCase()])
+    })
+  })
+
+  describe('and one of the tiles carries no owner', () => {
+    let result: string[]
+
+    beforeEach(async () => {
+      fetchMock = jest.spyOn(globalThis, 'fetch').mockResolvedValue({
+        json: async () => ({
+          data: {
+            '0,0': { owner: FIRST_OWNER },
+            '0,1': {},
+          },
+        }),
+      } as Response)
+      result = await getLandOwnerAddresses()
+    })
+
+    // A single malformed entry used to throw, and the throw became an empty list, which is the shape
+    // that revokes every holder. Skipping the entry keeps the rest of the list usable.
+    it('should skip that tile and keep the remaining owners', () => {
+      expect(result).toEqual([FIRST_OWNER.toLowerCase()])
+    })
+  })
+
+  describe('when the land api request fails', () => {
+    beforeEach(() => {
+      fetchMock = jest.spyOn(globalThis, 'fetch').mockRejectedValue(new Error('network down'))
+    })
+
+    // Revocation is derived from absence, so answering with an empty list would revoke every holder.
+    it('should throw rather than answer with an empty list', async () => {
+      await expect(getLandOwnerAddresses()).rejects.toThrow(LandOwnersUnavailableError)
+    })
+  })
+
+  describe('and the land api answers with no tile data at all', () => {
+    beforeEach(() => {
+      fetchMock = jest.spyOn(globalThis, 'fetch').mockResolvedValue({
+        json: async () => ({}),
+      } as Response)
+    })
+
+    it('should throw rather than answer with an empty list', async () => {
+      await expect(getLandOwnerAddresses()).rejects.toThrow(LandOwnersUnavailableError)
+    })
+  })
+
+  describe('and the land api answers with tiles but no owners among them', () => {
+    beforeEach(() => {
+      fetchMock = jest.spyOn(globalThis, 'fetch').mockResolvedValue({
+        json: async () => ({ data: { '0,0': {}, '0,1': {} } }),
+      } as Response)
+    })
+
+    it('should throw rather than answer with an empty list', async () => {
+      await expect(getLandOwnerAddresses()).rejects.toThrow(LandOwnersUnavailableError)
+    })
+  })
+
+  describe('when the request is made', () => {
+    beforeEach(async () => {
+      fetchMock = jest.spyOn(globalThis, 'fetch').mockResolvedValue({
+        json: async () => ({ data: { '0,0': { owner: FIRST_OWNER } } }),
+      } as Response)
+      await getLandOwnerAddresses()
+    })
+
+    it('should abort rather than hang on an unresponsive land api', () => {
+      expect(fetchMock).toHaveBeenCalledWith(expect.any(String), { signal: expect.any(AbortSignal) })
+    })
+  })
+})

--- a/src/entities/Badges/utils.ts
+++ b/src/entities/Badges/utils.ts
@@ -11,6 +11,7 @@ import { getUsersWhoVoted } from '../Snapshot/utils'
 import { BadgeStatus } from './types'
 
 const TOP_VOTER_TITLE_PREFIX = `Top Voter`
+const LAND_API_TIMEOUT_MS = 30000
 
 export async function getClassifiedUsersForBadge(badgeCid: string, users: string[]) {
   const badges = await OtterspaceSubgraph.get().getBadges(badgeCid)
@@ -93,17 +94,40 @@ export async function getEligibleUsersForBadge(
   }
 }
 
+// Thrown rather than answered with an empty list: the caller treats "not in the list" as "revoke",
+// so an empty list is indistinguishable from "nobody owns land" and would revoke every holder.
+export class LandOwnersUnavailableError extends Error {
+  constructor(cause: unknown) {
+    super(`Could not read the land owners: ${cause}`)
+    this.name = 'LandOwnersUnavailableError'
+  }
+}
+
 export async function getLandOwnerAddresses(): Promise<string[]> {
   const LAND_API_URL = 'https://api.decentraland.org/v2/tiles?include=owner&type=owned'
   type LandOwner = { owner: string }
   try {
-    const response: ApiResponse<{ [coordinates: string]: LandOwner }> = await (await fetch(LAND_API_URL)).json()
+    const response: ApiResponse<{ [coordinates: string]: LandOwner }> = await (
+      await fetch(LAND_API_URL, { signal: AbortSignal.timeout(LAND_API_TIMEOUT_MS) })
+    ).json()
     const { data: landOwnersMap } = response
-    const landOwnersAddresses = new Set(Object.values(landOwnersMap).map((landOwner) => landOwner.owner.toLowerCase()))
+    if (!landOwnersMap || typeof landOwnersMap !== 'object') {
+      throw new Error('the response carried no tile data')
+    }
+    const landOwnersAddresses = new Set(
+      Object.values(landOwnersMap)
+        // A tile without an owner is skipped rather than throwing: one malformed entry must not turn
+        // into an empty list, which is the shape that revokes everyone.
+        .filter((landOwner) => !!landOwner?.owner)
+        .map((landOwner) => landOwner.owner.toLowerCase())
+    )
+    if (landOwnersAddresses.size === 0) {
+      throw new Error('the response carried no land owners')
+    }
     return Array.from(landOwnersAddresses)
   } catch (error) {
     ErrorClient.report("Couldn't fetch land owners", { error, category: ErrorCategory.Badges })
-    return []
+    throw new LandOwnersUnavailableError(error)
   }
 }
 

--- a/src/entities/Badges/utils.ts
+++ b/src/entities/Badges/utils.ts
@@ -1,11 +1,9 @@
 import { ApiResponse } from 'decentraland-gatsby/dist/utils/api/types'
 
-import { ErrorClient } from '../../clients/ErrorClient'
 import { OtterspaceSubgraph } from '../../clients/OtterspaceSubgraph'
 import { TOP_VOTER_BADGE_IMG_URL } from '../../constants'
 import Time from '../../utils/date/Time'
 import { getPreviousMonthStartAndEnd } from '../../utils/date/getPreviousMonthStartAndEnd'
-import { ErrorCategory } from '../../utils/errorCategories'
 import { getUsersWhoVoted } from '../Snapshot/utils'
 
 import { BadgeStatus } from './types'
@@ -126,7 +124,8 @@ export async function getLandOwnerAddresses(): Promise<string[]> {
     }
     return Array.from(landOwnersAddresses)
   } catch (error) {
-    ErrorClient.report("Couldn't fetch land owners", { error, category: ErrorCategory.Badges })
+    // Not reported here: the caller reports the skipped run with the cause attached, and reporting at
+    // both layers raised two alerts for one failure.
     throw new LandOwnersUnavailableError(error)
   }
 }

--- a/src/services/BadgesService.test.ts
+++ b/src/services/BadgesService.test.ts
@@ -6,12 +6,15 @@ import { getChecksumAddress } from '../entities/Snapshot/utils'
 import AirdropJobModel from '../models/AirdropJob'
 
 import { BadgesService } from './BadgesService'
+import { ErrorService } from './ErrorService'
 
 jest.mock('../constants', () => ({
   LEGISLATOR_BADGE_SPEC_CID: 'badge-spec-id',
+  LAND_OWNER_BADGE_SPEC_CID: 'land-owner-badge-spec-id',
 }))
 
 const COAUTHORS = ['0x56d0b5ed3d525332f00c9bc938f93598ab16aaa7', '0x49e4dbff86a2e5da27c540c9a9e8d2c3726e278f']
+const CURRENT_OWNER = '0x56d0b5ed3d525332f00c9bc938f93598ab16aaa7'
 describe('giveLegislatorBadges', () => {
   it('should call queueAirdropJob with correct arguments for governance proposals', async () => {
     jest.spyOn(AirdropJobModel, 'create').mockResolvedValue(async () => {})
@@ -41,5 +44,69 @@ describe('giveLegislatorBadges', () => {
     const proposal = createTestProposal(ProposalType.Draft, ProposalStatus.Passed)
     await BadgesService.giveLegislatorBadges([proposal])
     expect(AirdropJobModel.create).not.toHaveBeenCalled()
+  })
+})
+
+describe('giveAndRevokeLandOwnerBadges', () => {
+  let getLandOwnerAddresses: jest.SpyInstance
+  let getEligibleUsersForBadge: jest.SpyInstance
+  let revokeBadges: jest.SpyInstance
+
+  beforeEach(() => {
+    jest.spyOn(ErrorService, 'report').mockImplementation(() => undefined)
+    getEligibleUsersForBadge = jest.spyOn(BadgesUtils, 'getEligibleUsersForBadge')
+    revokeBadges = jest.spyOn(BadgesService, 'revokeBadges').mockResolvedValue([])
+  })
+
+  afterEach(() => {
+    jest.restoreAllMocks()
+  })
+
+  // The badge to revoke is derived from absence from the owner list, so an unreadable list is
+  // indistinguishable from "nobody owns land" and would revoke every current holder on-chain.
+  describe('when the land owners cannot be read', () => {
+    beforeEach(async () => {
+      getLandOwnerAddresses = jest
+        .spyOn(BadgesUtils, 'getLandOwnerAddresses')
+        .mockRejectedValue(new BadgesUtils.LandOwnersUnavailableError(new Error('network down')))
+      await BadgesService.giveAndRevokeLandOwnerBadges()
+    })
+
+    it('should not revoke any badge', () => {
+      expect(revokeBadges).not.toHaveBeenCalled()
+    })
+
+    it('should not classify holders against an empty owner list', () => {
+      expect(getEligibleUsersForBadge).not.toHaveBeenCalled()
+    })
+
+    it('should report the skipped run', () => {
+      expect(ErrorService.report).toHaveBeenCalledWith(
+        'Skipping the LandOwner badge run: the land owners could not be read',
+        expect.objectContaining({ error: expect.stringContaining('LandOwnersUnavailableError') })
+      )
+    })
+  })
+
+  describe('and the land owners are read and a holder no longer owns land', () => {
+    const FORMER_OWNER = '0x49e4dbff86a2e5da27c540c9a9e8d2c3726e278f'
+
+    beforeEach(async () => {
+      getLandOwnerAddresses = jest.spyOn(BadgesUtils, 'getLandOwnerAddresses').mockResolvedValue([CURRENT_OWNER])
+      getEligibleUsersForBadge.mockResolvedValue({
+        eligibleUsersForBadge: [],
+        usersWithBadgesToReinstate: [],
+        usersWithBadgesToRevoke: [FORMER_OWNER],
+      })
+      await BadgesService.giveAndRevokeLandOwnerBadges()
+    })
+
+    it('should still revoke that holder, so failing closed did not disable the job', () => {
+      expect(revokeBadges).toHaveBeenCalledWith('land-owner-badge-spec-id', [FORMER_OWNER])
+    })
+
+    it('should classify holders against the owner list it read', () => {
+      expect(getLandOwnerAddresses).toHaveBeenCalled()
+    })
   })
 })

--- a/src/services/BadgesService.test.ts
+++ b/src/services/BadgesService.test.ts
@@ -1,9 +1,12 @@
+import { OtterspaceSubgraph } from '../clients/OtterspaceSubgraph'
+import { ActionStatus, ErrorReason, RevokeOrReinstateResult } from '../entities/Badges/types'
 import * as BadgesUtils from '../entities/Badges/utils'
 import CoauthorModel from '../entities/Coauthor/model'
 import { createTestProposal } from '../entities/Proposal/testHelpers'
 import { ProposalStatus, ProposalType } from '../entities/Proposal/types'
 import { getChecksumAddress } from '../entities/Snapshot/utils'
 import AirdropJobModel from '../models/AirdropJob'
+import * as contractInteractions from '../utils/contractInteractions'
 
 import { BadgesService } from './BadgesService'
 import { ErrorService } from './ErrorService'
@@ -11,6 +14,21 @@ import { ErrorService } from './ErrorService'
 jest.mock('../constants', () => ({
   LEGISLATOR_BADGE_SPEC_CID: 'badge-spec-id',
   LAND_OWNER_BADGE_SPEC_CID: 'land-owner-badge-spec-id',
+  TRIMMED_OTTERSPACE_RAFT_ID: 'raft-id',
+  // The real implementation: an id is usable only when it is a two-part `spec:token` string.
+  trimOtterspaceId: (rawId: string) => {
+    const parts = rawId.split(':')
+    return parts.length === 2 ? parts[1] : ''
+  },
+}))
+
+jest.mock('../utils/contractInteractions', () => ({
+  getBadgesSignerAndContract: jest.fn(),
+  estimateGas: jest.fn(),
+  airdropWithRetry: jest.fn(),
+  createSpecWithRetry: jest.fn(),
+  reinstateBadge: jest.fn(),
+  revokeBadge: jest.fn(),
 }))
 
 const COAUTHORS = ['0x56d0b5ed3d525332f00c9bc938f93598ab16aaa7', '0x49e4dbff86a2e5da27c540c9a9e8d2c3726e278f']
@@ -107,6 +125,103 @@ describe('giveAndRevokeLandOwnerBadges', () => {
 
     it('should classify holders against the owner list it read', () => {
       expect(getLandOwnerAddresses).toHaveBeenCalled()
+    })
+  })
+})
+
+// Gas is estimated once for the whole batch. Estimating against an unusable id throws before the loop
+// records anything, so a single bad id at the front used to fail every revocation in the batch.
+describe.each([
+  ['revokeBadges' as const, 'revokeBadge' as const],
+  ['reinstateBadges' as const, 'reinstateBadge' as const],
+])('BadgesService.%s', (method, contractMethod) => {
+  const ADDRESS = '0x56d0b5ed3d525332f00c9bc938f93598ab16aaa7'
+  const OTHER_ADDRESS = '0x49e4dbff86a2e5da27c540c9a9e8d2c3726e278f'
+
+  let getRecipientsBadgeIds: jest.Mock
+  let estimateGasSpy: jest.Mock
+  let contractCall: jest.Mock
+
+  beforeEach(() => {
+    contractCall = jest.fn().mockResolvedValue({ hash: '0xhash', wait: jest.fn().mockResolvedValue({}) })
+    estimateGasSpy = contractInteractions.estimateGas as jest.Mock
+    estimateGasSpy.mockResolvedValue({})
+    ;(contractInteractions.getBadgesSignerAndContract as jest.Mock).mockReturnValue({
+      signer: {},
+      contract: {
+        estimateGas: { [contractMethod]: jest.fn().mockResolvedValue({}) },
+        connect: () => ({ [contractMethod]: contractCall }),
+      },
+    })
+    getRecipientsBadgeIds = jest.fn()
+    jest.spyOn(OtterspaceSubgraph, 'get').mockReturnValue({ getRecipientsBadgeIds } as never)
+  })
+
+  afterEach(() => {
+    jest.restoreAllMocks()
+    jest.clearAllMocks()
+  })
+
+  describe('when every returned badge id is unusable', () => {
+    let results: RevokeOrReinstateResult[]
+
+    beforeEach(async () => {
+      getRecipientsBadgeIds.mockResolvedValue([
+        { id: 'malformed', address: ADDRESS },
+        { id: 'also-malformed', address: OTHER_ADDRESS },
+      ])
+      results = await BadgesService[method]('badge-cid', [ADDRESS, OTHER_ADDRESS])
+    })
+
+    it('should not estimate gas against an unusable id', () => {
+      expect(estimateGasSpy).not.toHaveBeenCalled()
+    })
+
+    it('should not submit any transaction', () => {
+      expect(contractCall).not.toHaveBeenCalled()
+    })
+
+    it('should report the invalid id for every recipient', () => {
+      expect(results).toEqual([
+        { status: ActionStatus.Failed, address: ADDRESS, badgeId: 'malformed', error: ErrorReason.InvalidBadgeId },
+        {
+          status: ActionStatus.Failed,
+          address: OTHER_ADDRESS,
+          badgeId: 'also-malformed',
+          error: ErrorReason.InvalidBadgeId,
+        },
+      ])
+    })
+  })
+
+  // The batch used to be estimated against whichever id came first, so a leading bad id took the
+  // whole batch down with it.
+  describe('and only the first badge id is unusable', () => {
+    let results: RevokeOrReinstateResult[]
+
+    beforeEach(async () => {
+      getRecipientsBadgeIds.mockResolvedValue([
+        { id: 'malformed', address: ADDRESS },
+        { id: 'spec:token', address: OTHER_ADDRESS },
+      ])
+      results = await BadgesService[method]('badge-cid', [ADDRESS, OTHER_ADDRESS])
+    })
+
+    it('should estimate gas against the first usable id', () => {
+      expect(estimateGasSpy).toHaveBeenCalled()
+    })
+
+    it('should still act on the recipient whose id is usable', () => {
+      expect(results).toContainEqual({ status: ActionStatus.Success, address: OTHER_ADDRESS, badgeId: 'token' })
+    })
+
+    it('should report the invalid id for the other recipient', () => {
+      expect(results).toContainEqual({
+        status: ActionStatus.Failed,
+        address: ADDRESS,
+        badgeId: 'malformed',
+        error: ErrorReason.InvalidBadgeId,
+      })
     })
   })
 })

--- a/src/services/BadgesService.ts
+++ b/src/services/BadgesService.ts
@@ -152,7 +152,20 @@ export class BadgesService {
   }
 
   static async giveAndRevokeLandOwnerBadges() {
-    const landOwnerAddresses = await getLandOwnerAddresses()
+    let landOwnerAddresses: string[]
+    try {
+      landOwnerAddresses = await getLandOwnerAddresses()
+    } catch (error) {
+      // Revocation is derived from absence, so an unreadable owner list would revoke every holder
+      // on-chain. Nothing is granted either, because a partial run cannot be told apart from a
+      // complete one; the next scheduled run retries.
+      ErrorService.report('Skipping the LandOwner badge run: the land owners could not be read', {
+        category: ErrorCategory.Badges,
+        error: `${error}`,
+      })
+      return
+    }
+
     const { eligibleUsersForBadge, usersWithBadgesToReinstate, usersWithBadgesToRevoke, error } =
       await getEligibleUsersForBadge(LAND_OWNER_BADGE_SPEC_CID, landOwnerAddresses)
     if (error) {
@@ -318,6 +331,7 @@ export class BadgesService {
             badgeId: badgeOwnership.id,
             error: ErrorReason.InvalidBadgeId,
           })
+          continue
         }
         const txn = await contract.connect(signer).revokeBadge(TRIMMED_OTTERSPACE_RAFT_ID, trimmedId, reason, gasConfig)
         await txn.wait()
@@ -360,6 +374,7 @@ export class BadgesService {
             badgeId: badgeOwnership.id,
             error: ErrorReason.InvalidBadgeId,
           })
+          continue
         }
         const txn = await contract.connect(signer).reinstateBadge(TRIMMED_OTTERSPACE_RAFT_ID, trimmedId, gasConfig)
         await txn.wait()

--- a/src/services/BadgesService.ts
+++ b/src/services/BadgesService.ts
@@ -67,6 +67,23 @@ function splitArray<Type>(array: Type[], chunkSize: number): Type[][] {
   )
 }
 
+type BadgeOwnership = { id: string; address: string }
+
+// Gas is estimated once for the batch, so it has to be estimated against an id the batch will
+// actually use rather than whichever one happens to be first.
+function getFirstValidBadgeId(badgeOwnerships: BadgeOwnership[]): string | undefined {
+  return badgeOwnerships.map((badgeOwnership) => trimOtterspaceId(badgeOwnership.id)).find((id) => id !== '')
+}
+
+function invalidBadgeIdResults(badgeOwnerships: BadgeOwnership[]): RevokeOrReinstateResult[] {
+  return badgeOwnerships.map((badgeOwnership) => ({
+    status: ActionStatus.Failed,
+    address: badgeOwnership.address,
+    badgeId: badgeOwnership.id,
+    error: ErrorReason.InvalidBadgeId,
+  }))
+}
+
 export class BadgesService {
   public static async getBadges(address: string): Promise<UserBadges> {
     const otterspaceBadges: OtterspaceBadge[] = await OtterspaceSubgraph.get().getBadgesForAddress(address)
@@ -311,13 +328,16 @@ export class BadgesService {
     if (!badgeOwnerships || badgeOwnerships.length === 0) {
       return []
     }
+    const firstValidBadgeId = getFirstValidBadgeId(badgeOwnerships)
+    // Estimating against an unusable id fails the whole batch before a single per-item result is
+    // recorded, so with nothing valid to estimate against there is nothing worth submitting either.
+    if (!firstValidBadgeId) {
+      return invalidBadgeIdResults(badgeOwnerships)
+    }
+
     const { signer, contract } = getBadgesSignerAndContract()
     const gasConfig = await estimateGas(async () => {
-      return contract.estimateGas.revokeBadge(
-        TRIMMED_OTTERSPACE_RAFT_ID,
-        trimOtterspaceId(badgeOwnerships[0].id),
-        reason
-      )
+      return contract.estimateGas.revokeBadge(TRIMMED_OTTERSPACE_RAFT_ID, firstValidBadgeId, reason)
     })
 
     const actionResults: RevokeOrReinstateResult[] = []
@@ -357,9 +377,16 @@ export class BadgesService {
     if (!badgeOwnerships || badgeOwnerships.length === 0) {
       return []
     }
+    const firstValidBadgeId = getFirstValidBadgeId(badgeOwnerships)
+    // Estimating against an unusable id fails the whole batch before a single per-item result is
+    // recorded, so with nothing valid to estimate against there is nothing worth submitting either.
+    if (!firstValidBadgeId) {
+      return invalidBadgeIdResults(badgeOwnerships)
+    }
+
     const { signer, contract } = getBadgesSignerAndContract()
     const gasConfig = await estimateGas(async () => {
-      return contract.estimateGas.reinstateBadge(TRIMMED_OTTERSPACE_RAFT_ID, trimOtterspaceId(badgeOwnerships[0].id))
+      return contract.estimateGas.reinstateBadge(TRIMMED_OTTERSPACE_RAFT_ID, firstValidBadgeId)
     })
 
     const actionResults: RevokeOrReinstateResult[] = []


### PR DESCRIPTION
## What

`getLandOwnerAddresses` returned `[]` on any failure, and the LandOwner badge job derives revocation from *absence* from that list. With an empty list, every current holder falls into `unlistedUsersWithMintedOrReinstatedBadge` and comes back as `usersWithBadgesToRevoke`.

Nothing threw, so `getEligibleUsersForBadge` returned no `error`, the guard in `giveAndRevokeLandOwnerBadges` did not fire, and `revokeBadges` signed and broadcast a real `revokeBadge` transaction per holder with the raft owner key. The job runs daily at 02:30 in production.

Any of these was enough to trigger it: a request timeout, a DNS or TLS blip, a non-JSON response, or a single tile missing `owner` — `landOwner.owner.toLowerCase()` threw inside the same `try` and became the same empty list.

Recovery is not symmetric, which is what makes this worse than a transient outage. Reinstatement only covers holders who also voted on Snapshot, so any land owner who never voted stayed revoked permanently. It also burns MATIC per address.

## How

- `getLandOwnerAddresses` throws `LandOwnersUnavailableError` instead of returning an empty list. It also refuses a response carrying no tile data, or tiles with no owners among them, because those reach the caller as the same revoke-everyone shape.
- A tile without an `owner` is now skipped rather than throwing, so one malformed entry no longer discards the entire list.
- The request carries `AbortSignal.timeout`; it previously had none, unlike every other outbound call in the repo.
- `giveAndRevokeLandOwnerBadges` skips the run and reports it rather than proceeding on a list it could not read. Nothing is granted either — a partial read cannot be distinguished from a complete one, and the next scheduled run retries.

Scope check: LandOwner is the only badge whose job acts on `usersWithBadgesToRevoke`. The other caller of `getEligibleUsersForBadge` discards it, so no other badge could be mass-revoked this way.

## Also in here

The `trimmedId === ''` branch in `revokeBadges` and `reinstateBadges` recorded an `InvalidBadgeId` failure but had no `continue`, so it fell through and submitted the transaction anyway with an empty badge id, then could push a second result for the same entry. Both now `continue`. The third site with this shape already used an `else` and was correct — this brings the three into line.

## Deliberately not here

A ratio cap on the revocation batch (refuse if the revoke set exceeds some fraction of holders) would be belt-and-braces on top of this. I left it out because it needs `getEligibleUsersForBadge` to return the holder total, which ripples into its other caller, and the realistic failure modes are all covered by the guards above — the Land API is not paginated, and a truncated body fails JSON parsing rather than yielding a partial list. Worth doing separately if you want the extra margin.

## Testing

- New `src/entities/Badges/utils.test.ts`: owners deduped and lowercased on the happy path; a tile with no owner skipped rather than discarding the list; throws on request failure, on missing tile data, and on tiles with no owners; the request passes an abort signal.
- New cases in `src/services/BadgesService.test.ts`: an unreadable list revokes nothing and never classifies holders, and reports the skipped run — plus a happy-path case asserting a genuine former owner is still revoked, so failing closed did not quietly disable the job.
- Full suite green: 67 suites, 1104 tests. `npm run build` clean.
