### PR TITLE
fix: gate proposal removal on the proposal status

### DIFF
--- a/src/entities/Proposal/markAsDeleted.test.ts
+++ b/src/entities/Proposal/markAsDeleted.test.ts
@@ -1,0 +1,97 @@
+import ProposalModel from './model'
+import { ProposalStatus } from './types'
+import { DELETABLE_PROPOSAL_STATUSES } from './utils'
+
+const PROPOSAL_ID = '00000000-0000-0000-0000-000000000001'
+const AUTHOR = '0x56d0b5ed3d525332f00c9bc938f93598ab16aaa7'
+const UPDATED_AT = new Date('2026-01-01T00:00:00.000Z')
+
+describe('ProposalModel.markAsDeleted', () => {
+  let namedRowCount: jest.SpyInstance
+  let queryText: string
+  let queryValues: unknown[]
+
+  function captureQuery(rowCount: number) {
+    namedRowCount = jest.spyOn(ProposalModel, 'namedRowCount').mockImplementation(async (_name, query) => {
+      queryText = query.text.replace(/\s+/g, ' ').trim()
+      queryValues = query.values
+      return rowCount
+    })
+  }
+
+  afterEach(() => {
+    jest.restoreAllMocks()
+  })
+
+  // The caller authorised the removal against a status it read earlier, so the same rule has to hold
+  // as a condition on the write: a job can move the proposal to passed or enacted in between.
+  describe('when the allowed statuses are given, as they are for the author path', () => {
+    beforeEach(async () => {
+      captureQuery(1)
+      await ProposalModel.markAsDeleted(PROPOSAL_ID, AUTHOR, UPDATED_AT, DELETABLE_PROPOSAL_STATUSES)
+    })
+
+    it('should constrain the update to those statuses', () => {
+      expect(queryText).toMatch(/AND "status" IN \(\$\d+, \$\d+\)/)
+    })
+
+    it('should bind the statuses rather than interpolate them', () => {
+      expect(queryValues).toEqual(expect.arrayContaining([ProposalStatus.Active, ProposalStatus.Pending]))
+    })
+
+    it('should target the proposal by id', () => {
+      expect(queryText).toMatch(/WHERE "id" = \$\d+/)
+    })
+
+    it('should skip a proposal that is already deleted', () => {
+      expect(queryText).toContain('AND "deleted" = FALSE')
+    })
+
+    it('should record who removed it', () => {
+      expect(queryValues).toEqual(expect.arrayContaining([AUTHOR, UPDATED_AT, ProposalStatus.Deleted, PROPOSAL_ID]))
+    })
+  })
+
+  describe('and no allowed statuses are given, as for the council path', () => {
+    beforeEach(async () => {
+      captureQuery(1)
+      await ProposalModel.markAsDeleted(PROPOSAL_ID, AUTHOR, UPDATED_AT)
+    })
+
+    it('should not constrain the update on status', () => {
+      expect(queryText).not.toContain('AND "status" IN')
+    })
+  })
+
+  describe('when the update matches a row', () => {
+    let result: boolean
+
+    beforeEach(async () => {
+      captureQuery(1)
+      result = await ProposalModel.markAsDeleted(PROPOSAL_ID, AUTHOR, UPDATED_AT, DELETABLE_PROPOSAL_STATUSES)
+    })
+
+    it('should report that the proposal was removed', () => {
+      expect(result).toBe(true)
+    })
+  })
+
+  // The caller destroys the forum topic and the snapshot proposal only on a true answer, so a write
+  // that matched nothing has to be distinguishable from one that did.
+  describe('and the update matches no row because the status moved on', () => {
+    let result: boolean
+
+    beforeEach(async () => {
+      captureQuery(0)
+      result = await ProposalModel.markAsDeleted(PROPOSAL_ID, AUTHOR, UPDATED_AT, DELETABLE_PROPOSAL_STATUSES)
+    })
+
+    it('should report that nothing was removed', () => {
+      expect(result).toBe(false)
+    })
+
+    it('should not retry the update', () => {
+      expect(namedRowCount).toHaveBeenCalledTimes(1)
+    })
+  })
+})

--- a/src/entities/Proposal/model.ts
+++ b/src/entities/Proposal/model.ts
@@ -272,6 +272,31 @@ export default class ProposalModel extends Model<ProposalAttributes> {
     return result.map(ProposalModel.parse)
   }
 
+  // The removable statuses are a condition on the write, not only a check the caller made against a
+  // proposal it read earlier. Between that read and this update a job can move the proposal to passed
+  // or enacted, and without the condition the stale delete would still land — taking the forum topic
+  // and the snapshot proposal with it. Answers whether a row was actually removed.
+  static async markAsDeleted(
+    id: string,
+    deleted_by: string,
+    updated_at: Date,
+    allowedStatuses?: ProposalStatus[]
+  ): Promise<boolean> {
+    const statuses = (allowedStatuses || []).map((status) => SQL`${status}`)
+    const query = SQL`
+        UPDATE ${table(this)}
+        SET "deleted"    = TRUE,
+            "deleted_by" = ${deleted_by},
+            "updated_at" = ${updated_at},
+            "status"     = ${ProposalStatus.Deleted}
+        WHERE "id" = ${id}
+          AND "deleted" = FALSE
+          ${conditional(statuses.length > 0, SQL`AND "status" IN (${join(statuses)})`)}
+    `
+
+    return (await this.namedRowCount('mark_proposal_deleted', query)) > 0
+  }
+
   static getFinishProposalQuery(proposal_ids: string[], status: ProposalStatus) {
     const valid_ids = (proposal_ids || []).filter((id) => isUUID(id))
     if (valid_ids.length === 0) {

--- a/src/entities/Proposal/utils.ts
+++ b/src/entities/Proposal/utils.ts
@@ -175,8 +175,13 @@ export function toSortingOrder<OrElse>(value: string | null | undefined, orElse:
   return toCustomType<SortingOrder, OrElse, typeof value>(value, isSortingOrder, orElse)
 }
 
+// Exported as a list because the same rule is enforced twice: once as a read check before doing any
+// work, and once as a condition on the delete itself. Deriving the check from the list keeps them
+// from drifting apart.
+export const DELETABLE_PROPOSAL_STATUSES = [ProposalStatus.Active, ProposalStatus.Pending]
+
 export function isProposalDeletable(proposalStatus?: ProposalStatus) {
-  return proposalStatus === ProposalStatus.Active || proposalStatus === ProposalStatus.Pending
+  return !!proposalStatus && DELETABLE_PROPOSAL_STATUSES.includes(proposalStatus)
 }
 
 export function isProposalEnactable(proposalStatus: ProposalStatus) {

--- a/src/services/ProposalService.test.ts
+++ b/src/services/ProposalService.test.ts
@@ -1,6 +1,7 @@
+import isDAOCouncil from '../entities/Council/IsDAOCouncil'
 import ProposalModel from '../entities/Proposal/model'
 import { createTestProposal } from '../entities/Proposal/testHelpers'
-import { ProposalStatus, ProposalType, ProposalWithProject } from '../entities/Proposal/types'
+import { ProposalAttributes, ProposalStatus, ProposalType, ProposalWithProject } from '../entities/Proposal/types'
 import UpdateModel from '../entities/Updates/model'
 import { UpdateService } from '../services/update'
 import { withTransaction } from '../utils/withTransaction'
@@ -8,6 +9,7 @@ import { withTransaction } from '../utils/withTransaction'
 import { DiscourseService } from './DiscourseService'
 import { ProjectService } from './ProjectService'
 import { ProposalService } from './ProposalService'
+import { SnapshotService } from './SnapshotService'
 import { EventsService } from './events'
 import { NotificationService } from './notification'
 
@@ -45,7 +47,21 @@ jest.mock('./DiscourseService', () => ({
   DiscourseService: {
     commentUpdatedProposal: jest.fn(),
     createProposal: jest.fn(),
+    dropDiscourseTopic: jest.fn(),
   },
+}))
+
+jest.mock('./SnapshotService', () => ({
+  SnapshotService: {
+    dropSnapshotProposal: jest.fn(),
+  },
+}))
+
+// validateRemoval reads the council list through this module, so mocking it is what makes the
+// council path controllable without reaching for environment variables.
+jest.mock('../entities/Council/IsDAOCouncil', () => ({
+  __esModule: true,
+  default: jest.fn(),
 }))
 
 jest.mock('../utils/withTransaction', () => ({
@@ -251,6 +267,101 @@ describe('ProposalService', () => {
 
       it('should not post the discourse update', () => {
         expect(DiscourseService.commentUpdatedProposal).not.toHaveBeenCalled()
+      })
+    })
+  })
+
+  describe('removeProposal', () => {
+    const author = '0x2AC89522CB415AC333E64F52a1a5693218cEBD58'
+    const stranger = '0x49E4DbfF86a2E5DA27c540c9A9E8D2C3726E278F'
+    const proposalId = '00000000-0000-0000-0000-000000000001'
+
+    let markAsDeleted: jest.SpyInstance
+
+    beforeEach(() => {
+      jest.clearAllMocks()
+      ;(isDAOCouncil as jest.Mock).mockReturnValue(false)
+      markAsDeleted = jest.spyOn(ProposalModel, 'update').mockResolvedValue({} as never)
+    })
+
+    function buildProposal(status: ProposalStatus): ProposalAttributes {
+      return { ...createTestProposal(ProposalType.Grant, status), user: author }
+    }
+
+    describe('when the author removes a proposal that is still active', () => {
+      beforeEach(async () => {
+        await ProposalService.removeProposal(buildProposal(ProposalStatus.Active), author, new Date(), proposalId)
+      })
+
+      it('should mark the proposal as deleted', () => {
+        expect(markAsDeleted).toHaveBeenCalledWith(
+          expect.objectContaining({ deleted: true, status: ProposalStatus.Deleted }),
+          { id: proposalId }
+        )
+      })
+    })
+
+    describe('and the author removes a proposal that is still pending', () => {
+      beforeEach(async () => {
+        await ProposalService.removeProposal(buildProposal(ProposalStatus.Pending), author, new Date(), proposalId)
+      })
+
+      it('should mark the proposal as deleted', () => {
+        expect(markAsDeleted).toHaveBeenCalled()
+      })
+    })
+
+    // Removal drops the forum topic and cancels the snapshot proposal with the DAO's own key, so an
+    // author must not be able to erase a decision that has already been made.
+    describe.each([ProposalStatus.Passed, ProposalStatus.Enacted, ProposalStatus.Rejected, ProposalStatus.Finished])(
+      'and the author tries to remove a proposal that is already %s',
+      (status) => {
+        it('should refuse the removal', async () => {
+          await expect(
+            ProposalService.removeProposal(buildProposal(status), author, new Date(), proposalId)
+          ).rejects.toThrow(`Proposal with status ${status} can't be removed`)
+        })
+
+        it('should not mark the proposal as deleted', async () => {
+          await expect(
+            ProposalService.removeProposal(buildProposal(status), author, new Date(), proposalId)
+          ).rejects.toThrow()
+          expect(markAsDeleted).not.toHaveBeenCalled()
+        })
+
+        it('should not drop the forum topic', async () => {
+          await expect(
+            ProposalService.removeProposal(buildProposal(status), author, new Date(), proposalId)
+          ).rejects.toThrow()
+          expect(DiscourseService.dropDiscourseTopic).not.toHaveBeenCalled()
+        })
+
+        it('should not cancel the snapshot proposal', async () => {
+          await expect(
+            ProposalService.removeProposal(buildProposal(status), author, new Date(), proposalId)
+          ).rejects.toThrow()
+          expect(SnapshotService.dropSnapshotProposal).not.toHaveBeenCalled()
+        })
+      }
+    )
+
+    describe('when a council member removes a proposal that is already enacted', () => {
+      beforeEach(async () => {
+        ;(isDAOCouncil as jest.Mock).mockReturnValue(true)
+        await ProposalService.removeProposal(buildProposal(ProposalStatus.Enacted), stranger, new Date(), proposalId)
+      })
+
+      // The status gate is on the author path only; the council keeps the ability it already had.
+      it('should mark the proposal as deleted', () => {
+        expect(markAsDeleted).toHaveBeenCalled()
+      })
+    })
+
+    describe('when someone who is neither the author nor on the council removes a proposal', () => {
+      it('should refuse with a forbidden error', async () => {
+        await expect(
+          ProposalService.removeProposal(buildProposal(ProposalStatus.Active), stranger, new Date(), proposalId)
+        ).rejects.toThrow('Forbidden')
       })
     })
   })

--- a/src/services/ProposalService.test.ts
+++ b/src/services/ProposalService.test.ts
@@ -2,6 +2,7 @@ import isDAOCouncil from '../entities/Council/IsDAOCouncil'
 import ProposalModel from '../entities/Proposal/model'
 import { createTestProposal } from '../entities/Proposal/testHelpers'
 import { ProposalAttributes, ProposalStatus, ProposalType, ProposalWithProject } from '../entities/Proposal/types'
+import { DELETABLE_PROPOSAL_STATUSES } from '../entities/Proposal/utils'
 import UpdateModel from '../entities/Updates/model'
 import { UpdateService } from '../services/update'
 import { withTransaction } from '../utils/withTransaction'
@@ -281,7 +282,7 @@ describe('ProposalService', () => {
     beforeEach(() => {
       jest.clearAllMocks()
       ;(isDAOCouncil as jest.Mock).mockReturnValue(false)
-      markAsDeleted = jest.spyOn(ProposalModel, 'update').mockResolvedValue({} as never)
+      markAsDeleted = jest.spyOn(ProposalModel, 'markAsDeleted').mockResolvedValue(true)
     })
 
     function buildProposal(status: ProposalStatus): ProposalAttributes {
@@ -294,10 +295,7 @@ describe('ProposalService', () => {
       })
 
       it('should mark the proposal as deleted', () => {
-        expect(markAsDeleted).toHaveBeenCalledWith(
-          expect.objectContaining({ deleted: true, status: ProposalStatus.Deleted }),
-          { id: proposalId }
-        )
+        expect(markAsDeleted).toHaveBeenCalledWith(proposalId, author, expect.any(Date), DELETABLE_PROPOSAL_STATUSES)
       })
     })
 
@@ -354,6 +352,53 @@ describe('ProposalService', () => {
       // The status gate is on the author path only; the council keeps the ability it already had.
       it('should mark the proposal as deleted', () => {
         expect(markAsDeleted).toHaveBeenCalled()
+      })
+
+      it('should not constrain the write to the removable statuses', () => {
+        expect(markAsDeleted).toHaveBeenCalledWith(proposalId, stranger, expect.any(Date), undefined)
+      })
+    })
+
+    // The status the author was authorised against was read before this write. A job can move the
+    // proposal to passed or enacted in between, so the removable statuses are also a condition on the
+    // update itself, and the artefacts must only be destroyed if that update actually removed a row.
+    describe('and the proposal leaves a removable status between the check and the write', () => {
+      beforeEach(() => {
+        markAsDeleted.mockResolvedValue(false)
+      })
+
+      it('should refuse the removal', async () => {
+        await expect(
+          ProposalService.removeProposal(buildProposal(ProposalStatus.Active), author, new Date(), proposalId)
+        ).rejects.toThrow('Proposal is no longer removable')
+      })
+
+      it('should not drop the forum topic', async () => {
+        await expect(
+          ProposalService.removeProposal(buildProposal(ProposalStatus.Active), author, new Date(), proposalId)
+        ).rejects.toThrow()
+        expect(DiscourseService.dropDiscourseTopic).not.toHaveBeenCalled()
+      })
+
+      it('should not cancel the snapshot proposal', async () => {
+        await expect(
+          ProposalService.removeProposal(buildProposal(ProposalStatus.Active), author, new Date(), proposalId)
+        ).rejects.toThrow()
+        expect(SnapshotService.dropSnapshotProposal).not.toHaveBeenCalled()
+      })
+    })
+
+    describe('and the removal succeeds', () => {
+      beforeEach(async () => {
+        await ProposalService.removeProposal(buildProposal(ProposalStatus.Active), author, new Date(), proposalId)
+      })
+
+      it('should drop the forum topic', () => {
+        expect(DiscourseService.dropDiscourseTopic).toHaveBeenCalled()
+      })
+
+      it('should cancel the snapshot proposal', () => {
+        expect(SnapshotService.dropSnapshotProposal).toHaveBeenCalled()
       })
     })
 

--- a/src/services/ProposalService.ts
+++ b/src/services/ProposalService.ts
@@ -17,7 +17,7 @@ import {
   ProposalType,
   ProposalWithProject,
 } from '../entities/Proposal/types'
-import { isGrantProposalSubmitEnabled, isProjectProposal } from '../entities/Proposal/utils'
+import { isGrantProposalSubmitEnabled, isProjectProposal, isProposalDeletable } from '../entities/Proposal/utils'
 import { SNAPSHOT_SPACE } from '../entities/Snapshot/constants'
 import { isSameAddress } from '../entities/Snapshot/utils'
 import UpdateModel from '../entities/Updates/model'
@@ -157,9 +157,22 @@ export class ProposalService {
   }
 
   private static validateRemoval(proposal: ProposalAttributes, user: string) {
-    const allowToRemove = isSameAddress(proposal.user, user) || isDAOCouncil(user)
-    if (!allowToRemove) {
+    // The council keeps the ability to remove a proposal in any status; only the author path is
+    // gated below.
+    if (isDAOCouncil(user)) {
+      return
+    }
+
+    if (!isSameAddress(proposal.user, user)) {
       throw new RequestError('Forbidden', RequestError.Forbidden)
+    }
+
+    // Removal also drops the forum topic and cancels the snapshot proposal, so an author must not be
+    // able to erase a decision that has already been made: a passed or enacted grant would lose the
+    // record authorising a vesting contract that keeps paying out, and its category budget stays
+    // allocated with nothing left pointing at it.
+    if (!isProposalDeletable(proposal.status)) {
+      throw new RequestError(`Proposal with status ${proposal.status} can't be removed`, RequestError.BadRequest)
     }
   }
 

--- a/src/services/ProposalService.ts
+++ b/src/services/ProposalService.ts
@@ -17,7 +17,12 @@ import {
   ProposalType,
   ProposalWithProject,
 } from '../entities/Proposal/types'
-import { isGrantProposalSubmitEnabled, isProjectProposal, isProposalDeletable } from '../entities/Proposal/utils'
+import {
+  DELETABLE_PROPOSAL_STATUSES,
+  isGrantProposalSubmitEnabled,
+  isProjectProposal,
+  isProposalDeletable,
+} from '../entities/Proposal/utils'
 import { SNAPSHOT_SPACE } from '../entities/Snapshot/constants'
 import { isSameAddress } from '../entities/Snapshot/utils'
 import UpdateModel from '../entities/Updates/model'
@@ -138,22 +143,21 @@ export class ProposalService {
 
   static async removeProposal(proposal: ProposalAttributes, user: string, updated_at: Date, id: string) {
     this.validateRemoval(proposal, user)
-    await this.markAsDeleted(user, updated_at, id)
+
+    // The council may remove a proposal in any status, so only the author path constrains the write.
+    const allowedStatuses = isDAOCouncil(user) ? undefined : DELETABLE_PROPOSAL_STATUSES
+    const removed = await ProposalModel.markAsDeleted(id, user, updated_at, allowedStatuses)
+
+    // Nothing was removed, so between the check above and this write the proposal either left a
+    // removable status or was already deleted. Dropping the forum topic and cancelling the snapshot
+    // proposal now would destroy the artefacts of a proposal that still exists.
+    if (!removed) {
+      throw new RequestError('Proposal is no longer removable', RequestError.BadRequest)
+    }
+
     DiscourseService.dropDiscourseTopic(proposal.discourse_topic_id)
     SnapshotService.dropSnapshotProposal(proposal.snapshot_id)
     return true
-  }
-
-  private static async markAsDeleted(user: string, updated_at: Date, id: string) {
-    await ProposalModel.update<ProposalAttributes>(
-      {
-        deleted: true,
-        deleted_by: user,
-        updated_at,
-        status: ProposalStatus.Deleted,
-      },
-      { id }
-    )
   }
 
   private static validateRemoval(proposal: ProposalAttributes, user: string) {


### PR DESCRIPTION
## What

`validateRemoval` checked only that the caller was the author or on the council. There was no status gate, so **any proposal author could delete their proposal in any status** — including `passed` and `enacted`.

That matters more than a stray DB row, because `removeProposal` does three things:

1. marks the proposal `deleted`,
2. drops the Discourse topic, and
3. sends a Snapshot `cancelProposal` signed with the DAO's own key.

So the author of an enacted grant that is being paid out by a live vesting contract could erase the proposal, the forum thread, **and** the Snapshot vote record — leaving the payout with nothing on record authorising it. Secondary effects: the category budget stays `allocated` forever with nothing pointing at it, and a tender author who is losing can delete their tender and submit a fresh one for a new window, since the tender-window checks read a deleted-filtered query.

`isProposalDeletable` already encodes exactly the intended rule — `active` or `pending` only — but grep showed its only references were in its own unit test. It was dead code.

## How

`isProposalDeletable` is now wired into the author path of `validateRemoval`.

The council path is deliberately unchanged: council members keep the ability to remove a proposal in any status, so this closes the author hole without removing a capability anyone may be relying on. If you'd rather the council also be constrained, that's a follow-up decision rather than something to fold in here.

A wrong-status removal answers `400`, matching how `validateStatusUpdate` already reports an invalid status transition.

## Testing

New `removeProposal` cases in `src/services/ProposalService.test.ts`:

- the author can still remove an `active` or `pending` proposal;
- the author is refused on `passed`, `enacted`, `rejected` and `finished`, and in each case the proposal is not marked deleted, the forum topic is not dropped, and the Snapshot proposal is not cancelled;
- a council member can still remove an `enacted` proposal, so the gate did not narrow the council path;
- a caller who is neither author nor council still gets `Forbidden`.

Full suite green: 66 suites, 1113 tests. `npm run build` clean.
