### PR TITLE
fix: elect a tender or bid winner only once

### DIFF
--- a/src/entities/Proposal/jobs.test.ts
+++ b/src/entities/Proposal/jobs.test.ts
@@ -11,7 +11,7 @@ import CoauthorModel from '../Coauthor/model'
 import { NewGrantCategory } from '../Grant/types'
 import { getQuarterEndDate } from '../QuarterBudget/utils'
 
-import { finishProposal, getFinishableLinkedProposals } from './jobs'
+import { finishProposal, getFinishableLinkedProposals, getLinkedProposalGroups } from './jobs'
 import ProposalModel from './model'
 import * as calculateOutcome from './outcome'
 import {
@@ -402,5 +402,169 @@ describe('getFinishabledLinkedProposals', () => {
 
     const finishableBidProposals = await getFinishableLinkedProposals(pendingProposals, ProposalType.Bid)
     expect(finishableBidProposals.length).toEqual(4)
+  })
+})
+
+describe('getLinkedProposalGroups', () => {
+  const LINKED_ID = '123'
+  let pendingProposals: ProposalAttributes[]
+  let siblings: ProposalAttributes[]
+  let result: { activeProposals: ProposalAttributes[]; decidedLinkedProposalIds: Set<string> }
+
+  beforeEach(() => {
+    pendingProposals = [createTestBid('late', LINKED_ID)]
+  })
+
+  afterEach(() => {
+    jest.restoreAllMocks()
+  })
+
+  describe('when every sibling of the group is still active', () => {
+    beforeEach(async () => {
+      siblings = [createTestBid('a', LINKED_ID), createTestBid('b', LINKED_ID)]
+      jest.spyOn(ProposalModel, 'getProposalList').mockResolvedValue(siblings)
+      result = await getLinkedProposalGroups(pendingProposals, ProposalType.Bid)
+    })
+
+    it('should return all of them as candidates', () => {
+      expect(result.activeProposals.map((item) => item.id)).toEqual(['a', 'b'])
+    })
+
+    it('should not mark the group as already decided', () => {
+      expect(result.decidedLinkedProposalIds.has(LINKED_ID)).toBe(false)
+    })
+  })
+
+  // An earlier run already elected a winner here. Feeding it back into the election is what produced
+  // two passed bids for one tender, because the rejection that would correct it is CAS'd on 'active'.
+  describe('and one sibling was already passed by an earlier run', () => {
+    beforeEach(async () => {
+      siblings = [createTestBid('a', LINKED_ID, ProposalStatus.Passed), createTestBid('late', LINKED_ID)]
+      jest.spyOn(ProposalModel, 'getProposalList').mockResolvedValue(siblings)
+      result = await getLinkedProposalGroups(pendingProposals, ProposalType.Bid)
+    })
+
+    it('should leave the passed sibling out of the candidates', () => {
+      expect(result.activeProposals.map((item) => item.id)).toEqual(['late'])
+    })
+
+    it('should mark the group as already decided', () => {
+      expect(result.decidedLinkedProposalIds.has(LINKED_ID)).toBe(true)
+    })
+  })
+
+  describe('and one sibling was already enacted', () => {
+    beforeEach(async () => {
+      siblings = [createTestBid('a', LINKED_ID, ProposalStatus.Enacted), createTestBid('late', LINKED_ID)]
+      jest.spyOn(ProposalModel, 'getProposalList').mockResolvedValue(siblings)
+      result = await getLinkedProposalGroups(pendingProposals, ProposalType.Bid)
+    })
+
+    it('should mark the group as already decided', () => {
+      expect(result.decidedLinkedProposalIds.has(LINKED_ID)).toBe(true)
+    })
+  })
+
+  describe('and the siblings were all rejected without a winner', () => {
+    beforeEach(async () => {
+      siblings = [createTestBid('a', LINKED_ID, ProposalStatus.Rejected), createTestBid('late', LINKED_ID)]
+      jest.spyOn(ProposalModel, 'getProposalList').mockResolvedValue(siblings)
+      result = await getLinkedProposalGroups(pendingProposals, ProposalType.Bid)
+    })
+
+    // Nothing was elected, so the remaining sibling may still win.
+    it('should not mark the group as already decided', () => {
+      expect(result.decidedLinkedProposalIds.has(LINKED_ID)).toBe(false)
+    })
+  })
+})
+
+describe('finishProposal for a linked proposal group', () => {
+  const LINKED_ID = '123'
+  const HIGHER_POWER = { ...ACCEPTED_OUTCOME, winnerVotingPower: 500 }
+
+  beforeEach(() => {
+    jest.spyOn(logger, 'error').mockImplementation(() => {})
+    jest.spyOn(logger, 'log').mockImplementation(() => {})
+    jest.spyOn(ProposalModel, 'getFinishProposalQuery')
+    jest.spyOn(ProposalModel, 'findByIds').mockResolvedValue([])
+    jest.spyOn(CoauthorModel, 'findAllByProposals').mockResolvedValue([])
+    jest.spyOn(DiscourseService, 'commentUpdatedProposal').mockImplementation(() => {})
+    jest.spyOn(DiscordService, 'finishProposal').mockImplementation(() => {})
+    jest.spyOn(NotificationService, 'authoredProposalFinished').mockImplementation()
+    jest.spyOn(BudgetService, 'getBudgetsForProposals').mockResolvedValue([getTestBudgetWithAvailableSize()])
+    jest.spyOn(BudgetService, 'getBudgetUpdateQueries').mockReturnValue([])
+  })
+
+  afterEach(() => {
+    jest.restoreAllMocks()
+  })
+
+  // The straggler is the only active bid left, so before the guard it won its group unopposed and the
+  // tender ended up with two passed bids, which downstream becomes two funded projects.
+  describe('when a bid becomes finishable after its group already elected a winner', () => {
+    const straggler = createTestBid('late', LINKED_ID)
+
+    beforeEach(async () => {
+      jest.spyOn(ProposalModel, 'getFinishableProposals').mockResolvedValue([straggler])
+      jest
+        .spyOn(ProposalModel, 'getProposalList')
+        .mockResolvedValue([createTestBid('winner', LINKED_ID, ProposalStatus.Passed), straggler])
+      jest.spyOn(calculateOutcome, 'calculateVotingResult').mockResolvedValue(HIGHER_POWER)
+      await finishProposal()
+    })
+
+    it('should reject it rather than pass a second winner', () => {
+      expect(ProposalModel.getFinishProposalQuery).toHaveBeenCalledWith(['late'], ProposalStatus.Rejected)
+    })
+
+    it('should never pass it, even though its voting power is the highest among active bids', () => {
+      expect(ProposalModel.getFinishProposalQuery).not.toHaveBeenCalledWith(
+        expect.arrayContaining(['late']),
+        ProposalStatus.Passed
+      )
+    })
+  })
+
+  describe('and one bid in the group has no voting result yet', () => {
+    const resolved = createTestBid('resolved', LINKED_ID)
+    const unresolved = createTestBid('unresolved', LINKED_ID)
+
+    beforeEach(async () => {
+      jest.spyOn(ProposalModel, 'getFinishableProposals').mockResolvedValue([resolved, unresolved])
+      jest.spyOn(ProposalModel, 'getProposalList').mockResolvedValue([resolved, unresolved])
+      jest
+        .spyOn(calculateOutcome, 'calculateVotingResult')
+        .mockImplementation(async (proposal) => (proposal.id === 'resolved' ? HIGHER_POWER : undefined))
+      await finishProposal()
+    })
+
+    // Electing from the subset that resolved can crown the wrong bid, and that is unrecoverable
+    // because the rejection of the real winner is CAS'd on 'active'.
+    it('should not decide the group at all', () => {
+      expect(ProposalModel.getFinishProposalQuery).not.toHaveBeenCalled()
+    })
+  })
+
+  describe('and every bid in the group has a voting result', () => {
+    const winner = createTestBid('winner', LINKED_ID)
+    const loser = createTestBid('loser', LINKED_ID)
+
+    beforeEach(async () => {
+      jest.spyOn(ProposalModel, 'getFinishableProposals').mockResolvedValue([winner, loser])
+      jest.spyOn(ProposalModel, 'getProposalList').mockResolvedValue([winner, loser])
+      jest
+        .spyOn(calculateOutcome, 'calculateVotingResult')
+        .mockImplementation(async (proposal) => (proposal.id === 'winner' ? HIGHER_POWER : ACCEPTED_OUTCOME))
+      await finishProposal()
+    })
+
+    it('should pass the bid with the highest voting power', () => {
+      expect(ProposalModel.getFinishProposalQuery).toHaveBeenCalledWith(['winner'], ProposalStatus.Passed)
+    })
+
+    it('should reject the other one', () => {
+      expect(ProposalModel.getFinishProposalQuery).toHaveBeenCalledWith(['loser'], ProposalStatus.Rejected)
+    })
   })
 })

--- a/src/entities/Proposal/jobs.ts
+++ b/src/entities/Proposal/jobs.ts
@@ -71,21 +71,63 @@ async function getProposalsVotingResult(proposals: ProposalAttributes[]) {
   return proposalsWithVotingResult
 }
 
+type LinkedProposalGroups = {
+  activeProposals: ProposalAttributes[]
+  decidedLinkedProposalIds: Set<string>
+}
+
+export async function getLinkedProposalGroups(
+  pendingProposals: ProposalAttributes[],
+  type: ProposalType.Tender | ProposalType.Bid
+): Promise<LinkedProposalGroups> {
+  const linkedProposalIds = [
+    ...new Set(
+      pendingProposals.filter((item) => item.type === type).map((item) => item.configuration.linked_proposal_id)
+    ),
+  ]
+
+  const activeProposals: ProposalAttributes[] = []
+  const decidedLinkedProposalIds = new Set<string>()
+
+  for (const linkedProposalId of linkedProposalIds) {
+    const siblings = await ProposalModel.getProposalList({ type, linkedProposalId })
+    // Only active siblings stand in the election. Re-judging one an earlier run already settled can
+    // hand the win to a different proposal, and the rejection that would correct it is CAS'd on
+    // 'active', so it cannot demote the one that already passed.
+    activeProposals.push(...siblings.filter((item) => item.status === ProposalStatus.Active))
+    if (siblings.some((item) => item.status === ProposalStatus.Passed || item.status === ProposalStatus.Enacted)) {
+      decidedLinkedProposalIds.add(linkedProposalId)
+    }
+  }
+
+  return { activeProposals, decidedLinkedProposalIds }
+}
+
 export async function getFinishableLinkedProposals(
   pendingProposals: ProposalAttributes[],
   type: ProposalType.Tender | ProposalType.Bid
 ) {
-  let proposals = pendingProposals.filter((item) => item.type === type)
-  if (proposals.length > 0) {
-    const linkedProposalIds = [...new Set(proposals.map((item) => item.configuration.linked_proposal_id))]
-    proposals = []
-    for (const id of linkedProposalIds) {
-      const tenderProposals = await ProposalModel.getProposalList({ type, linkedProposalId: id })
-      proposals = [...proposals, ...tenderProposals]
+  const { activeProposals } = await getLinkedProposalGroups(pendingProposals, type)
+  return activeProposals
+}
+
+// A group whose members did not all resolve to a voting result cannot be compared. Electing from the
+// subset that did resolve can crown the wrong proposal, and that is not recoverable: the rejection of
+// the real winner is CAS'd on 'active', so a later run cannot take the win back.
+function getIncompleteLinkedProposalIds(
+  activeProposals: ProposalAttributes[],
+  proposalsWithVotingResult: ProposalVotingResult[]
+) {
+  const resolvedIds = new Set(proposalsWithVotingResult.map((item) => item.id))
+  const incompleteLinkedProposalIds = new Set<string>()
+
+  for (const proposal of activeProposals) {
+    if (!resolvedIds.has(proposal.id)) {
+      incompleteLinkedProposalIds.add(proposal.configuration.linked_proposal_id)
     }
   }
 
-  return proposals
+  return incompleteLinkedProposalIds
 }
 
 function hasCustomOutcome(type: ProposalType) {
@@ -118,15 +160,24 @@ async function prepareProposalsAndBudgetsUpdates(
 ): Promise<{ proposalsWithOutcome: ProposalWithOutcome[]; budgetsWithUpdates: Budget[] }> {
   const proposalsWithOutcome: ProposalWithOutcome[] = []
   const budgetsWithUpdates = [...currentBudgets]
-  const finishableTenderProposals = await getFinishableLinkedProposals(pendingProposals, ProposalType.Tender)
-  const finishableBidProposals = await getFinishableLinkedProposals(pendingProposals, ProposalType.Bid)
+  const tenderGroups = await getLinkedProposalGroups(pendingProposals, ProposalType.Tender)
+  const bidGroups = await getLinkedProposalGroups(pendingProposals, ProposalType.Bid)
   const proposalsWithVotingResult = await getProposalsVotingResult([
     ...pendingProposals.filter((item) => item.type !== ProposalType.Tender && item.type !== ProposalType.Bid),
-    ...finishableTenderProposals,
-    ...finishableBidProposals,
+    ...tenderGroups.activeProposals,
+    ...bidGroups.activeProposals,
   ])
 
   reportPendingProposalsWithoutVotingResults(pendingProposals, proposalsWithVotingResult)
+
+  const linkedGroups = {
+    [ProposalType.Tender]: tenderGroups,
+    [ProposalType.Bid]: bidGroups,
+  }
+  const incompleteLinkedProposalIds = {
+    [ProposalType.Tender]: getIncompleteLinkedProposalIds(tenderGroups.activeProposals, proposalsWithVotingResult),
+    [ProposalType.Bid]: getIncompleteLinkedProposalIds(bidGroups.activeProposals, proposalsWithVotingResult),
+  }
 
   for (const proposal of proposalsWithVotingResult) {
     switch (proposal.votingOutcome) {
@@ -140,9 +191,29 @@ async function prepareProposalsAndBudgetsUpdates(
         if (!hasCustomOutcome(proposal.type)) {
           proposalsWithOutcome.push({ ...proposal, newStatus: ProposalStatus.Passed })
         } else if (proposal.type === ProposalType.Tender || proposal.type === ProposalType.Bid) {
+          const linkedProposalId = proposal.configuration.linked_proposal_id
+
+          // An earlier run already elected a winner for this group, so a sibling that only becomes
+          // finishable now can be rejected but never passed: passing it would leave the group with
+          // two winners, and downstream that is two funded projects for one tender.
+          if (linkedGroups[proposal.type].decidedLinkedProposalIds.has(linkedProposalId)) {
+            proposalsWithOutcome.push({ ...proposal, newStatus: ProposalStatus.Rejected })
+            break
+          }
+
+          // Leave the whole group active and retry on the next run rather than electing from a
+          // subset. Missing results are expected here: scores are fetched one proposal at a time.
+          if (incompleteLinkedProposalIds[proposal.type].has(linkedProposalId)) {
+            logger.log('Deferring a linked proposal group with an incomplete voting result', {
+              type: proposal.type,
+              linkedProposalId,
+            })
+            break
+          }
+
           const winnerProposal = getWinnerBiddingAndTenderingProposal(
             proposalsWithVotingResult,
-            proposal.configuration.linked_proposal_id,
+            linkedProposalId,
             proposal.type
           )
           if (winnerProposal?.id === proposal.id) {


### PR DESCRIPTION
## What

`getFinishableLinkedProposals` expanded a finishable tender or bid into every sibling sharing its `linked_proposal_id` by calling `getProposalList({ type, linkedProposalId })` — with **no status**. The status filter in `getProposalList` is `conditional(!!status, …)`, so it was omitted entirely and siblings an earlier run had already decided came back into the election.

That matters because scores are fetched one proposal at a time and `calculateVotingResult` swallows a failure by returning `undefined`, so a group can be judged from a subset:

1. Bids B1…Bn for tender T all become finishable together (they share `publish_at`, hence `finish_at`).
2. Run 1: the score fetch fails for B2. B2 is dropped, the winner is elected among the rest → **B1 passes**, the others are rejected, B2 stays active.
3. Run 2: B2 is finishable. The expansion pulls the whole group back, including the already-passed B1. Scores all resolve. If B2 has more voting power, **B2 passes too**.
4. The corrective rejection for B1 matches zero rows, because `getFinishProposalQuery` is CAS'd on `status = 'active'`.

The tender now has two passed proposals, and `ProjectService.createProjects` filters on `newStatus === Passed`, so it creates a **second funded project** — two vesting contracts from one tender. The advisory lock does not help: these are sequential runs, not overlapping ones.

This is not hypothetical: the codebase already ships `reportPendingProposalsWithoutVotingResults` precisely because these per-proposal score fetches are observed to fail in production.

## How

- Only **active** siblings stand in the election.
- `getLinkedProposalGroups` also reports whether a group already holds a `passed` or `enacted` proposal. A straggler in an already-decided group is **rejected** rather than elected. This part matters: a status filter *alone* would have introduced a new variant of the same bug, because the straggler would then be the only candidate in its group and would win unopposed.
- A group whose members did not all resolve to a voting result is **deferred to the next run** rather than decided from a subset, since crowning the wrong proposal cannot be undone once the real winner's rejection is CAS'd away.

A group where every sibling was `rejected` is *not* treated as decided — nothing was elected there, so a remaining sibling may still legitimately win.

`getFinishableLinkedProposals` keeps its signature and delegates to the new function, so its existing coverage is untouched.

## Testing

New `getLinkedProposalGroups` cases: all-active groups return every candidate and are not flagged decided; a `passed` or `enacted` sibling is excluded from candidates and flags the group decided; an all-`rejected` group is not flagged decided.

New `finishProposal` cases driving the real job: a bid that becomes finishable after its group already elected a winner is rejected and never passed even though its voting power is the highest among active bids; a group with one unresolved voting result is not decided at all; and a fully-resolved group still passes the highest and rejects the rest.

I checked these tests actually catch the bug rather than just documenting the fix — emulating the old behaviour (drop the status filter, never flag a decided group) makes four of them fail, including the two-winners case.

Full suite green: 66 suites, 1104 tests. `npm run build` clean.
